### PR TITLE
clib2: Use gcc builtins for math macros.

### DIFF
--- a/native-build/makefile
+++ b/native-build/makefile
@@ -47,7 +47,7 @@ COREUTILS_VERSION=5.2.1
 DIST_VERSION=$(shell date +%Y%m%d)-$(shell git rev-list --count HEAD)
 
 CLIB2_URL=https://github.com/sodero/clib2
-CLIB2_SHA1=125d92486da69d45fd18489d3226071d4be9ed9d
+CLIB2_SHA1=247ad4b725cf88b847aede6bcc95f2c8fa1c863f
 CLIB2_RELEASE_ARCHIVE_NAME=adtools-os4-clib2-$(DIST_VERSION).lha
 
 CROSS_PREFIX?=$(ROOT_DIR)/root-cross


### PR DESCRIPTION
By doing so we can remove macros that assume that
long doubles don't exist. Fallback to C11 generics to
support builds without builtins.