### PR TITLE
Fixes timing inaccuracy of wait_for() & wait_until()

### DIFF
--- a/gcc/8/patches/0025-Add-amigaos-thread-model.patch
+++ b/gcc/8/patches/0025-Add-amigaos-thread-model.patch
@@ -1261,7 +1261,7 @@ index 0000000000000000000000000000000000000000..7b03647a4a2e2acab21f73eb55733c62
 +    }
 +
 +  if (tv_now.tv_sec + borrow <= (uint32_t)(abs_timeout->seconds))
-+    tv_now.tv_sec = abs_timeout->seconds - tv_now.tv_sec + borrow;
++    tv_now.tv_sec = abs_timeout->seconds - (tv_now.tv_sec + borrow);
 +  else
 +    {
 +      tv_now.tv_sec = 0;


### PR DESCRIPTION
This change fixes the timing inaccuracy of condition_variable::wait_for() and condition_variable::wait_until(). It would intermittently wait 2 seconds longer than it should (issue #74 ).