### PR TITLE
Set default DWARF version to 2 in gcc 8

### DIFF
--- a/gcc/8/patches/0027-Default-to-DWARF-v2.patch
+++ b/gcc/8/patches/0027-Default-to-DWARF-v2.patch
@@ -1,0 +1,27 @@
+From 5859c8033fbe6a49418d5bd86eb9d93f5cbb6907 Mon Sep 17 00:00:00 2001
+From: Marcus Comstedt <marcus@mc.pp.se>
+Date: Wed, 31 Jul 2019 22:10:48 +0200
+Subject: [PATCH] Default to DWARF v2
+
+---
+ gcc/config/rs6000/amigaos.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index ec0146c4b8c..a8724d3f3ef 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -384,6 +384,10 @@ do                                   \
+     rs6000_altivec_abi = 1;          \
+     TARGET_ALTIVEC_VRSAVE = 1;       \
+   }                                  \
++  if (!global_options_set.x_dwarf_strict)	\
++    dwarf_strict = 1;				\
++  if (!global_options_set.x_dwarf_version)	\
++    dwarf_version = 2;				\
+ } while(0)
+ 
+ #undef SUBTARGET_EXPAND_BUILTIN
+-- 
+2.21.0
+


### PR DESCRIPTION
Normally gcc 8 defaults to DWARF v4.  However, AmigaOS has gdb 6.3
which only groks v2.  So at least until a port of gdb 7 is available,
it seems prudent to change the default to v2.  (It can still be
overridden with -gdwarf-#.) Code taken from the Darwin configuration.