### PR TITLE
GCC 10.3.0 support.

### DIFF
--- a/gcc/10/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/10/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,0 +1,3525 @@
+From a70cbcd23e215f8e6063237965992ab4ada0dba4 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Tue, 17 Feb 2015 20:25:55 +0100
+Subject: [PATCH 01/33] Changes for AmigaOS version of gcc.
+
+---
+ fixincludes/configure                 |   1 +
+ fixincludes/configure.ac              |   1 +
+ gcc/Makefile.in                       |   1 +
+ gcc/c-family/c-attribs.c              |  26 ++
+ gcc/c/c-typeck.c                      |  25 ++
+ gcc/config.gcc                        |   8 +
+ gcc/config.host                       |   6 +
+ gcc/config/rs6000/amigaos-protos.h    |  41 +++
+ gcc/config/rs6000/amigaos.c           | 467 ++++++++++++++++++++++++++++++++++
+ gcc/config/rs6000/amigaos.h           | 437 +++++++++++++++++++++++++++++++
+ gcc/config/rs6000/amigaos.opt         |  37 +++
+ gcc/config/rs6000/rs6000-builtin.def  |   7 +
+ gcc/config/rs6000/rs6000-call.c       |  45 +++-
+ gcc/config/rs6000/rs6000-internal.h   |   6 +
+ gcc/config/rs6000/rs6000-logue.c      |  83 ++++++
+ gcc/config/rs6000/rs6000.c            |  43 ++++
+ gcc/config/rs6000/rs6000.h            |   3 +
+ gcc/config/rs6000/rs6000.md           |  27 +-
+ gcc/config/rs6000/t-amigaos           |  20 ++
+ gcc/cp/typeck.c                       |  16 ++
+ gcc/doc/extend.texi                   | 168 ++++++++++++
+ gcc/doc/invoke.texi                   | 161 ++++++++++++
+ gcc/expr.c                            |   1 -
+ gcc/gcc.c                             |  12 +-
+ gcc/prefix.c                          |   2 +-
+ intl/dcigettext.c                     |   2 +
+ libcpp/line-map.c                     |   3 +
+ libgcc/config.host                    |   3 +
+ libgcc/config/rs6000/t-amigaos        |  45 ++++
+ libiberty/Makefile.in                 |   9 +
+ libiberty/basename.c                  |  21 +-
+ libiberty/configure                   |   1 +
+ libiberty/configure.ac                |   1 +
+ libiberty/lrealpath.c                 |   3 +-
+ libiberty/make-relative-prefix.c      |  37 ++-
+ libiberty/make-temp-file.c            |  27 +-
+ libiberty/pex-amigaos.c               | 325 +++++++++++++++++++++++
+ libstdc++-v3/configure                | 160 ++++++++++++
+ libstdc++-v3/configure.ac             |   3 +
+ libstdc++-v3/crossconfig.m4           |   8 +
+ libstdc++-v3/include/c_global/cstddef |   3 +
+ libstdc++-v3/include/c_std/cstddef    |   3 +
+ 42 files changed, 2245 insertions(+), 53 deletions(-)
+ create mode 100644 gcc/config/rs6000/amigaos-protos.h
+ create mode 100644 gcc/config/rs6000/amigaos.c
+ create mode 100644 gcc/config/rs6000/amigaos.h
+ create mode 100644 gcc/config/rs6000/amigaos.opt
+ create mode 100644 gcc/config/rs6000/t-amigaos
+ create mode 100644 libgcc/config/rs6000/t-amigaos
+ create mode 100644 libiberty/pex-amigaos.c
+
+diff --git a/fixincludes/configure b/fixincludes/configure
+index 6e2d67b655b2f0c1914550e0b2e3b97f8391eef0..cde46a525a606d3b87fb75e50d839f53ce02b141 100755
+--- a/fixincludes/configure
++++ b/fixincludes/configure
+@@ -4813,12 +4813,13 @@ else
+ fi
+ else
+   case $host in
+ 	i?86-*-msdosdjgpp* | \
+ 	i?86-*-mingw32* | \
+ 	x86_64-*-mingw32* | \
++	*-*-amigaos* | \
+ 	*-*-beos* | \
+         *-*-*vms*)
+ 		TARGET=twoprocess
+ 		;;
+ 
+ 	* )
+diff --git a/fixincludes/configure.ac b/fixincludes/configure.ac
+index 14813b910f196a7adc7f185a55d02195c021351f..cdb37b0700d46dde6698dce552959aa404a7733a 100644
+--- a/fixincludes/configure.ac
++++ b/fixincludes/configure.ac
+@@ -49,12 +49,13 @@ else
+ 	TARGET=oneprocess
+ fi],
+ [case $host in
+ 	i?86-*-msdosdjgpp* | \
+ 	i?86-*-mingw32* | \
+ 	x86_64-*-mingw32* | \
++	*-*-amigaos* | \
+ 	*-*-beos* | \
+         *-*-*vms*)
+ 		TARGET=twoprocess
+ 		;;
+ 
+ 	* )
+diff --git a/gcc/Makefile.in b/gcc/Makefile.in
+index 646db219460950266ac1346eba8a5b7564e98a49..f421a41c9eea5a3dd1be6d2f31e3e4f605268cac 100644
+--- a/gcc/Makefile.in
++++ b/gcc/Makefile.in
+@@ -2210,12 +2210,13 @@ default-d.o: config/default-d.c
+ 	$(COMPILE) $<
+ 	$(POSTCOMPILE)
+ 
+ # Language-independent files.
+ 
+ DRIVER_DEFINES = \
++  -DEXEC_PREFIX=\"$(exec_prefix)/\" \
+   -DSTANDARD_STARTFILE_PREFIX=\"$(unlibsubdir)/\" \
+   -DSTANDARD_EXEC_PREFIX=\"$(libdir)/gcc/\" \
+   -DSTANDARD_LIBEXEC_PREFIX=\"$(libexecdir)/gcc/\" \
+   -DDEFAULT_TARGET_VERSION=\"$(version)\" \
+   -DDEFAULT_REAL_TARGET_MACHINE=\"$(real_target_noncanonical)\" \
+   -DDEFAULT_TARGET_MACHINE=\"$(target_noncanonical)\" \
+diff --git a/gcc/c-family/c-attribs.c b/gcc/c-family/c-attribs.c
+index e67c71a50e7fdc1e1380856ea10787e4f33b338c..803590e45b97ca0cc7b6dba2568f41123813e603 100644
+--- a/gcc/c-family/c-attribs.c
++++ b/gcc/c-family/c-attribs.c
+@@ -122,12 +122,13 @@ static tree handle_nonnull_attribute (tree *, tree, tree, int, bool *);
+ static tree handle_nonstring_attribute (tree *, tree, tree, int, bool *);
+ static tree handle_nothrow_attribute (tree *, tree, tree, int, bool *);
+ static tree handle_cleanup_attribute (tree *, tree, tree, int, bool *);
+ static tree handle_warn_unused_result_attribute (tree *, tree, tree, int,
+ 						 bool *);
+ static tree handle_access_attribute (tree *, tree, tree, int, bool *);
++static tree handle_libcall_attribute (tree *, tree, tree, int, bool *);
+ 
+ static tree handle_sentinel_attribute (tree *, tree, tree, int, bool *);
+ static tree handle_type_generic_attribute (tree *, tree, tree, int, bool *);
+ static tree handle_alloc_size_attribute (tree *, tree, tree, int, bool *);
+ static tree handle_alloc_align_attribute (tree *, tree, tree, int, bool *);
+ static tree handle_assume_aligned_attribute (tree *, tree, tree, int, bool *);
+@@ -386,12 +387,17 @@ const struct attribute_spec c_common_attribute_table[] =
+   { "may_alias",	      0, 0, false, true, false, false, NULL, NULL },
+   { "cleanup",		      1, 1, true, false, false, false,
+ 			      handle_cleanup_attribute, NULL },
+   { "warn_unused_result",     0, 0, false, true, true, false,
+ 			      handle_warn_unused_result_attribute,
+ 	                      attr_warn_unused_result_exclusions },
++  { "libcall",                0, 0, false, true, true, false,
++                              handle_libcall_attribute, NULL },
++  /* Similiar to libcall but doesn't imply linearvarargs. Can be handled as libcall here. */
++  { "libcall2",               0, 0, false, true, true, false,
++                              handle_libcall_attribute, NULL },
+   { "sentinel",               0, 1, false, true, true, false,
+ 			      handle_sentinel_attribute, NULL },
+   /* For internal use (marking of builtins) only.  The name contains space
+      to prevent its usage in source code.  */
+   { "type generic",           0, 0, false, true, true, false,
+ 			      handle_type_generic_attribute, NULL },
+@@ -4289,12 +4295,32 @@ handle_warn_unused_result_attribute (tree *node, tree name,
+       *no_add_attrs = true;
+     }
+ 
+   return NULL_TREE;
+ }
+ 
++/* Handle a "libcall" attribute.  No special handling.  */
++
++static tree
++handle_libcall_attribute (tree *node, tree name,
++       tree ARG_UNUSED (args), int ARG_UNUSED (flags),
++       bool *no_add_attrs)
++{
++  if (TREE_CODE (*node) != FUNCTION_TYPE
++      && TREE_CODE (*node) != METHOD_TYPE
++      && TREE_CODE (*node) != FIELD_DECL
++      && TREE_CODE (*node) != TYPE_DECL)
++    {
++      warning (OPT_Wattributes,"%qs attribute only applies to functions",
++              IDENTIFIER_POINTER (name));
++      *no_add_attrs = true;
++    }
++
++   return NULL_TREE;
++}
++
+ /* Handle a "sentinel" attribute.  */
+ 
+ static tree
+ handle_sentinel_attribute (tree *node, tree name, tree args,
+ 			   int ARG_UNUSED (flags), bool *no_add_attrs)
+ {
+diff --git a/gcc/c/c-typeck.c b/gcc/c/c-typeck.c
+index 9342d3a071ac38ecfca39d3e7f83392eb83b4a2e..ac420bb7c4d3546885de63a14ec8f8826b47bf9f 100644
+--- a/gcc/c/c-typeck.c
++++ b/gcc/c/c-typeck.c
+@@ -3077,12 +3077,14 @@ build_function_call_vec (location_t loc, vec<location_t> arg_loc,
+   tree fntype, fundecl = NULL_TREE;
+   tree name = NULL_TREE, result;
+   tree tem;
+   int nargs;
+   tree *argarray;
+ 
++  vec<tree, va_gc> *new_params = NULL;
++  vec<tree, va_gc> *new_origtypes = NULL;
+ 
+   /* Strip NON_LVALUE_EXPRs, etc., since we aren't using as an lvalue.  */
+   STRIP_TYPE_NOPS (function);
+ 
+   /* Convert anything with function type to a pointer-to-function.  */
+   if (TREE_CODE (function) == FUNCTION_DECL)
+@@ -3137,12 +3139,35 @@ build_function_call_vec (location_t loc, vec<location_t> arg_loc,
+   if (fundecl && TREE_THIS_VOLATILE (fundecl))
+     current_function_returns_abnormally = 1;
+ 
+   /* fntype now gets the type of function pointed to.  */
+   fntype = TREE_TYPE (fntype);
+ 
++  if (lookup_attribute ("libcall", TYPE_ATTRIBUTES (fntype)) ||
++      lookup_attribute ("libcall2", TYPE_ATTRIBUTES (fntype)))
++  {
++	if (TREE_CODE (function) == COMPONENT_REF && lvalue_p (function))
++	{
++		/* We copy the involved vectors here, as adding an element may
++		 * free the original pointer, but we are not the owner of those.
++		 *
++		 * FIXME: At the moment, we don't free the memory allocated here
++		 * If it is freed at the exit of the function via VEC_free() in
++		 * some cases a segfault occurs */
++		params = new_params = vec_safe_copy(params);
++		origtypes = new_origtypes = vec_safe_copy(origtypes);
++
++		/* Type of 0 operand of a component ref is always a dereferenced object but
++		 * we need to pass the address of this object */
++		vec_safe_insert(params,0,
++			build1(ADDR_EXPR, build_pointer_type (TREE_TYPE (TREE_OPERAND (function, 0))),
++				TREE_OPERAND (function, 0)));
++		vec_safe_insert(origtypes,0,(tree)NULL);
++	}
++  }
++
+   /* Convert the parameters to the types declared in the
+      function prototype, or apply default promotions.  */
+ 
+   nargs = convert_arguments (loc, arg_loc, TYPE_ARG_TYPES (fntype), params,
+ 			     origtypes, function, fundecl);
+   if (nargs < 0)
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 6fcdd771d4c32604685ebc5da3e20260fe6da2ad..e279090d89753ab025c43972d1f6b4f74ec351a9 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -2859,12 +2859,20 @@ or1k*-*-*)
+ 	esac
+ 	;;
+ pdp11-*-*)
+ 	tm_file="${tm_file} newlib-stdint.h"
+ 	use_gcc_stdint=wrap
+ 	;;
++powerpc-*-amigaos*)
++	tm_file="${tm_file} dbxelf.h elfos.h rs6000/sysv4.h rs6000/amigaos.h"
++	tm_p_file="${tm_p_file} rs6000/amigaos-protos.h"
++	extra_options="${extra_options} rs6000/sysv4.opt rs6000/amigaos.opt"
++	tmake_file="rs6000/t-amigaos"
++	extra_objs="$extra_objs amigaos.o"
++	use_collect2=no
++	;;
+ # port not yet contributed
+ #powerpc-*-openbsd*)
+ #	tmake_file="${tmake_file} rs6000/t-fprules"
+ #	extra_headers=
+ #	;;
+ powerpc-*-darwin*)
+diff --git a/gcc/config.host b/gcc/config.host
+index 84f0433e2ad25c8620a175a4b18641cc327a73cc..52e682d365625d3b257838699a9dd1a107bf57f4 100644
+--- a/gcc/config.host
++++ b/gcc/config.host
+@@ -252,12 +252,18 @@ case ${host} in
+     host_lto_plugin_soname=liblto_plugin-0.dll
+     ;;
+   i[34567]86-*-darwin* | x86_64-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-i386-darwin.o"
+     host_xmake_file="${host_xmake_file} i386/x-darwin"
+     ;;
++  powerpc-*-amigaos*) # AmigaOS 4
++    prefix=/gcc
++    local_prefix=/gcc
++    host_can_use_collect2=no
++    host_xm_defines=HOST_LACKS_INODE_NUMBERS
++    ;;
+   powerpc-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-ppc-darwin.o"
+     host_xmake_file="${host_xmake_file} rs6000/x-darwin"
+     ;;
+   powerpc64-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-ppc64-darwin.o"
+diff --git a/gcc/config/rs6000/amigaos-protos.h b/gcc/config/rs6000/amigaos-protos.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..eb5f8fc5f3d546b8d8e1cdd8118a3085079df50e
+--- /dev/null
++++ b/gcc/config/rs6000/amigaos-protos.h
+@@ -0,0 +1,41 @@
++/* Prototypes.
++   Copyright (C) 2003 Free Software Foundation, Inc.
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify it
++   under the terms of the GNU General Public License as published
++   by the Free Software Foundation; either version 2, or (at your
++   option) any later version.
++
++   GCC is distributed in the hope that it will be useful, but WITHOUT
++   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
++   License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with GCC; see the file COPYING.  If not, write to the
++   Free Software Foundation, 59 Temple Place - Suite 330, Boston,
++   MA 02111-1307, USA.  */
++
++
++//#ifdef RTX_CODE
++//#ifdef TREE_CODE
++
++extern void amigaos_init_cumulative_args (CUMULATIVE_ARGS *, tree, rtx, int, int);
++extern void amigaos_function_arg_advance (CUMULATIVE_ARGS *, enum machine_mode, tree, int);
++extern struct rtx_def *amigaos_function_arg (CUMULATIVE_ARGS *, enum machine_mode, tree, int);
++extern void amigaos_expand_builtin_va_start (tree valist, rtx nextarg);
++extern struct rtx_def *amigaos_expand_builtin_saveregs (void);
++extern void amigaos_init_builtins (void);
++extern rtx amigaos_expand_builtin (tree, rtx, rtx, enum machine_mode, int, bool*);
++extern tree amigaos_handle_linearvarargs_attribute (tree *, tree, tree, int, bool*);
++extern tree amigaos_handle_baserel_restore_attribute (tree *, tree, tree, int, bool*);
++extern tree amigaos_handle_force_no_baserel_attribute (tree *, tree, tree, int, bool*);
++extern tree amigaos_handle_check68kfuncptr_attribute (tree *, tree, tree, int, bool*);
++extern rtx amigaos_legitimize_baserel_address (rtx addr);
++extern int amigaos_baserel_operand(rtx x);
++extern int amigaos_not_baserel_tree_p(tree decl);
++
++//#endif /* TREE_CODE */
++//#endif /* RTX_CODE */
+diff --git a/gcc/config/rs6000/amigaos.c b/gcc/config/rs6000/amigaos.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..ad8c0e64c056129afcd8bfa2a656749a2febfaaa
+--- /dev/null
++++ b/gcc/config/rs6000/amigaos.c
+@@ -0,0 +1,467 @@
++/* Subroutines used for code generation on Amiga OS 4
++   Copyright (C) 2003 Free Software Foundation, Inc.
++   Contributed by Thomas Frieden (ThomasF@hyperion-entertainment.com)
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify it
++   under the terms of the GNU General Public License as published
++   by the Free Software Foundation; either version 2, or (at your
++   option) any later version.
++
++   GCC is distributed in the hope that it will be useful, but WITHOUT
++   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
++   License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with GCC; see the file COPYING.  If not, write to the
++   Free Software Foundation, 59 Temple Place - Suite 330, Boston,
++   MA 02111-1307, USA.  */
++
++
++#include "config.h"
++#include "system.h"
++#include "coretypes.h"
++#include "diagnostic-core.h"
++#include "tm.h"
++#include "hash-set.h"
++#include "inchash.h"
++#include "memmodel.h"
++#include "profile-count.h"
++#include "rtl.h"
++#include "regs.h"
++#include "hard-reg-set.h"
++#include "real.h"
++#include "insn-config.h"
++#include "conditions.h"
++#include "insn-flags.h"
++#include "insn-attr.h"
++#include "flags.h"
++#include "recog.h"
++#include "obstack.h"
++#include "symtab.h"
++#include "tree.h"
++#include "expr.h"
++#include "optabs.h"
++#include "except.h"
++#include "function.h"
++#include "output.h"
++#include "tm_p.h"
++#include "fold-const.h"
++#include "langhooks.h"
++#include "explow.h"
++#include "emit-rtl.h"
++#include "stringpool.h"
++#include "attribs.h"
++
++#undef DEBUG
++#ifdef DEBUG
++#define dprintf(...)      			\
++printf("%s: ", __PRETTY_FUNCTION__);		\
++printf(__VA_ARGS__)
++#else
++#define dprintf(...) /* __VA_ARGS__ */
++#endif
++
++#undef TARGET_EXPAND_BUILTIN_SAVEREGS
++#define TARGET_EXPAND_BUILTIN_SAVEREGS() \
++    amigaos_expand_builtin_saveregs ()
++
++#ifdef __amigaos4__
++static const char * __attribute__((used)) amigaos_stack_cookie = "$STACK:768000";
++#endif /* __amigaos4__ */
++
++/* Initialize a variable CUM of type CUMULATIVE_ARGS
++   for a call to a function whose data type is FNTYPE.
++   For a library call, FNTYPE is 0.
++
++   Most of the work is delegated to init_cumulative_args() in rs6000.c,
++   here we just check for special attributes and update call_cookie
++   accordingly.  */
++#if 0
++void
++amigaos_init_cumulative_args (CUMULATIVE_ARGS *cum, tree fntype,
++	rtx libname ATTRIBUTE_UNUSED, int incoming,
++	int n_named_args)
++{
++  dprintf ("enter(cum=%p,fntype=%p)\n",cum,fntype);
++  init_cumulative_args (cum, fntype, libname, incoming, FALSE, n_named_args);
++
++  /* Check if either libcall or linear varargs, set appropriate cookie */
++  if (fntype && (lookup_attribute ("libcall", TYPE_ATTRIBUTES (fntype))))
++    cum->call_cookie |= CALL_LINEARVARARGS;
++
++  if (fntype && (lookup_attribute ("linearvarargs", TYPE_ATTRIBUTES (fntype))))
++    cum->call_cookie |= CALL_LINEARVARARGS;
++
++  dprintf ("exit\n");
++}
++
++/* Update the data in CUM to advance over an argument
++   of mode MODE and data type TYPE.
++   (TYPE is null for libcalls where that information may not be available.)
++
++   If the function has the linearvarargs attribute and this argument
++   to advance over is the last non-vararg argument, then advance over
++   all registers, so that the overflow area is hit immediately.
++   Otherwise, just let function_arg_advance () from rs6000.c do its
++   thing.  */
++
++void
++amigaos_function_arg_advance (CUMULATIVE_ARGS *cum, enum machine_mode mode,
++	tree type, int named)
++{
++  dprintf ("enter\n");
++  function_arg_advance (cum, mode, type, named, 0);
++
++  if (cum->call_cookie & CALL_LINEARVARARGS && cum->nargs_prototype <= 0)
++    {
++      cum->sysv_gregno = GP_ARG_MAX_REG + 1;
++      cum->fregno = FP_ARG_V4_MAX_REG + 1;
++    }
++  dprintf ("exit\n");
++}
++
++
++/* Determine where to put an argument to a function.
++
++   Linearvarargs should always go to the stack, apart from that
++   any decision made by function_arg () in rs6000.c will be OK. */
++
++struct rtx_def *
++amigaos_function_arg (CUMULATIVE_ARGS *cum, enum machine_mode mode,
++	tree type, int named)
++{
++  struct rtx_def *res = 0;
++
++  dprintf ("enter\n");
++  if (mode == VOIDmode && cum->call_cookie & CALL_LINEARVARARGS)
++    res = GEN_INT (cum->call_cookie);
++  else
++    res = function_arg (cum, mode, type, named);
++
++  dprintf ("exit\n");
++
++  return res;
++}
++#endif
++
++/* Implement va_start.
++
++   For linearvarargs functions, immediately increase the fpr
++   and gpr count to the maximum value, so that va_arg will look
++   only at the stack. */
++#if 0
++void
++amigaos_expand_builtin_va_start (tree valist, rtx nextarg)
++{
++printf("amigaos_expand_builtin_va_start()\n");
++  rs6000_va_start (valist, nextarg);
++
++  if (crtl->args.info.call_cookie & CALL_LINEARVARARGS)
++    {
++      tree f_gpr, f_fpr;
++      tree gpr, fpr, t;
++
++      f_gpr = TYPE_FIELDS (TREE_TYPE (va_list_type_node));
++      f_fpr = TREE_CHAIN (f_gpr);
++
++      valist = build1 (INDIRECT_REF, TREE_TYPE (TREE_TYPE (valist)), valist);
++      gpr = build3 (COMPONENT_REF, TREE_TYPE (f_gpr), valist, f_gpr, NULL_TREE);
++      fpr = build3 (COMPONENT_REF, TREE_TYPE (f_fpr), valist, f_fpr, NULL_TREE);
++
++      /* Set gpr use count to 8, forcing the overflow area to be used */
++      t = build2 (MODIFY_EXPR, TREE_TYPE (gpr), gpr, build_int_cst (NULL_TREE, 8));
++      TREE_SIDE_EFFECTS (t) = 1;
++      expand_expr (t, const0_rtx, VOIDmode, EXPAND_NORMAL);
++
++      /* Likewise for floating point arguments */
++      t = build2 (MODIFY_EXPR, TREE_TYPE (fpr), fpr, build_int_cst (NULL_TREE, 8));
++      TREE_SIDE_EFFECTS (t) = 1;
++      expand_expr (t, const0_rtx, VOIDmode, EXPAND_NORMAL);
++    }
++}
++#endif
++
++/* Implement __builtin_saveregs for linearvarargs functions. */
++#if 0
++struct rtx_def *
++amigaos_expand_builtin_saveregs (void)
++{
++  rtx block, mem_gpr_fpr, mem_overflow, tmp;
++  tree fntype;
++  int stdarg_p;
++  HOST_WIDE_INT words, gpr;
++  struct rtx_def *res;
++
++  dprintf ("enter\n");
++
++  if (crtl->args.info.call_cookie & CALL_LINEARVARARGS)
++    {
++      HOST_WIDE_INT bits;
++
++      fntype = TREE_TYPE (current_function_decl);
++      stdarg_p = (TYPE_ARG_TYPES (fntype) != 0
++		  && (TREE_VALUE (tree_last (TYPE_ARG_TYPES (fntype)))
++		      != void_type_node));
++
++      /* Allocate the va_list constructor.  */
++      block = assign_stack_local (BLKmode, 3 * UNITS_PER_WORD, BITS_PER_WORD);
++      MEM_READONLY_P (block) = 1;
++      MEM_READONLY_P (XEXP (block, 0)) = 1;
++
++      mem_gpr_fpr = change_address (block, word_mode, XEXP (block, 0));
++      mem_overflow = change_address (block, ptr_mode,
++				     plus_constant (XEXP (block, 0),
++                                                UNITS_PER_WORD));
++      /*mem_reg_save_area = change_address (block, ptr_mode,
++	plus_constant (XEXP (block, 0),
++	2 * UNITS_PER_WORD));*/
++
++      /* Construct the two characters of `gpr' and `fpr' as a unit.  */
++      words = crtl->args.info.words;
++      gpr = crtl->args.info.sysv_gregno - GP_ARG_MIN_REG;
++
++      /* Varargs has the va_dcl argument, but we don't count it.  */
++      if (!stdarg_p)
++	{
++	  if (gpr > GP_ARG_NUM_REG)
++	    words -= 1;
++	}
++
++      bits = (GP_ARG_MAX_REG - GP_ARG_MIN_REG + 1) << 8
++	| (FP_ARG_MAX_REG - FP_ARG_MIN_REG + 1);
++      if (HOST_BITS_PER_WIDE_INT >= BITS_PER_WORD)
++	tmp = GEN_INT (bits << (BITS_PER_WORD - 16));
++      else
++	{
++	  bits <<= BITS_PER_WORD - HOST_BITS_PER_WIDE_INT - 16;
++	  tmp = immed_double_const (0, bits, word_mode);
++	}
++
++      emit_move_insn (mem_gpr_fpr, tmp);
++
++      /* Find the overflow area.  */
++      tmp = expand_binop (Pmode, add_optab, virtual_incoming_args_rtx,
++			  GEN_INT (words * UNITS_PER_WORD),
++			  mem_overflow, 0, OPTAB_WIDEN);
++      if (tmp != mem_overflow)
++	  emit_move_insn (mem_overflow, tmp);
++
++      /*tmp = expand_binop (Pmode, add_optab, virtual_stack_vars_rtx,
++	GEN_INT (-RS6000_VARARGS_SIZE),
++	mem_reg_save_area, 0, OPTAB_WIDEN);
++	if (tmp != mem_reg_save_area)
++	emit_move_insn (mem_reg_save_area, tmp);*/
++
++      /* Return the address of the va_list constructor.  */
++      res = XEXP (block, 0);
++    }
++  else
++    {
++      res = expand_builtin_saveregs ();
++    }
++
++  dprintf ("exit\n");
++  return res;
++}
++#endif
++
++/* Define subtarget builtins */
++
++void
++amigaos_init_builtins (void)
++{
++	tree ftype;
++  ftype = build_function_type (ptr_type_node,
++			 tree_cons (NULL_TREE,
++				    build_pointer_type (TREE_TYPE (va_list_type_node)),
++				    void_list_node));
++
++  add_builtin_function ("__builtin_getlinearva",
++		    ftype,
++		    AMIGAOS_BUILTIN_GETLINEARVA,
++		    BUILT_IN_MD, NULL, NULL_TREE);
++}
++
++
++/* Expand builtins */
++rtx
++amigaos_expand_builtin (tree exp, rtx target, rtx subtarget ATTRIBUTE_UNUSED,
++			enum machine_mode mode ATTRIBUTE_UNUSED,
++			int ignore ATTRIBUTE_UNUSED, bool *success)
++{
++  tree fndecl = TREE_OPERAND (CALL_EXPR_FN (exp), 0);
++  tree f_gpr, f_fpr, f_res, f_ovf;
++  tree arg0, valist, ovf;
++
++  unsigned int fcode = DECL_FUNCTION_CODE (fndecl);
++
++//  debug_tree(exp);
++//  debug_tree(fndecl);
++  if (fcode != AMIGAOS_BUILTIN_GETLINEARVA)
++  {
++	  *success = 0;
++	  return NULL_RTX;
++  }
++
++  if (! (crtl->args.info.call_cookie & CALL_LINEARVARARGS))
++  {
++      /* TODO: This probably should be a fatal, but then the generated executable can't be linked. */
++      error ("__builtin_getlinearva can only be used in a linearvarargs function");
++      *success = 1;
++      return 0;
++  }
++
++  arg0 = CALL_EXPR_ARG (exp, 0);
++  if (arg0 == error_mark_node)
++    return const0_rtx;
++
++  f_gpr = TYPE_FIELDS (TREE_TYPE (va_list_type_node));
++  f_fpr = TREE_CHAIN (f_gpr);
++  f_res = TREE_CHAIN (f_fpr);
++  f_ovf = TREE_CHAIN (f_res);
++  target = const0_rtx;
++  valist = build_simple_mem_ref(arg0);//build1 (INDIRECT_REF, TREE_TYPE (TREE_TYPE (arg0)), arg0);
++  ovf = build3 (COMPONENT_REF, TREE_TYPE (f_ovf), valist, f_ovf, NULL_TREE);
++  target = copy_to_reg (expand_expr (ovf, NULL_RTX, Pmode, EXPAND_NORMAL));
++  *success = 1;
++  return target;
++}
++
++/* Handle a "linearvarargs" attribute. */
++tree
++amigaos_handle_linearvarargs_attribute (tree *node, tree name,
++	tree args ATTRIBUTE_UNUSED, int flags ATTRIBUTE_UNUSED,
++	bool *no_add_attrs)
++{
++  if (TREE_CODE (*node) != FUNCTION_TYPE
++      && TREE_CODE (*node) != METHOD_TYPE
++      && TREE_CODE (*node) != FIELD_DECL
++      && TREE_CODE (*node) != TYPE_DECL)
++    {
++      warning (0, "%s attribute only applies to functions",
++	       IDENTIFIER_POINTER (name));
++      *no_add_attrs = true;
++    }
++
++  return NULL_TREE;
++}
++
++
++/* Generate code for base relative access */
++
++rtx
++amigaos_legitimize_baserel_address (rtx addr)
++{
++  rtx dest = gen_reg_rtx (Pmode);
++
++  emit_insn (gen_elf_base_high (dest, gen_rtx_REG (Pmode, 2), addr));
++  emit_insn (gen_elf_base_low (dest, dest, addr));
++
++  return dest;
++}
++
++int
++amigaos_not_baserel_tree_p(tree decl)
++{
++  return(TREE_READONLY(decl)
++         || TREE_CONSTANT(decl)
++         || (DECL_ATTRIBUTES(decl)
++             && lookup_attribute("force_no_baserel", DECL_ATTRIBUTES(decl))));
++}
++
++int
++amigaos_baserel_operand(rtx x)
++{
++  tree decl;
++  int ret = 0;
++
++  if (GET_CODE(x) == SYMBOL_REF)
++  {
++    decl = SYMBOL_REF_DECL(x);
++
++    if (decl)
++    {
++      if (SYMBOL_REF_FUNCTION_P(x) || amigaos_not_baserel_tree_p(decl))
++        ret = 0;
++      else
++        ret = 1;
++    }
++  }
++  else if (GET_CODE(x) == CONST
++           && GET_CODE(XEXP(x, 0)) == PLUS
++           && GET_CODE(XEXP(XEXP(x, 0), 0)) == SYMBOL_REF
++           && GET_CODE(XEXP(XEXP(x, 0), 1)) == CONST_INT)
++    ret = amigaos_baserel_operand(XEXP(XEXP(x, 0), 0));
++  else if (GET_CODE(x) == LO_SUM)
++    ret = amigaos_baserel_operand(XEXP(x, 1));
++
++  return ret;
++}
++
++void amigaos_function_end_prologue(FILE *file);
++void amigaos_function_end_prologue(FILE *file)
++{
++  if (TARGET_BASEREL
++      && current_function_decl
++      && lookup_attribute ("baserel_restore", TYPE_ATTRIBUTES (TREE_TYPE (current_function_decl))))
++    {
++       fprintf( file, "\tbl __baserel_get_addr\n");
++    }
++}
++
++
++tree
++amigaos_handle_baserel_restore_attribute (tree *node, tree name,
++	tree args ATTRIBUTE_UNUSED, int flags ATTRIBUTE_UNUSED,
++	bool *no_add_attrs)
++{
++  if (TREE_CODE (*node) != FUNCTION_TYPE
++      && TREE_CODE (*node) != METHOD_TYPE
++      && TREE_CODE (*node) != FIELD_DECL
++      && TREE_CODE (*node) != TYPE_DECL)
++    {
++      warning (0, "%s attribute only applies to functions",
++	       IDENTIFIER_POINTER (name));
++      *no_add_attrs = true;
++    }
++
++  return NULL_TREE;
++}
++
++tree
++amigaos_handle_force_no_baserel_attribute (tree *node, tree name,
++	tree args ATTRIBUTE_UNUSED, int flags ATTRIBUTE_UNUSED,
++	bool *no_add_attrs)
++{
++  if (TREE_CODE (*node) != VAR_DECL)
++    {
++      warning (0, "%s attribute only applies to variables",
++	       IDENTIFIER_POINTER (name));
++      *no_add_attrs = true;
++    }
++
++  return NULL_TREE;
++}
++
++/* Handle a "check68kfuncptr" attribute. */
++
++tree
++amigaos_handle_check68kfuncptr_attribute (tree *node, tree name,
++	tree args ATTRIBUTE_UNUSED, int flags ATTRIBUTE_UNUSED,
++	bool *no_add_attrs)
++{
++  if (TREE_CODE (*node) != FUNCTION_TYPE
++      && TREE_CODE (*node) != METHOD_TYPE
++      && TREE_CODE (*node) != FIELD_DECL
++      && TREE_CODE (*node) != TYPE_DECL)
++    {
++      warning (0, "%s attribute only applies to functions",
++	       IDENTIFIER_POINTER (name));
++      *no_add_attrs = true;
++    }
++
++  return NULL_TREE;
++}
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..1153ece337930f7bbf5f9978bf6f3faf2138bda6
+--- /dev/null
++++ b/gcc/config/rs6000/amigaos.h
+@@ -0,0 +1,437 @@
++/* Definitions of target machine for GNU compiler, for AmigaOS.
++   Copyright (C) 1997, 2003, 2005 Free Software Foundation, Inc.
++
++   This file is part of GCC.
++
++   GCC is free software; you can redistribute it and/or modify it
++   under the terms of the GNU General Public License as published
++   by the Free Software Foundation; either version 2, or (at your
++   option) any later version.
++
++   GCC is distributed in the hope that it will be useful, but WITHOUT
++   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
++   License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with GCC; see the file COPYING.  If not, write to the
++   Free Software Foundation, 59 Temple Place - Suite 330, Boston,
++   MA 02111-1307, USA.  */
++
++
++/* Don't assume anything about the header files. */
++#define NO_IMPLICIT_EXTERN_C
++
++#undef MD_EXEC_PREFIX
++#undef MD_STARTFILE_PREFIX
++
++/* Make CPU default to 604e. FIXME: Make this 750 later */
++#undef PROCESSOR_DEFAULT
++#define PROCESSOR_DEFAULT PROCESSOR_PPC604e
++
++#undef DEFAULT_ABI
++#define DEFAULT_ABI ABI_V4
++
++#undef ASM_CPU_SPEC
++#define ASM_CPU_SPEC \
++"%{!mcpu*: \
++  %{mpower: %{!mpower2: -mpwr}} \
++  %{mpower2: -mpwrx} \
++  %{mpowerpc64*: -mppc64} \
++  %{!mpowerpc64*: %{mpowerpc*: -mppc}} \
++  %{mno-power: %{!mpowerpc*: -mcom}} \
++  %{!mno-power: %{!mpower*: %(asm_default)}}} \
++%{mcpu=common: -mcom} \
++%{mcpu=power: -mpwr} \
++%{mcpu=power2: -mpwrx} \
++%{mcpu=power3: -mppc64} \
++%{mcpu=power4: -mpower4} \
++%{mcpu=power5: -mpower4} \
++%{mcpu=powerpc: -mppc} \
++%{mcpu=rios: -mpwr} \
++%{mcpu=rios1: -mpwr} \
++%{mcpu=rios2: -mpwrx} \
++%{mcpu=rsc: -mpwr} \
++%{mcpu=rsc1: -mpwr} \
++%{mcpu=rs64a: -mppc64} \
++%{mcpu=401: -mppc} \
++%{mcpu=403: -m403} \
++%{mcpu=405: -m405} \
++%{mcpu=405fp: -m405} \
++%{mcpu=440: -m440} \
++%{mcpu=440fp: -m440} \
++%{mcpu=505: -mppc} \
++%{mcpu=601: -m601} \
++%{mcpu=602: -mppc} \
++%{mcpu=603: -mppc} \
++%{mcpu=603e: -mppc} \
++%{mcpu=ec603e: -mppc} \
++%{mcpu=604: -mppc} \
++%{mcpu=604e: -mppc} \
++%{mcpu=620: -mppc64} \
++%{mcpu=630: -mppc64} \
++%{mcpu=740: -mppc} \
++%{mcpu=750: -mppc} \
++%{mcpu=G3: -mppc} \
++%{mcpu=7400: -mppc -maltivec} \
++%{mcpu=7450: -mppc -maltivec} \
++%{mcpu=G4: -mppc -maltivec} \
++%{mcpu=801: -mppc} \
++%{mcpu=821: -mppc} \
++%{mcpu=823: -mppc} \
++%{mcpu=860: -mppc} \
++%{mcpu=970: -mpower4 -maltivec} \
++%{mcpu=G5: -mpower4 -maltivec} \
++%{mcpu=8540: -me500} \
++%{maltivec: -maltivec}"
++
++#define IS_MCRT(MCRTNAME) \
++  (strcmp(amigaos_crt, MCRTNAME) == 0)
++
++/* Make most of the definitions from other compilers available */
++#undef TARGET_OS_CPP_BUILTINS
++#define TARGET_OS_CPP_BUILTINS()                \
++  do                                            \
++    {                                           \
++      builtin_define_std ("PPC");		\
++      builtin_define_std ("powerpc");		\
++      builtin_assert ("cpu=powerpc");		\
++      builtin_assert ("machine=powerpc");	\
++      builtin_define_std ("AMIGA");		\
++      builtin_define_std ("AMIGAOS");		\
++      builtin_define_std ("AMIGAOS4");		\
++      builtin_define_std ("amiga");		\
++      builtin_define_std ("amigaos");		\
++      builtin_define_std ("amigaos4");		\
++      builtin_assert ("system=amigaos");	\
++      if (!amigaos_crt)			\
++        {					\
++          error ("no CRT specified");		\
++        }					\
++      else if (IS_MCRT("clib2") || IS_MCRT("clib2-ts")) \
++        {					\
++          builtin_define_std ("CLIB2");		\
++          if (IS_MCRT("clib2-ts"))		\
++            builtin_define ("__THREAD_SAFE");	\
++        }					\
++      else if (IS_MCRT("ixemul"))		\
++        {					\
++          builtin_define_std ("ixemul");	\
++          builtin_define_std ("IXEMUL");	\
++        }					\
++      else if (IS_MCRT("libnix"))		\
++        {					\
++          builtin_define_std ("libnix");	\
++          builtin_define_std ("LIBNIX");	\
++        }					\
++      else if (IS_MCRT("newlib"))		\
++        {					\
++          builtin_define_std ("NEWLIB");	\
++        }					\
++      TARGET_OS_SYSV_CPP_BUILTINS ();		\
++    }                                           \
++  while (0)
++
++#undef CPP_SPEC
++#define CPP_SPEC "%{posix: -D_POSIX_SOURCE} %(cpp_os_default)"
++
++/*#define STANDARD_INCLUDE_DIR "/GCC/include"*/
++/*#undef SYSTEM_INCLUDE_DIR *//* So that the include path order is the same in native and cross compilers */
++#undef LOCAL_INCLUDE_DIR
++
++#ifndef CROSS_DIRECTORY_STRUCTURE
++#define BASE_GCC_SPEC "/GCC/"
++#define BASE_SDK_SPEC "/SDK/"
++#else
++#define BASE_GCC_SPEC EXEC_PREFIX
++#define BASE_SDK_SPEC EXEC_PREFIX "ppc-amigaos/SDK/"
++#endif
++
++#define LIB_SUBDIR_TYPE_SPEC "\
++%{mbaserel:/baserel; msdata|msdata=default|msdata=sysv:/small-data}\
++%{msoft-float:/soft-float}"
++
++/* default linker specs */
++#undef REAL_LIBGCC_SPEC
++#define REAL_LIBGCC_SPEC "\
++%{static|static-libgcc: %{!use-dynld: -lgcc -lgcc_eh} %{use-dynld: -lgcc} }%{!static:%{!static-libgcc:%{!shared:%{!shared-libgcc: %{!use-dynld: -lgcc -lgcc_eh} %{use-dynld: -lgcc}}%{shared-libgcc:-lgcc}}%{shared:%{shared-libgcc:-lgcc}%{!shared-libgcc:-lgcc}}}}"
++
++
++/* make newlib the default */
++#if 1
++#define CPP_AMIGA_DEFAULT_SPEC "%{mcrt=default|!mcrt=*:%<mcrt=default -mcrt=newlib} %(cpp_newlib)"
++#define LINK_AMIGA_DEFAULT_SPEC "%(link_newlib)"
++#define STARTFILE_AMIGA_DEFAULT_SPEC "%(startfile_newlib)"
++#define ENDFILE_AMIGA_DEFAULT_SPEC "%(endfile_newlib)"
++#undef MULTILIB_DEFAULTS
++#define MULTILIB_DEFAULTS {"mcrt=newlib"}
++#else
++/* make clib2 the default */
++#define CPP_AMIGA_DEFAULT_SPEC "%{mcrt=default|!mcrt=*:%<mcrt=default -mcrt=clib2} %(cpp_clib2)"
++#define LINK_AMIGA_DEFAULT_SPEC "%(link_clib2)"
++#define STARTFILE_AMIGA_DEFAULT_SPEC "%(startfile_clib2)"
++#define ENDFILE_AMIGA_DEFAULT_SPEC "%(endfile_clib2)"
++#undef MULTILIB_DEFAULTS
++#define MULTILIB_DEFAULTS {"mcrt=clib2"}
++#endif
++
++
++/* For specifying the include system paths, we generally use -idirafter so the include
++ * paths are added at the end of the gcc default include paths. This is required for
++ * fixincludes and libstdc++ to work properly
++ */
++
++
++/* clib2 */
++
++#define CPP_CLIB2_SPEC "\
++-idirafter %(base_sdk)clib2/include -idirafter %(base_sdk)local/clib2/include"
++
++#define LIB_SUBDIR_CLIB2_SPEC "%{mcrt=clib2-ts:lib.threadsafe; :lib}%(lib_subdir_type)"
++
++#define LINK_CLIB2_SPEC "\
++-L%(base_sdk)clib2/%(lib_subdir_clib2) \
++-L%(base_gcc)lib/gcc/ppc-amigaos/%(version)/%{mcrt=clib2-ts:clib2-ts; :clib2}/lib%(lib_subdir_type) \
++-L%(base_sdk)local/clib2/%(lib_subdir_clib2)"
++
++#define STARTFILE_CLIB2_SPEC "\
++%(base_sdk)clib2/%{mcrt=clib2-ts:lib.threadsafe; :lib}" \
++                 "%{!msoft-float:%(lib_subdir_type)}/crtbegin.o \
++%(base_sdk)clib2/%{mcrt=clib2-ts:lib.threadsafe; :lib}" \
++                 "%{!msoft-float:%(lib_subdir_type)}/crt0.o"
++
++#define ENDFILE_CLIB2_SPEC "\
++%(base_sdk)clib2/%{mcrt=clib2-ts:lib.threadsafe; :lib}" \
++                 "%{!msoft-float:%(lib_subdir_type)}/crtend.o"
++
++/* ixemul */
++
++#define CPP_IXEMUL_SPEC "\
++-idirafter %(base_sdk)ixemul/include -idirafter %(base_sdk)local/ixemul/include"
++
++#define LIB_SUBDIR_IXEMUL_SPEC "lib%(lib_subdir_type)"
++
++#define LINK_IXEMUL_SPEC "\
++-L%(base_sdk)ixemul/%(lib_subdir_ixemul) \
++-L%(base_gcc)lib/gcc/ppc-amigaos/%(version)/ixemul/%(lib_subdir_ixemul) \
++-L%(base_sdk)local/ixemul/%(lib_subdir_ixemul)"
++
++/* ixemul startfile should work for all library flavours */
++#define STARTFILE_IXEMUL_SPEC "%(base_sdk)ixemul/%(lib_subdir_ixemul)/crtbegin.o"
++#define ENDFILE_IXEMUL_SPEC "%(base_sdk)ixemul/%(lib_subdir_ixemul)/crtend.o"
++
++/* libnix */
++
++#define CPP_LIBNIX_SPEC "\
++-idirafter %(base_sdk)libnix/include -idirafter %(base_sdk)local/libnix/include"
++
++#define LIB_SUBDIR_LIBNIX_SPEC "lib%(lib_subdir_type)"
++
++#define LINK_LIBNIX_SPEC "\
++-L%(base_sdk)libnix/%(lib_subdir_libnix) \
++-L%(base_gcc)lib/gcc/ppc-amigaos/%(version)/libnix/%(lib_subdir_libnix) \
++-L%(base_sdk)local/libnix/%(lib_subdir_libnix)"
++
++#define STARTFILE_LIBNIX_SPEC "%(base_sdk)libnix/%(lib_subdir_libnix)/crtbegin.o"
++#define ENDFILE_LIBNIX_SPEC "%(base_sdk)libnix/%(lib_subdir_libnix)/crtend.o"
++
++/* newlib */
++
++#define CPP_NEWLIB_SPEC "\
++-idirafter %(base_sdk)newlib/include -idirafter %(base_sdk)local/newlib/include"
++
++#define LIB_SUBDIR_NEWLIB_SPEC "lib%(lib_subdir_type)"
++
++#define LINK_NEWLIB_SPEC "\
++-L%(base_sdk)newlib/%(lib_subdir_newlib) \
++-L%(base_gcc)lib/gcc/ppc-amigaos/%(version)/newlib/%(lib_subdir_newlib) \
++-L%(base_sdk)local/newlib/%(lib_subdir_newlib)"
++
++/* newlib startfile should work for all library flavours */
++#define STARTFILE_NEWLIB_SPEC "\
++%{shared: %(base_sdk)newlib/%(lib_subdir_newlib)/shcrtbegin.o} %{!shared: %(base_sdk)newlib/%(lib_subdir_newlib)/crtbegin.o}"
++
++#define ENDFILE_NEWLIB_SPEC "\
++%{shared: %(base_sdk)newlib/%(lib_subdir_newlib)/shcrtend.o} %{!shared: %(base_sdk)newlib/%(lib_subdir_newlib)/crtend.o}"
++
++/* End clib specific */
++
++#undef CPP_OS_DEFAULT_SPEC
++#define CPP_OS_DEFAULT_SPEC "\
++%{mcrt=clib2|mcrt=clib2-ts: %(cpp_clib2); \
++mcrt=ixemul: %(cpp_ixemul); \
++mcrt=libnix: %(cpp_libnix); \
++mcrt=newlib: %(cpp_newlib); \
++mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
++: %eInvalid C runtime library} \
++-idirafter %(base_sdk)include/include_h \
++-idirafter %(base_sdk)include/netinclude \
++-idirafter %(base_sdk)local/common/include \
++%{mbaserel: %{msdata|msdata=default|msdata=sysv: %e-mbaserel and -msdata options are incompatible}} \
++%{newlib: %e-newlib is obsolete, use -mcrt=newlib instead}"
++
++#undef LINK_SPEC
++#define LINK_SPEC "\
++--defsym __amigaos4__=1 \
++%{!shared: %{!use-dynld: -Bstatic}} \
++-q -d %{h*} %{v:-V} %{G*} \
++%{Wl,*:%*} %{YP,*} %{R*} \
++%{Qy:} %{!Qn:-Qy} \
++%(link_shlib) %(link_text) \
++%{mbaserel: %{msdata|msdata=default|msdata=sysv: %e-mbaserel and -msdata options are incompatible}} \
++%{mcrt=clib2|mcrt=clib2-ts: %(link_clib2); \
++mcrt=ixemul: %(link_ixemul); \
++mcrt=libnix: %(link_libnix); \
++mcrt=newlib: %(link_newlib); \
++mcrt=default|!mcrt=*: %(link_amiga_default); \
++: %eInvalid C runtime library} \
++-L%(base_sdk)local/common/lib%(lib_subdir_type) \
++%{newlib: %e-newlib is obsolete, use -mcrt=newlib instead}"
++
++/* FIXME: LINK_TEXT has been made empty now. Could we get rid of it? */
++#if 0
++#define LINK_TEXT "\
++%{use-dynld: -Ttext=0x100000} %{!use-dynld: %{shared: -Ttext=0x100000} %{!shared: %{!Wl,-T*: %{!T*:-Ttext=0}}}}"
++#else
++#define LINK_TEXT ""
++#endif
++
++#define LINK_SHLIB "\
++%{shared:-shared -dy --defsym __dynld_version__=1} %{!shared: %{static:-static}} %{use-dynld: -dy}"
++
++#undef STARTFILE_SPEC
++#define STARTFILE_SPEC "\
++%{mcrt=clib2|mcrt=clib2-ts: %(startfile_clib2); \
++mcrt=ixemul: %(startfile_ixemul); \
++mcrt=libnix: %(startfile_libnix); \
++mcrt=newlib: %(startfile_newlib); \
++mcrt=default|!mcrt=*: %(startfile_amiga_default); \
++: %eInvalid C runtime library}"
++
++#undef ENDFILE_SPEC
++#define ENDFILE_SPEC "\
++%{mcrt=clib2|mcrt=clib2-ts: %(endfile_clib2); \
++mcrt=ixemul: %(endfile_ixemul); \
++mcrt=libnix: %(endfile_libnix); \
++mcrt=newlib: %(endfile_newlib); \
++mcrt=default|!mcrt=*: %(endfile_amiga_default); \
++: %eInvalid C runtime library}"
++
++#undef LIB_SPEC
++#define LIB_SPEC "\
++--start-group -lc --end-group"
++
++#undef TARGET_DEFAULT
++#define TARGET_DEFAULT 0
++
++#undef SUBTARGET_EXTRA_SPECS
++#define SUBTARGET_EXTRA_SPECS \
++  {"base_gcc", BASE_GCC_SPEC}, \
++  {"base_sdk", BASE_SDK_SPEC}, \
++  {"cpp_os_default", CPP_OS_DEFAULT_SPEC}, \
++  {"lib_subdir_type", LIB_SUBDIR_TYPE_SPEC}, \
++  /* default C runtime */ \
++  {"cpp_amiga_default", CPP_AMIGA_DEFAULT_SPEC}, \
++  {"link_amiga_default", LINK_AMIGA_DEFAULT_SPEC}, \
++  {"startfile_amiga_default", STARTFILE_AMIGA_DEFAULT_SPEC}, \
++  {"endfile_amiga_default", ENDFILE_AMIGA_DEFAULT_SPEC}, \
++  /* clib2 */ \
++  {"cpp_clib2", CPP_CLIB2_SPEC}, \
++  {"lib_subdir_clib2", LIB_SUBDIR_CLIB2_SPEC}, \
++  {"link_clib2", LINK_CLIB2_SPEC}, \
++  {"startfile_clib2", STARTFILE_CLIB2_SPEC}, \
++  {"endfile_clib2", ENDFILE_CLIB2_SPEC}, \
++  /* ixemul */ \
++  {"cpp_ixemul", CPP_IXEMUL_SPEC}, \
++  {"lib_subdir_ixemul", LIB_SUBDIR_IXEMUL_SPEC}, \
++  {"link_ixemul", LINK_IXEMUL_SPEC}, \
++  {"startfile_ixemul", STARTFILE_IXEMUL_SPEC}, \
++  {"endfile_ixemul", ENDFILE_IXEMUL_SPEC}, \
++  /* libnix */ \
++  {"cpp_libnix", CPP_LIBNIX_SPEC}, \
++  {"lib_subdir_libnix", LIB_SUBDIR_LIBNIX_SPEC}, \
++  {"link_libnix", LINK_LIBNIX_SPEC}, \
++  {"startfile_libnix", STARTFILE_LIBNIX_SPEC}, \
++  {"endfile_libnix", ENDFILE_LIBNIX_SPEC}, \
++  /* newlib */ \
++  {"cpp_newlib", CPP_NEWLIB_SPEC}, \
++  {"lib_subdir_newlib", LIB_SUBDIR_NEWLIB_SPEC}, \
++  {"link_newlib", LINK_NEWLIB_SPEC}, \
++  {"startfile_newlib", STARTFILE_NEWLIB_SPEC}, \
++  {"endfile_newlib", ENDFILE_NEWLIB_SPEC}, \
++  /* used in link spec  */ \
++  {"link_text", LINK_TEXT}, \
++  {"link_shlib", LINK_SHLIB},
++
++#undef DEFAULT_VTABLE_THUNKS
++#ifndef USE_GNULIBC_1
++#define DEFAULT_VTABLE_THUNKS 1
++#endif
++
++#undef JUMP_TABLES_IN_TEXT_SECTION
++#define JUMP_TABLES_IN_TEXT_SECTION 0
++
++/* Used as cookie for linear vararg passing */
++#define CALL_LINEARVARARGS      0x10000000
++
++#define SUB3TARGET_OVERRIDE_OPTIONS  \
++do                                   \
++{                                    \
++  if (TARGET_ALTIVEC)                \
++  {                                  \
++    rs6000_altivec_abi = 1;          \
++    TARGET_ALTIVEC_VRSAVE = 1;       \
++  }                                  \
++} while(0)
++
++#undef SUBTARGET_EXPAND_BUILTIN
++#define SUBTARGET_EXPAND_BUILTIN(EXP, TARGET, SUBTARGET, MODE, IGNORE, SUCCESS) \
++  amigaos_expand_builtin (EXP, TARGET, SUBTARGET, MODE, IGNORE, SUCCESS)
++
++#undef SUBTARGET_INIT_BUILTINS
++#define SUBTARGET_INIT_BUILTINS \
++  amigaos_init_builtins ()
++
++/* AmigaOS specific attribute */
++/* { name, min_len, max_len, decl_req, type_req, fn_type_req,
++       affects_type_identity, handler, exclude } */
++#define SUBTARGET_ATTRIBUTE_TABLE \
++  { "linearvarargs", 0, 0, false, true,  true, false, amigaos_handle_linearvarargs_attribute, NULL}, \
++  { "lineartags", 0, 0, false, true, true, false, amigaos_handle_lineartags_attribute, NULL}, \
++  { "baserel_restore", 0, 0, false, true, true, false, amigaos_handle_baserel_restore_attribute, NULL }, \
++  { "force_no_baserel", 0, 0, true, false, false, false, amigaos_handle_force_no_baserel_attribute, NULL }, \
++  { "check68kfuncptr", 0, 0, false, true, true, false, amigaos_handle_check68kfuncptr_attribute, NULL }
++
++/* Overrides */
++/*
++#undef INIT_CUMULATIVE_ARGS
++#define INIT_CUMULATIVE_ARGS(CUM, FNTYPE, LIBNAME, INDIRECT, N_NAMED_ARGS) \
++  amigaos_init_cumulative_args (&CUM, FNTYPE, LIBNAME, FALSE, N_NAMED_ARGS)
++
++#undef INIT_CUMULATIVE_INCOMING_ARGS
++#define INIT_CUMULATIVE_INCOMING_ARGS(CUM, FNTYPE, LIBNAME) \
++  amigaos_init_cumulative_args (&CUM, FNTYPE, LIBNAME, TRUE, 1000)
++
++#undef FUNCTION_ARG_ADVANCE
++#define FUNCTION_ARG_ADVANCE(CUM, MODE, TYPE, NAMED)    \
++  amigaos_function_arg_advance (&CUM, MODE, TYPE, NAMED)
++
++#undef FUNCTION_ARG
++#define FUNCTION_ARG(CUM, MODE, TYPE, NAMED) \
++  amigaos_function_arg (&CUM, MODE, TYPE, NAMED)
++*/
++#undef EXPAND_BUILTIN_VA_START
++#define EXPAND_BUILTIN_VA_START(VALIST, NEXTARG) \
++  amigaos_expand_builtin_va_start (VALIST, NEXTARG)
++
++/*
++//#undef SLOW_UNALIGNED_ACCESS
++//#define SLOW_UNALIGNED_ACCESS(MODE, ALIGN)				\
++//  (STRICT_ALIGNMENT							\
++//   || (((MODE) == SFmode) && (ALIGN) < 32)				\
++//   || (((MODE) == DFmode || (MODE) == TFmode || (MODE) == DImode)	\
++//       && (ALIGN) < 64))
++*/
++
++/* This target uses the amigaos.opt file.  */
++#define TARGET_USES_AMIGAOS_OPT 1
+diff --git a/gcc/config/rs6000/amigaos.opt b/gcc/config/rs6000/amigaos.opt
+new file mode 100644
+index 0000000000000000000000000000000000000000..93d74f10bea8c1b23c82a9650bb0c3c153464ba7
+--- /dev/null
++++ b/gcc/config/rs6000/amigaos.opt
+@@ -0,0 +1,37 @@
++; Options for the PowerPC AmigaOS port
++;
++; Copyright (C) 2005 Free Software Foundation, Inc.
++; Contributed by Jens Langner <Jens.Langner@light-speed.de>
++;
++; This file is part of GCC.
++;
++; GCC is free software; you can redistribute it and/or modify it under
++; the terms of the GNU General Public License as published by the Free
++; Software Foundation; either version 2, or (at your option) any later
++; version.
++;
++; GCC is distributed in the hope that it will be useful, but WITHOUT
++; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
++; License for more details.
++;
++; You should have received a copy of the GNU General Public License
++; along with GCC; see the file COPYING.  If not, write to the Free
++; Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA
++; 02110-1301, USA.
++
++mcrt=
++Target RejectNegative Joined Var(amigaos_crt) Init("newlib")
++Select C runtime library
++
++mbaserel
++Target Report Mask(BASEREL)
++Generate base relative data access
++
++mcheck68kfuncptr
++Target Report Var(CHECK68KFUNCPTR)
++Generate target checking for function pointers
++
++use-dynld
++Target Driver
++Generated binary employs the dynamic linker for shared objects.
+diff --git a/gcc/config/rs6000/rs6000-builtin.def b/gcc/config/rs6000/rs6000-builtin.def
+index 1766d325bfb03f06d2d4efec10c5fb88512f7047..435ebc538b6d5a14d8a33006ac3b655964cfa1c5 100644
+--- a/gcc/config/rs6000/rs6000-builtin.def
++++ b/gcc/config/rs6000/rs6000-builtin.def
+@@ -2764,12 +2764,19 @@ BU_SPECIAL_X (RS6000_BUILTIN_CPU_SUPPORTS, "__builtin_cpu_supports",
+ 	      RS6000_BTM_ALWAYS, RS6000_BTC_MISC)
+ 
+ /* Darwin CfString builtin.  */
+ BU_SPECIAL_X (RS6000_BUILTIN_CFSTRING, "__builtin_cfstring", RS6000_BTM_ALWAYS,
+ 	      RS6000_BTC_MISC)
+ 
++/* AmigaOS specific builtin. */
++RS6000_BUILTIN_2 (AMIGAOS_BUILTIN_GETLINEARVA,	/* ENUM */	\
++		    "__builtin_getlinearva",	/* NAME */	\
++		    RS6000_BTM_ALWAYS,		/* MASK */	\
++		    RS6000_BTC_MISC,		/* ATTR */	\
++		    CODE_FOR_nothing)		/* ICODE */
++
+ /* POWER10 MMA builtins.  */
+ BU_P10V_VSX_1 (XVCVBF16SPN,	    "xvcvbf16spn",	MISC, vsx_xvcvbf16spn)
+ BU_P10V_VSX_1 (XVCVSPBF16,	    "xvcvspbf16",	MISC, vsx_xvcvspbf16)
+ 
+ BU_MMA_1 (XXMFACC,	    "xxmfacc",		QUAD, mma_xxmfacc)
+ BU_MMA_1 (XXMTACC,	    "xxmtacc",		QUAD, mma_xxmtacc)
+diff --git a/gcc/config/rs6000/rs6000-call.c b/gcc/config/rs6000/rs6000-call.c
+index a112593878abf8357aa6c50aa1e6ab8cc114728e..37ac5c50da657b96d52cda9d82a64bef4107073c 100644
+--- a/gcc/config/rs6000/rs6000-call.c
++++ b/gcc/config/rs6000/rs6000-call.c
+@@ -5991,12 +5991,18 @@ init_cumulative_args (CUMULATIVE_ARGS *cum, tree fntype,
+ 	  if (!(fntype
+ 		&& lookup_attribute ("plt", TYPE_ATTRIBUTES (fntype))))
+ 	    cum->call_cookie |= CALL_LONG;
+ 	}
+     }
+ 
++  /* AmigaOS4: Check if either libcall or linear varargs, set appropriate cookie */
++  if (fntype && (lookup_attribute ("libcall", TYPE_ATTRIBUTES (fntype))))
++    cum->call_cookie |= CALL_LINEARVARARGS;
++  if (fntype && (lookup_attribute ("linearvarargs", TYPE_ATTRIBUTES (fntype))))
++    cum->call_cookie |= CALL_LINEARVARARGS;
++
+   if (TARGET_DEBUG_ARG)
+     {
+       fprintf (stderr, "\ninit_cumulative_args:");
+       if (fntype)
+ 	{
+ 	  tree ret_type = TREE_TYPE (fntype);
+@@ -6692,12 +6698,21 @@ rs6000_function_arg_advance_1 (CUMULATIVE_ARGS *cum, machine_mode mode,
+ 	  fprintf (stderr, "nargs = %4d, proto = %d, mode = %4s, ",
+ 		   cum->nargs_prototype, cum->prototype, GET_MODE_NAME (mode));
+ 	  fprintf (stderr, "named = %d, align = %d, depth = %d\n",
+ 		   named, align_words - start_words, depth);
+ 	}
+     }
++
++  /*  If the function has the linearvarargs attribute and this argument
++   to advance over is the last non-vararg argument, then advance over
++   all registers, so that the overflow area is hit immediately. */
++  if (cum->call_cookie & CALL_LINEARVARARGS && cum->nargs_prototype <= 0)
++    {
++      cum->sysv_gregno = GP_ARG_MAX_REG + 1;
++      cum->fregno = FP_ARG_V4_MAX_REG + 1;
++    }
+ }
+ 
+ void
+ rs6000_function_arg_advance (cumulative_args_t cum,
+ 			     const function_arg_info &arg)
+ {
+@@ -7763,12 +7778,18 @@ setup_incoming_varargs (cumulative_args_t cum,
+       save_area = crtl->args.internal_arg_pointer;
+ 
+       if (targetm.calls.must_pass_in_stack (arg))
+ 	first_reg_offset += rs6000_arg_size (TYPE_MODE (arg.type), arg.type);
+     }
+ 
++#ifdef CALL_LINEARVARARGS
++  /* For AmigaOS: No need to save registers for linearvarargs functions */
++  if (next_cum.call_cookie & CALL_LINEARVARARGS)
++    return;
++#endif
++
+   set = get_varargs_alias_set ();
+   if (! no_rtl && first_reg_offset < GP_ARG_NUM_REG
+       && cfun->va_list_gpr_size)
+     {
+       int n_gpr, nregs = GP_ARG_NUM_REG - first_reg_offset;
+ 
+@@ -7886,13 +7907,13 @@ rs6000_build_builtin_va_list (void)
+   return build_array_type (record, build_index_type (size_zero_node));
+ }
+ 
+ /* Implement va_start.  */
+ 
+ void
+-rs6000_va_start (tree valist, rtx nextarg)
++rs6000_va_start2 (tree valist, rtx nextarg)
+ {
+   HOST_WIDE_INT words, n_gpr, n_fpr;
+   tree f_gpr, f_fpr, f_res, f_ovf, f_sav;
+   tree gpr, fpr, ovf, sav, t;
+ 
+   /* Only SVR4 needs something special.  */
+@@ -7921,12 +7942,21 @@ rs6000_va_start (tree valist, rtx nextarg)
+   words = crtl->args.info.words;
+   n_gpr = MIN (crtl->args.info.sysv_gregno - GP_ARG_MIN_REG,
+ 	       GP_ARG_NUM_REG);
+   n_fpr = MIN (crtl->args.info.fregno - FP_ARG_MIN_REG,
+ 	       FP_ARG_NUM_REG);
+ 
++  /* For linearvarargs functions, immediately increase the fpr
++     and gpr count to the maximum value, so that va_arg will look
++     only at the stack. */
++  if (crtl->args.info.call_cookie & CALL_LINEARVARARGS)
++    {
++	n_gpr = GP_ARG_NUM_REG;
++	n_fpr = FP_ARG_NUM_REG;
++    }
++
+   if (TARGET_DEBUG_ARG)
+     fprintf (stderr, "va_start: words = " HOST_WIDE_INT_PRINT_DEC", n_gpr = "
+ 	     HOST_WIDE_INT_PRINT_DEC", n_fpr = " HOST_WIDE_INT_PRINT_DEC"\n",
+ 	     words, n_gpr, n_fpr);
+ 
+   if (cfun->va_list_gpr_size)
+@@ -7972,12 +8002,18 @@ rs6000_va_start (tree valist, rtx nextarg)
+     t = fold_build_pointer_plus_hwi (t, cfun->machine->varargs_save_offset);
+   t = build2 (MODIFY_EXPR, TREE_TYPE (sav), sav, t);
+   TREE_SIDE_EFFECTS (t) = 1;
+   expand_expr (t, const0_rtx, VOIDmode, EXPAND_NORMAL);
+ }
+ 
++void
++rs6000_va_start (tree valist, rtx nextarg)
++{
++  rs6000_va_start2(valist, nextarg);
++}
++
+ /* Implement va_arg.  */
+ 
+ tree
+ rs6000_gimplify_va_arg (tree valist, tree type, gimple_seq *pre_p,
+ 			gimple_seq *post_p)
+ {
+@@ -11963,12 +11999,19 @@ rs6000_expand_builtin (tree exp, rtx target, rtx subtarget ATTRIBUTE_UNUSED,
+       case CODE_FOR_xststdcnegqp_kf:	icode = CODE_FOR_xststdcnegqp_tf; break;
+       case CODE_FOR_xsiexpqp_kf:	icode = CODE_FOR_xsiexpqp_tf;	break;
+       case CODE_FOR_xsiexpqpf_kf:	icode = CODE_FOR_xsiexpqpf_tf;	break;
+       case CODE_FOR_xststdcqp_kf:	icode = CODE_FOR_xststdcqp_tf;	break;
+       }
+ 
++  /* Try subtarget first */
++#ifdef SUBTARGET_EXPAND_BUILTIN
++  ret = SUBTARGET_EXPAND_BUILTIN (exp, target, subtarget, mode, ignore, &success);
++  if (success)
++    return ret;
++#endif
++
+   if (TARGET_DEBUG_BUILTIN)
+     {
+       const char *name1 = rs6000_builtin_info[uns_fcode].name;
+       const char *name2 = (icode != CODE_FOR_nothing)
+ 			   ? get_insn_name ((int) icode)
+ 			   : "nothing";
+diff --git a/gcc/config/rs6000/rs6000-internal.h b/gcc/config/rs6000/rs6000-internal.h
+index 9caef013a719fc0b3a93e5427476dcb7728131d1..114053233239b564da9ffc16896254b2de0d3d81 100644
+--- a/gcc/config/rs6000/rs6000-internal.h
++++ b/gcc/config/rs6000/rs6000-internal.h
+@@ -55,12 +55,18 @@ typedef struct rs6000_stack {
+   int altivec_size;		/* size of saved AltiVec registers */
+   int cr_size;			/* size to hold CR if not in fixed area */
+   int vrsave_size;		/* size to hold VRSAVE */
+   int altivec_padding_size;	/* size of altivec alignment padding */
+   HOST_WIDE_INT total_size;	/* total bytes allocated for stack */
+   int savres_strategy;
++#ifdef TARGET_BASEREL
++  int baserel_save_p;           /* true if the baserel register needs to be
++                                   saved */
++  int baserel_save_offset;      /* offset to save baserel register */
++  int baserel_size;             /* size of saved baserel register */
++#endif
+ } rs6000_stack_t;
+ 
+ 
+ extern int need_toc_init;
+ extern char toc_label_name[10];
+ extern int rs6000_pic_labelno;
+diff --git a/gcc/config/rs6000/rs6000-logue.c b/gcc/config/rs6000/rs6000-logue.c
+index 6aad1ff826ab6ff9e5afa9b2afba239854ab43e7..93028165d19419c2648e8d34edff345059bb8e38 100644
+--- a/gcc/config/rs6000/rs6000-logue.c
++++ b/gcc/config/rs6000/rs6000-logue.c
+@@ -714,12 +714,25 @@ rs6000_stack_info (void)
+   info->altivec_size = 16 * (LAST_ALTIVEC_REGNO + 1
+ 				 - info->first_altivec_reg_save);
+ 
+   /* Does this function call anything?  */
+   info->calls_p = (!crtl->is_leaf || cfun->machine->ra_needs_full_frame);
+ 
++#ifdef TARGET_BASEREL
++  /* Check if the function wants to setup the baserel register (r2) */
++  if (TARGET_BASEREL
++      && current_function_decl
++      && lookup_attribute ("baserel_restore", TYPE_ATTRIBUTES (TREE_TYPE (current_function_decl))))
++    {
++      info->baserel_save_p = 1;
++      info->baserel_size = reg_size;
++      df_set_regs_ever_live(2,true);
++      info->calls_p = 1;
++    }
++#endif /* TARGET_BASEREL */
++
+   /* Determine if we need to save the condition code registers.  */
+   if (save_reg_p (CR2_REGNO)
+       || save_reg_p (CR3_REGNO)
+       || save_reg_p (CR4_REGNO))
+     {
+       info->cr_save_p = 1;
+@@ -817,13 +830,18 @@ rs6000_stack_info (void)
+       info->lr_save_offset = 2*reg_size;
+       break;
+ 
+     case ABI_V4:
+       info->fp_save_offset = -info->fp_size;
+       info->gp_save_offset = info->fp_save_offset - info->gp_size;
++#ifdef TARGET_BASEREL
++      info->baserel_save_offset = info->gp_save_offset - info->baserel_size;
++      info->cr_save_offset = info->baserel_save_offset - info->cr_size;
++#else
+       info->cr_save_offset = info->gp_save_offset - info->cr_size;
++#endif
+ 
+       if (TARGET_ALTIVEC_ABI)
+ 	{
+ 	  info->vrsave_save_offset = info->cr_save_offset - info->vrsave_size;
+ 
+ 	  /* Align stack so vector save area is on a quadword boundary.  */
+@@ -852,12 +870,16 @@ rs6000_stack_info (void)
+ 				  + ehrd_size
+ 				  + ehcr_size
+ 				  + info->cr_size
+ 				  + info->vrsave_size,
+ 				  save_align);
+ 
++#ifdef TARGET_BASEREL
++  info->save_size += RS6000_ALIGN (info->baserel_size, save_align);
++#endif
++
+   non_fixed_size = info->vars_size + info->parm_size + info->save_size;
+ 
+   info->total_size = RS6000_ALIGN (non_fixed_size + info->fixed_size,
+ 				   ABI_STACK_BOUNDARY / BITS_PER_UNIT);
+ 
+   /* Determine if we need to save the link register.  */
+@@ -961,12 +983,17 @@ debug_stack_info (rs6000_stack_t *info)
+   if (info->lr_save_p)
+     fprintf (stderr, "\tlr_save_p           = %5d\n", info->lr_save_p);
+ 
+   if (info->cr_save_p)
+     fprintf (stderr, "\tcr_save_p           = %5d\n", info->cr_save_p);
+ 
++#ifdef TARGET_BASEREL
++  if (info->baserel_save_p)
++    fprintf (stderr, "\tbaserel_save_p      = %5d\n", info->baserel_save_p);
++#endif
++
+   if (info->vrsave_mask)
+     fprintf (stderr, "\tvrsave_mask         = 0x%x\n", info->vrsave_mask);
+ 
+   if (info->push_p)
+     fprintf (stderr, "\tpush_p              = %5d\n", info->push_p);
+ 
+@@ -993,12 +1020,17 @@ debug_stack_info (rs6000_stack_t *info)
+   if (info->cr_save_p)
+     fprintf (stderr, "\tcr_save_offset      = %5d\n", info->cr_save_offset);
+ 
+   if (info->varargs_save_offset)
+     fprintf (stderr, "\tvarargs_save_offset = %5d\n", info->varargs_save_offset);
+ 
++#ifdef TARGET_BASEREL
++  if (info->baserel_save_offset && TARGET_BASEREL)
++    fprintf (stderr, "\tbaserel_save_offset = %5d\n", info->baserel_save_offset);
++#endif
++
+   if (info->total_size)
+     fprintf (stderr, "\ttotal_size          = " HOST_WIDE_INT_PRINT_DEC"\n",
+ 	     info->total_size);
+ 
+   if (info->vars_size)
+     fprintf (stderr, "\tvars_size           = " HOST_WIDE_INT_PRINT_DEC"\n",
+@@ -1019,12 +1051,17 @@ debug_stack_info (rs6000_stack_t *info)
+   if (info->altivec_size)
+     fprintf (stderr, "\taltivec_size        = %5d\n", info->altivec_size);
+ 
+   if (info->vrsave_size)
+     fprintf (stderr, "\tvrsave_size         = %5d\n", info->vrsave_size);
+ 
++#ifdef TARGET_BASEREL
++  if (info->baserel_size && TARGET_BASEREL)
++    fprintf (stderr, "\tbaserel_size        = %5d\n", info->baserel_size);
++#endif
++
+   if (info->altivec_padding_size)
+     fprintf (stderr, "\taltivec_padding_size= %5d\n",
+ 	     info->altivec_padding_size);
+ 
+   if (info->cr_size)
+     fprintf (stderr, "\tcr_size             = %5d\n", info->cr_size);
+@@ -3378,12 +3415,28 @@ rs6000_emit_prologue (void)
+ 			     sp_off - frame_off);
+ 
+ 	  offset += reg_size;
+ 	}
+     }
+ 
++#ifdef TARGET_BASEREL
++  if (info->baserel_save_p && TARGET_BASEREL)
++    {
++      /* Store r2 */
++      rtx addr, reg, mem;
++
++      addr = gen_rtx_PLUS (Pmode, frame_reg_rtx,
++			   GEN_INT (info->baserel_save_offset + frame_off)); /* or sp_off? */
++      mem = gen_frame_mem (reg_mode, addr);
++
++      reg = gen_rtx_REG (reg_mode, 2);
++      insn = emit_move_insn (mem, reg);
++      rs6000_frame_related (insn, gen_rtx_REG (Pmode, 12), info->total_size, /* verify info->total_size */
++				NULL_RTX, NULL_RTX);
++    }
++#endif
+   if (crtl->calls_eh_return)
+     {
+       unsigned int i;
+       rtvec p;
+ 
+       for (i = 0; ; ++i)
+@@ -3839,12 +3892,19 @@ rs6000_emit_prologue (void)
+ 
+       if (!info->lr_save_p)
+ 	emit_move_insn (lr, gen_rtx_REG (Pmode, 0));
+     }
+ #endif
+ 
++#ifdef TARGET_BASEREL
++      /* Emit a blockage to prevent r2-dependant instructions from moving into
++       * the prologue. r2 is set up later in amigaos_function_end_prologue.  */
++      if (info->baserel_save_p && TARGET_BASEREL)
++        emit_insn (gen_blockage ());
++#endif
++
+   /* If we need to, save the TOC register after doing the stack setup.
+      Do not emit eh frame info for this save.  The unwinder wants info,
+      conceptually attached to instructions in this function, about
+      register values in the caller of this function.  This R2 may have
+      already been changed from the value in the caller.
+      We don't attempt to write accurate DWARF EH frame info for R2
+@@ -3900,12 +3960,17 @@ rs6000_output_savres_externs (FILE *file)
+ 		     & REST_NOINLINE_FPRS_DOESNT_RESTORE_LR) == 0;
+ 	  int sel = SAVRES_FPR | (lr ? SAVRES_LR : 0);
+ 	  name = rs6000_savres_routine_name (regno, sel);
+ 	  fprintf (file, "\t.extern %s\n", name);
+ 	}
+     }
++
++#ifdef TARGET_BASEREL
++  if (info->baserel_save_p && TARGET_BASEREL)
++    fprintf (file, "\t.extern __baserel_get_addr\n");
++#endif
+ }
+ 
+ /* Write function prologue.  */
+ 
+ void
+ rs6000_output_function_prologue (FILE *file)
+@@ -4807,12 +4872,30 @@ rs6000_emit_epilogue (enum epilogue_type epilogue_type)
+ 				      + reg_size * (int) i);
+ 
+ 	  emit_move_insn (gen_rtx_REG (reg_mode, regno), mem);
+ 	}
+     }
+ 
++#ifdef TARGET_BASEREL
++  if (info->baserel_save_p && TARGET_BASEREL)
++    {
++      rtx addr, mem, reg;
++
++      /* Restore r2 */
++      addr = gen_rtx_PLUS (Pmode, gen_rtx_REG (Pmode, 12),
++			   GEN_INT (info->baserel_save_offset + frame_off)); /* or sp_off? */
++      mem = gen_frame_mem (reg_mode, addr);
++
++      reg = gen_rtx_REG (reg_mode, 2);
++      emit_move_insn (reg, mem);
++
++      /* Mark register as used.  */
++      emit_insn (gen_rtx_USE (VOIDmode, reg));
++    }
++#endif
++
+   /* Restore GPRs.  This is done as a PARALLEL if we are using
+      the load-multiple instructions.  */
+   if (!restoring_GPRs_inline)
+     {
+       /* We are jumping to an out-of-line function.  */
+       rtx ptr_reg;
+diff --git a/gcc/config/rs6000/rs6000.c b/gcc/config/rs6000/rs6000.c
+index a6dc11569941c553322811e0fc6b4cdd87fc3f2d..883e8b037572e88bbe43fa24b9c4ad19f1de4cc8 100644
+--- a/gcc/config/rs6000/rs6000.c
++++ b/gcc/config/rs6000/rs6000.c
+@@ -1363,12 +1363,18 @@ static const struct attribute_spec rs6000_attribute_table[] =
+ 
+ #undef TARGET_ASM_FUNCTION_PROLOGUE
+ #define TARGET_ASM_FUNCTION_PROLOGUE rs6000_output_function_prologue
+ #undef TARGET_ASM_FUNCTION_EPILOGUE
+ #define TARGET_ASM_FUNCTION_EPILOGUE rs6000_output_function_epilogue
+ 
++#ifdef TARGET_BASEREL
++extern void amigaos_function_end_prologue(FILE *);
++#undef TARGET_ASM_FUNCTION_END_PROLOGUE
++#define TARGET_ASM_FUNCTION_END_PROLOGUE amigaos_function_end_prologue
++#endif
++
+ #undef TARGET_ASM_OUTPUT_ADDR_CONST_EXTRA
+ #define TARGET_ASM_OUTPUT_ADDR_CONST_EXTRA rs6000_output_addr_const_extra
+ 
+ #undef TARGET_LEGITIMIZE_ADDRESS
+ #define TARGET_LEGITIMIZE_ADDRESS rs6000_legitimize_address
+ 
+@@ -5642,12 +5648,15 @@ rs6000_file_start (void)
+ 	putc ('\n', file);
+     }
+ 
+ #ifdef USING_ELFOS_H
+   rs6000_machine = rs6000_machine_from_flags ();
+   emit_asm_machine ();
++  /* AmigaOS: This was temporarily disabled to not override e.g., -mcpu=440 */
++  /* Not entirely sure why, but there might be a good reason so consider this
++   * a FIXME. Refer to patches for gcc <= 9. */
+ #endif
+ 
+   if (DEFAULT_ABI == ABI_ELFv2)
+     fprintf (file, "\t.abiversion 2\n");
+ }
+ 
+@@ -8254,12 +8263,20 @@ rs6000_legitimize_address (rtx x, rtx oldx ATTRIBUTE_UNUSED,
+     {
+       enum tls_model model = SYMBOL_REF_TLS_MODEL (x);
+       if (model != 0)
+ 	return rs6000_legitimize_tls_address (x, model);
+     }
+ 
++#ifdef TARGET_BASEREL
++  if (TARGET_BASEREL
++      && amigaos_baserel_operand(x))
++    {
++      return amigaos_legitimize_baserel_address(x);
++    }
++#endif
++
+   extra = 0;
+   switch (mode)
+     {
+     case E_TFmode:
+     case E_TDmode:
+     case E_TImode:
+@@ -9767,12 +9784,21 @@ rs6000_emit_move (rtx dest, rtx source, machine_mode mode)
+ 	  tmp = gen_rtx_PLUS (mode, tmp, addend);
+ 	  tmp = force_operand (tmp, operands[0]);
+ 	}
+       operands[1] = tmp;
+     }
+ 
++#ifdef TARGET_BASEREL
++  if (/*GET_CODE (operands[1]) == SYMBOL_REF
++      && */TARGET_BASEREL
++      && amigaos_baserel_operand (operands[1]))
++    {
++       operands[1] = amigaos_legitimize_baserel_address (operands[1]);
++    }
++#endif
++
+   /* 128-bit constant floating-point values on Darwin should really be loaded
+      as two parts.  However, this premature splitting is a problem when DFmode
+      values can go into Altivec registers.  */
+   if (TARGET_MACHO && CONST_DOUBLE_P (operands[1]) && FLOAT128_IBM_P (mode)
+       && !reg_addr[DFmode].scalar_in_vmx_p)
+     {
+@@ -10027,12 +10053,20 @@ rs6000_emit_move (rtx dest, rtx source, machine_mode mode)
+ 	      emit_insn (gen_macho_high (Pmode, target, operands[1]));
+ 	      emit_insn (gen_macho_low (Pmode, operands[0],
+ 					target, operands[1]));
+ 	      return;
+ 	    }
+ 
++#ifdef TARGET_BASEREL
++	  if (TARGET_BASEREL && amigaos_baserel_operand(operands[1]))
++	    {
++              emit_insn (gen_elf_base_high (target, gen_rtx_REG (Pmode, 2), operands[1]));
++              emit_insn (gen_elf_base_low (operands[0], target, operands[1]));
++              return;
++        }
++#endif
+ 	  emit_insn (gen_elf_high (target, operands[1]));
+ 	  emit_insn (gen_elf_low (operands[0], target, operands[1]));
+ 	  return;
+ 	}
+ 
+       /* If this is a SYMBOL_REF that refers to a constant pool entry,
+@@ -13494,13 +13528,22 @@ print_operand_address (FILE *file, rtx x)
+ #endif
+ #if TARGET_ELF
+   else if (GET_CODE (x) == LO_SUM && REG_P (XEXP (x, 0))
+ 	   && CONSTANT_P (XEXP (x, 1)))
+     {
+       output_addr_const (file, XEXP (x, 1));
++#ifdef TARGET_BASEREL
++      if (TARGET_BASEREL && amigaos_baserel_operand(x))
++        {
++          fprintf (file, "@brel@l(%s)", reg_names[ REGNO (XEXP (x, 0)) ]);
++        }
++      else
++          fprintf (file, "@l(%s)", reg_names[ REGNO (XEXP (x, 0)) ]);
++#else
+       fprintf (file, "@l(%s)", reg_names[ REGNO (XEXP (x, 0)) ]);
++#endif
+     }
+ #endif
+   else if (toc_relative_expr_p (x, false, &tocrel_base_oac, &tocrel_offset_oac))
+     {
+       /* This hack along with a corresponding hack in
+ 	 rs6000_output_addr_const_extra arranges to output addends
+diff --git a/gcc/config/rs6000/rs6000.h b/gcc/config/rs6000/rs6000.h
+index efd989c5d29b3eafe19802c0ddaed290dd68e491..b4db208fa953778e3c0aeb2abb4c8ca0f8dc0f86 100644
+--- a/gcc/config/rs6000/rs6000.h
++++ b/gcc/config/rs6000/rs6000.h
+@@ -2602,6 +2602,9 @@ while (0)
+   do									\
+     {									\
+      if (TARGET_PREFIXED)						\
+        rs6000_asm_output_opcode (STREAM);				\
+     }									\
+   while (0)
++
++/* Used by amigaos port */
++void rs6000_va_start (tree valist, rtx nextarg);
+diff --git a/gcc/config/rs6000/rs6000.md b/gcc/config/rs6000/rs6000.md
+index c4d7cdb6fa7a32e4731bde5724277c5a53a7dfbd..a8b01d72a3fc7553b72a62b683033fdb9ff47bf4 100644
+--- a/gcc/config/rs6000/rs6000.md
++++ b/gcc/config/rs6000/rs6000.md
+@@ -10316,12 +10316,37 @@
+     && legitimate_constant_pool_address_p (operands[1], QImode, false)"
+    "la %0,%a1"
+    "&& TARGET_CMODEL != CMODEL_SMALL && reload_completed"
+   [(set (match_dup 0) (high:P (match_dup 1)))
+    (set (match_dup 0) (lo_sum:P (match_dup 0) (match_dup 1)))])
+ 
++;; This needs to be above elf_high/elf_low since elf_base_low and elf_low
++;; have the same instruction signature, so in some cases elf_low would be
++;; generated instead of elf_base_low. Since the requirements for elf_base_low
++;; are more restrictive than those for elf_low, there should be no problems
++;; when determining which instruction to use. Additionally, the elf_low function
++;; has now been guared against used accidently.
++(define_insn "elf_base_high"
++  [(set (match_operand:SI 0 "gpc_reg_operand" "=b")
++        (plus:SI (match_operand:SI 1 "gpc_reg_operand" "b")
++                 (high:SI (match_operand 2 "" ""))))]
++  "TARGET_ELF && ! TARGET_64BIT && TARGET_BASEREL"
++  "{cau|addis} %0,%1,%2@brel@ha"
++  [(set_attr "length" "4")])
++
++;; Nearly same as elf_low, but used base relative relocs.
++;; The second alternative has also been removed (as %K always
++;; uses normal relocs, see rs6000.c/print_operand()).
++(define_insn "elf_base_low"
++  [(set (match_operand:SI 0 "gpc_reg_operand" "=r")
++	(lo_sum:SI (match_operand:SI 1 "gpc_reg_operand" "b")
++		   (match_operand 2 "" "")))]
++   "TARGET_ELF && ! TARGET_64BIT && TARGET_BASEREL && amigaos_baserel_operand(operands[2])"
++   "{cal|la} %0,%2@brel@l(%1)"
++   [(set_attr "length" "4")])
++
+ ;; Elf specific ways of loading addresses for non-PIC code.
+ ;; The output of this could be r0, but we make a very strong
+ ;; preference for a base register because it will usually
+ ;; be needed there.
+ (define_insn "elf_high"
+   [(set (match_operand:SI 0 "gpc_reg_operand" "=b*r")
+@@ -10330,13 +10355,13 @@
+   "lis %0,%1@ha")
+ 
+ (define_insn "elf_low"
+   [(set (match_operand:SI 0 "gpc_reg_operand" "=r")
+ 	(lo_sum:SI (match_operand:SI 1 "gpc_reg_operand" "b")
+ 		   (match_operand 2 "" "")))]
+-   "TARGET_ELF && !TARGET_64BIT && !flag_pic"
++   "TARGET_ELF && !TARGET_64BIT && !flag_pic && !(TARGET_BASEREL && amigaos_baserel_operand(operands[2]))"
+    "la %0,%2@l(%1)")
+ 
+ (define_insn "*pltseq_tocsave_<mode>"
+   [(set (match_operand:P 0 "memory_operand" "=m")
+ 	(unspec:P [(match_operand:P 1 "gpc_reg_operand" "b")
+ 		   (match_operand:P 2 "symbol_ref_operand" "s")
+diff --git a/gcc/config/rs6000/t-amigaos b/gcc/config/rs6000/t-amigaos
+new file mode 100644
+index 0000000000000000000000000000000000000000..15d9d3fd5a5f0c8109cd158242745fa52b19257e
+--- /dev/null
++++ b/gcc/config/rs6000/t-amigaos
+@@ -0,0 +1,20 @@
++# Makefile fragment for AmigaOS/PPC target.
++
++# Extra object file linked to the cc1* executables.
++amigaos.o: $(srcdir)/config/rs6000/amigaos.c $(CONFIG_H)
++	$(CXX) -c $(ALL_CXXFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) $< $(OUTPUT_OPTION)
++
++# We always have limits.h.
++LIMITS_H_TEST = true
++
++# Override defaults.
++# FIXME: This is only correct when building a native version natively.
++NATIVE_SYSTEM_HEADER_DIR=/gcc/include
++#OTHER_FIXINCLUDES_DIRS=${gcc_tooldir}/include
++
++# Build the libraries for both newlib and clib2
++# We do not build soft float flavours as none of the
++# libs support soft floats
++MULTILIB_OPTIONS = mcrt=newlib/mcrt=clib2
++MULTILIB_DIRNAMES = newlib clib2
++#MULTILIB_REUSE = =mcrt=newlib
+diff --git a/gcc/cp/typeck.c b/gcc/cp/typeck.c
+index 6ebf6319efdfe1698e0d73abd0d6c0508c9fdbc2..cca35f69d41f8211cb8c488f8b7d23e4bcdeee5e 100644
+--- a/gcc/cp/typeck.c
++++ b/gcc/cp/typeck.c
+@@ -4017,12 +4017,28 @@ cp_build_function_call_vec (tree function, vec<tree, va_gc> **params,
+ 
+       return error_mark_node;
+     }
+ 
+   /* fntype now gets the type of function pointed to.  */
+   fntype = TREE_TYPE (fntype);
++
++  if (lookup_attribute ("libcall", TYPE_ATTRIBUTES (fntype)) ||
++      lookup_attribute ("libcall2", TYPE_ATTRIBUTES (fntype)))
++  {
++	if (TREE_CODE (function) == COMPONENT_REF && lvalue_p (function))
++	{
++		/* Type of 0 operand of a component ref is always a dereferenced object but
++		 * we need to pass the address of this object */
++
++		/* FIXME: param_types? */
++		vec_safe_insert(*params,0,
++			build1(ADDR_EXPR, build_pointer_type (TREE_TYPE (TREE_OPERAND (function, 0))),
++				TREE_OPERAND (function, 0)));
++	}
++  }
++
+   parm_types = TYPE_ARG_TYPES (fntype);
+ 
+   if (params == NULL)
+     {
+       allocated = make_tree_vector ();
+       params = &allocated;
+diff --git a/gcc/doc/extend.texi b/gcc/doc/extend.texi
+index 9c7345959504a56eb397004bcc86e8c68f655fe9..5ccde910fc4c1b9320a09f55f69898120ea946a9 100644
+--- a/gcc/doc/extend.texi
++++ b/gcc/doc/extend.texi
+@@ -3919,12 +3919,164 @@ int foo ()
+ @}
+ @end smallexample
+ 
+ @noindent
+ results in warning on line 5.
+ 
++
++@item libcall
++@cindex AmigaOS specific function attributes
++On AmigaOS, the @code{libcall} attribute is used to declare function
++pointers in an AmigaOS @emph{Interface}.  When such a function pointer
++is invoked, a pointer to the Interface itself is passed as a hidden
++first argument, similar to @code{this} in C++.
++
++ISO/IEC 9899:1999 Edits for Libcall functions
++
++The following are a set of changes to ISO/IEC 9899:1999 (aka C99)
++that document the exact semantics of the language extension.
++
++@itemize @bullet
++@item
++@cite{6.5.2.2  Function calls}
++
++Change paragraph 3 to
++
++@quotation
++[...] denotes the called function.  The arguments to the function
++are specified by the implicit argument, if any, followed by the list
++of expressions.
++@end quotation
++
++Add new paragraph before paragraph 4
++
++@quotation
++If the expression that denotes the called function is a structure or union
++member expression as defined in (6.5.2.3) (or such an expression enclosed
++in any number of parentheses expressions), is an lvalue, and has a type
++that includes the attribute @code{libcall}, then the function call has an
++implicit argument.  In other cases there is no implicit argument.  If there
++is an implicit argument, then this will be the first argument to the function,
++and the list of expressions will follow it.  The type of the implicit
++argument is that of a pointer to the structure or union object of which the
++function expression designates a member.  The value of the implicit argument
++is the address of this structure or union object.
++@end quotation
++@end itemize
++
++@item linearvarargs
++@cindex AmigaOS specific function attributes
++On AmigaOS, the @code{linearvarargs} attribute causes all unprototyped
++arguments to a varargs function to be passed on the stack, and not in
++registers as the SVR4 ABI defines.  Please note that @code{libcall} also
++implies @code{linearvarargs}.
++
++@item baserel_restore
++@cindex AmigaOS specific function attributes
++On AmigaOS, when compiling with @option{-mbaserel} causes the compiler
++to create a call to @code{baserel_get_addr} function in the function prologue
++to set up register @code{r2}. The previous contents of register @code{r2}
++are restored in the function epilogue. See @option{-mbaserel} option for
++more details.
++
++@item check68kfuncptr
++@cindex AmigaOS specific function attributes
++On AmigaOS, when calling a function using a function pointer causes
++the compiler to emit additional code to allow for function pointers
++to m68k functions. This is currently available only in the C front end.
++
++The generated code will call @code{__amigaos4_check68k_check} function
++which expects one function pointer argument and returns an integer
++value. If the return value is non-zero, the function pointer will be
++used to perform the function call in the usual way, otherwise
++@code{__amigaos4_check68k_trampoline} function will be called to perform
++the call. The @code{__amigaos4_check68k_check} function should be provided
++by the user and will usually just return the result of
++@code{exec.library} @code{IsNative} call on its argument.
++
++The @code{__amigaos4_check68k_trampoline} function is a @code{linearvarargs}
++function and should also be provided by the user. It will receive at
++least two arguments: the number of arguments to the function pointer and
++the function pointer itself. Additionally, the arguments to the function
++pointer will follow on the stack, each having one zero longword in front
++of it with one final zero longword after all the arguments. This makes it
++possible to create tag pairs and a terminating @code{TAG_DONE} for a
++call to @code{EmulateTags} in @code{exec.library}. The return code of
++@code{__amigaos4_check68k_trampoline} function will be used as a return
++code of the function pointer call.
++
++The following example can be used for functions that have no more than
++13 arguments:
++
++@smallexample
++static const UWORD trampoline_code[][6] =
++@{
++    /* @r{JMP (A5)} */
++    @{0X4ED5, 0, 0, 0, 0, 0@},
++    /* @r{MOVEM.L D0, -(A7); JSR (A5); ADDQ.L #4,A7; RTS} */
++    @{0X48E7, 0X8000, 0X4E95, 0X588F, 0X4E75, 0@},
++    /* @r{MOVEM.L D0-D1, -(A7); JSR (A5); ADDQ.L #8, A7; RTS} */
++    @{0X48E7, 0XC000, 0X4E95, 0X508F, 0X4E75, 0@},
++    /* @r{MOVEM.L D0-D2, -(A7); JSR (A5); ADDA.W #0X000C, A7; RTS} */
++    @{0X48E7, 0XE000, 0X4E95, 0XDEFC, 0X000C, 0X4E75@},
++    /* @r{MOVEM.L D0-D3, -(A7); JSR (A5); ADDA.W #0X0010, A7; RTS} */
++    @{0X48E7, 0XF000, 0X4E95, 0XDEFC, 0X0010, 0X4E75@},
++    /* @r{MOVEM.L D0-D4, -(A7); JSR (A5); ADDA.W #0X0014, A7; RTS} */
++    @{0X48E7, 0XF800, 0X4E95, 0XDEFC, 0X0014, 0X4E75@},
++    /* @r{MOVEM.L D0-D5, -(A7); JSR (A5); ADDA.W #0X0018, A7; RTS} */
++    @{0X48E7, 0XFC00, 0X4E95, 0XDEFC, 0X0018, 0X4E75@},
++    /* @r{MOVEM.L D0-D6, -(A7); JSR (A5); ADDA.W #0X001C, A7; RTS} */
++    @{0X48E7, 0XFE00, 0X4E95, 0XDEFC, 0X001C, 0X4E75@},
++    /* @r{MOVEM.L D0-D7, -(A7); JSR (A5); ADDA.W #0X0020, A7; RTS} */
++    @{0X48E7, 0XFF00, 0X4E95, 0XDEFC, 0X0020, 0X4E75@},
++    /* @r{MOVEM.L D0-D7/A0, -(A7); JSR (A5); ADDA.W #0X0024, A7; RTS} */
++    @{0X48E7, 0XFF80, 0X4E95, 0XDEFC, 0X0024, 0X4E75@},
++    /* @r{MOVEM.L D0-D7/A0-A1, -(A7); JSR (A5); ADDA.W #0X0028, A7; RTS} */
++    @{0X48E7, 0XFFC0, 0X4E95, 0XDEFC, 0X0028, 0X4E75@},
++    /* @r{MOVEM.L D0-D7/A0-A2, -(A7); JSR (A5); ADDA.W #0X002C, A7; RTS} */
++    @{0X48E7, 0XFFE0, 0X4E95, 0XDEFC, 0X002C, 0X4E75@},
++    /* @r{MOVEM.L D0-D7/A0-A3, -(A7); JSR (A5); ADDA.W #0X0030, A7; RTS} */
++    @{0X48E7, 0XFFF0, 0X4E95, 0XDEFC, 0X0030, 0X4E75@},
++    /* @r{MOVEM.L D0-D7/A0-A3, -(A7); JSR (A5); ADDA.W #0X0034, A7; RTS} */
++    @{0X48E7, 0XFFF8, 0X4E95, 0XDEFC, 0X0034, 0X4E75@}
++@};
++
++int VARARGS68K __amigaos4_check68k_trampoline(int num_args,
++                                              int func,
++                                              ...)
++@{
++    int result, i;
++    va_list args;
++    long *stack;
++
++    va_startlinear(args, func);
++    stack = va_getlinearva(args, long *);
++
++    /* @r{Replace 0's with tag id's} */
++    for(i = 0; i < 8 && i < num_args; i++)
++        stack[i * 2] = ET_RegisterD0 + i;
++
++    while(i < num_args)
++    @{
++        stack[i * 2] = ET_RegisterA0 + i - 8;
++        i++;
++    @}
++
++    if (num_args < sizeof(trampoline_code)
++                   / sizeof(trampoline_code[0]))
++        result = IExec->EmulateTags(trampoline_code[num_args],
++                                    ET_SaveRegs, TRUE,
++                                    ET_RegisterA5, func,
++                                    TAG_MORE, stack);
++
++    va_end(args);
++
++    return(result);
++@}
++@end smallexample
++
+ @item weak
+ @cindex @code{weak} function attribute
+ The @code{weak} attribute causes a declaration of an external symbol
+ to be emitted as a weak symbol rather than a global.  This is primarily
+ useful in defining library functions that can be overridden in user code,
+ though it can also be used with non-function declarations.  The overriding
+@@ -7741,12 +7893,28 @@ For full documentation of the struct attributes please see the
+ documentation in @ref{x86 Variable Attributes}.
+ 
+ @cindex @code{altivec} variable attribute, PowerPC
+ For documentation of @code{altivec} attribute please see the
+ documentation in @ref{PowerPC Type Attributes}.
+ 
++@subsection AmigaOS PPC Variable Attributes
++
++One attribute is currently defined for AmigaOS PPC.
++
++@table @code
++@item force_no_baserel
++@cindex forcing a variable not to be addressed base relative
++
++This attribute forces access to a variable in code compiled with
++@option{-mbaserel} option not to be base relative. If necessary, the
++access should be protected with some sort of arbitration. See
++documentation on @option{-mbaserel} option for more details about this
++attribute.
++
++@end table
++
+ @node RL78 Variable Attributes
+ @subsection RL78 Variable Attributes
+ 
+ @cindex @code{saddr} variable attribute, RL78
+ The RL78 back end supports the @code{saddr} variable attribute.  This
+ specifies placement of the corresponding variable in the SADDR area,
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index eabeec944e7d3db03a58ad43369805e3aa2654a0..690266503976613fe712b16f03c39a1bb4508383 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -1386,12 +1386,41 @@ See RS/6000 and PowerPC Options.
+ -mauto-litpools  -mno-auto-litpools @gol
+ -mtarget-align  -mno-target-align @gol
+ -mlongcalls  -mno-longcalls}
+ 
+ @emph{zSeries Options}
+ See S/390 and zSeries Options.
++
++@emph{AmigaOS PPC options}
++@gccoptlist{-mcrt=@var{crt}  -mbaserel  -mno-baserel @gol
++-mcheck68kfuncptr}
++
++@item Code Generation Options
++@xref{Code Gen Options,,Options for Code Generation Conventions}.
++@gccoptlist{-fcall-saved-@var{reg}  -fcall-used-@var{reg} @gol
++-ffixed-@var{reg}  -fexceptions @gol
++-fnon-call-exceptions  -fdelete-dead-exceptions  -funwind-tables @gol
++-fasynchronous-unwind-tables @gol
++-fno-gnu-unique @gol
++-finhibit-size-directive  -finstrument-functions @gol
++-finstrument-functions-exclude-function-list=@var{sym},@var{sym},@dots{} @gol
++-finstrument-functions-exclude-file-list=@var{file},@var{file},@dots{} @gol
++-fno-common  -fno-ident @gol
++-fpcc-struct-return  -fpic  -fPIC -fpie -fPIE @gol
++-fno-jump-tables @gol
++-frecord-gcc-switches @gol
++-freg-struct-return  -fshort-enums @gol
++-fshort-double  -fshort-wchar @gol
++-fverbose-asm  -fpack-struct[=@var{n}]  -fstack-check @gol
++-fstack-limit-register=@var{reg}  -fstack-limit-symbol=@var{sym} @gol
++-fno-stack-limit -fsplit-stack @gol
++-fleading-underscore  -ftls-model=@var{model} @gol
++-fstack-reuse=@var{reuse_level} @gol
++-ftrapv  -fwrapv  -fbounds-check @gol
++-fvisibility=@r{[}default@r{|}internal@r{|}hidden@r{|}protected@r{]} @gol
++-fstrict-volatile-bitfields -fsync-libcalls}
+ @end table
+ 
+ 
+ @node Overall Options
+ @section Options Controlling the Kind of Output
+ 
+@@ -16756,12 +16785,13 @@ platform.
+ * VMS Options::
+ * VxWorks Options::
+ * x86 Options::
+ * x86 Windows Options::
+ * Xstormy16 Options::
+ * Xtensa Options::
++* AmigaOS PPC options::
+ * zSeries Options::
+ @end menu
+ 
+ @node AArch64 Options
+ @subsection AArch64 Options
+ @cindex AArch64 Options
+@@ -30404,12 +30434,143 @@ These options are defined for Xstormy16:
+ @table @gcctabopt
+ @item -msim
+ @opindex msim
+ Choose startup files and linker script suitable for the simulator.
+ @end table
+ 
++@node AmigaOS PPC options
++@subsection AmigaOS PPC options
++@cindex AmigaOS PPC options
++
++@table @gcctabopt
++
++@item -mcrt=@var{crt}
++@opindex mcrt
++
++Select the C runtime library to use. The same option must be used for
++both compiling and linking. Some of the possible values are @samp{default},
++@samp{clib2}, @samp{clib2-ts} (thread-safe variant of clib2) and @samp{newlib}.
++Each option makes available an appropriate define, for example
++@code{__CLIB2__}, @code{__NEWLIB__} etc. Additionally, @samp{clib2-ts} option
++provides the @code{__THREAD_SAFE} define.
++
++@item -mbaserel
++@opindex mbaserel
++
++Generate code to access all non-constant data relative to register @code{r2}.
++The executable should also be linked with @option{-mbaserel} option.
++
++This option is useful for creating shared libraries for which all
++openers have a separate copy of non-constant data but share the constant
++data. A better way to do this is by using interface cloning, but
++sometimes this is not possible, for example when some package is being
++ported in form of shared library.
++
++This option can also be used to create residentable programs with
++special startup code.
++
++The startup code or the appropriate interface setup method should use
++@code{CopyDataSegment} function from @samp{elf.library} v51.8 or later to
++copy and relocate the data segment that each instance should have a copy of
++and then set up @code{r2} (and/or @code{EnvironmentVector} interface field
++for libraries) appropriately:
++
++@smallexample
++Elf32_Handle handle = NULL;
++BPTR seg = IDOS->GetProcSegList(NULL);
++
++if (seg)
++@{
++    IDOS->GetSegListInfoTags(seg, GSLI_ElfHandle, &handle, TAG_DONE);
++
++    if (handle
++        && (handle = IElf->OpenElfTags(OET_ElfHandle, handle, TAG_DONE)))
++    @{
++        uint32 offset;
++        uint8 *data = IElf->CopyDataSegment(handle, &offset);
++
++        if (data)
++        @{
++            /* @r{Store @code{data} somewhere since it will be required}
++             * @r{in the cleanup stage}
++             */
++
++            CurrentInterface->Data.EnvironmentVector = data + offset;
++
++            /* @r{Optionally, set r2 to the same value as @code{EnvironmentVector}} if the
++             * @r{current method will call functions access instance local data. This is}
++             * @r{not necessary if the current method will only call interface methods}
++             * @r{which have @code{baserel_restore} attribute (see below).}
++             */
++
++            IElf->CloseElfTags(handle, CET_ReClose, TRUE, TAG_DONE);
++        @}
++        else
++            /* Data was not allocated */;
++    @}
++    else
++        /* ELF handle couldn't be obtained */;
++@}
++else
++    /* Process segment list was not retrieved */;
++
++@end smallexample
++
++The copied data segment should be freed in the cleanup stage using the
++same procedure to obtain the ELF handle and then @code{FreeDataSegmentCopy}
++should be called with the value @code{CopyDataSegment} returned (@emph{not}
++with the value that @code{EnvironmentVector} contains).
++
++Interface methods should include @code{baserel_restore} attribute in their
++definition. When this attribute is present, the compiler will call
++@code{__baserel_get_addr} function in the function prologue. This function
++should set up @code{r2} register and must not modify any other registers
++except @code{r2}. Since it will be called in function prologue, register
++@code{r3} will contain the the first argument of the function. For
++interfaces, this is the interface pointer through which
++@code{EnvironmentVector} field can be accessed. Previous contents
++of register @code{r2} will be restored in the function epilogue.
++
++One possible implementation of @code{__baserel_get_addr} function:
++
++@smallexample
++asm("\n\
++     text\n\
++     globl __baserel_get_addr\n\
++
++__baserel_get_addr:\n\
++     lwz 2, 48(3) /* @r{Fetch EnvironmentVector from struct Interface *} */\n\
++     blr\n\
++");
++@end smallexample
++
++If some non-constant variable needs to be shared by all instances, it
++can be declared with @code{force_no_baserel} attribute. The variable will
++still be present in instance local data area that was created on
++startup, but the compiler will generate code to access it in the
++original data section for all instances. Because of that, the
++declaration of the variable with this attribute must be available to the
++compiler whenever the variable is accessed, otherwise it will generate
++code to access instance local copy of that variable which is probably
++not the desired behaviour. Additionally, some sort of access arbitration
++is probably required.
++
++@item -mno-baserel
++@opindex mno-baserel
++
++Generate absolute data access. This is the default.
++
++@item -mcheck68kfuncptr
++@opindex mcheck68kfuncptr
++
++Causes each function call through a function pointer to be performed as
++if the function pointer was declared with the @samp{check68kfuncptr}
++function attribute. @xref{Function Attributes}.
++
++@end table
++
+ @node Xtensa Options
+ @subsection Xtensa Options
+ @cindex Xtensa Options
+ 
+ These options are supported for Xtensa targets:
+ 
+diff --git a/gcc/expr.c b/gcc/expr.c
+index 991b26f3341c3c73b9f184687176b7264f7a1c12..4bb87211c5ba39187ad334fd3f6ab578fed9b605 100644
+--- a/gcc/expr.c
++++ b/gcc/expr.c
+@@ -8527,13 +8527,12 @@ expand_expr_real_2 (sepops ops, rtx target, machine_mode tmode,
+   tree treeop0, treeop1, treeop2;
+ #define REDUCE_BIT_FIELD(expr)	(reduce_bit_field			  \
+ 				 ? reduce_to_bit_field_precision ((expr), \
+ 								  target, \
+ 								  type)	  \
+ 				 : (expr))
+-
+   type = ops->type;
+   mode = TYPE_MODE (type);
+   unsignedp = TYPE_UNSIGNED (type);
+ 
+   treeop0 = ops->op0;
+   treeop1 = ops->op1;
+diff --git a/gcc/gcc.c b/gcc/gcc.c
+index 9f790db0daf407f3b095cbb8ade31e762b87ef3c..97fd5f63a650ff9d5772e4464bbe66a9962c561e 100644
+--- a/gcc/gcc.c
++++ b/gcc/gcc.c
+@@ -3071,13 +3071,13 @@ execute (void)
+ 	commands[0].argv[0] = string;
+     }
+ 
+   for (n_commands = 1, i = 0; argbuf.iterate (i, &arg); i++)
+     if (arg && strcmp (arg, "|") == 0)
+       {				/* each command.  */
+-#if defined (__MSDOS__) || defined (OS2) || defined (VMS)
++#if defined (__MSDOS__) || defined (OS2) || defined (VMS) || defined(AMIGA)
+ 	fatal_error (input_location, "%<-pipe%> not supported");
+ #endif
+ 	argbuf[i] = 0; /* Termination of command args.  */
+ 	commands[n_commands].prog = argbuf[i + 1];
+ 	commands[n_commands].argv
+ 	  = &(argbuf.address ())[i + 1];
+@@ -4696,13 +4696,12 @@ process_command (unsigned int decoded_options_count,
+       add_prefix (&exec_prefixes, standard_exec_prefix, "BINUTILS",
+ 		  PREFIX_PRIORITY_LAST, 2, 0);
+ #endif
+       add_prefix (&startfile_prefixes, standard_exec_prefix, "BINUTILS",
+ 		  PREFIX_PRIORITY_LAST, 1, 0);
+     }
+-
+   gcc_assert (!IS_ABSOLUTE_PATH (tooldir_base_prefix));
+   tooldir_prefix2 = concat (tooldir_base_prefix, spec_machine,
+ 			    dir_separator_str, NULL);
+ 
+   /* Look for tools relative to the location from which the driver is
+      running, or, if that is not available, the configured prefix.  */
+@@ -6787,12 +6786,17 @@ give_switch (int switchnum, int omit_first_word)
+ 	      if (dot)
+ 		(CONST_CAST (char *, arg))[length] = '.';
+ 	      do_spec_1 (suffix_subst, 1, NULL);
+ 	    }
+ 	  else
+ 	    do_spec_1 (arg, 1, NULL);
++
++#ifdef __amigaos__
++	  /* Don't lose args which happen to be the empty string */
++	  arg_going = 1;
++#endif /* __amigaos__ */
+ 	}
+     }
+ 
+   do_spec_1 (" ", 0, NULL);
+   switches[switchnum].validated = true;
+ }
+@@ -7180,13 +7184,15 @@ is_directory (const char *path1, bool linker)
+   len1 = strlen (path1);
+   path = (char *) alloca (3 + len1);
+   memcpy (path, path1, len1);
+   cp = path + len1;
+   if (!IS_DIR_SEPARATOR (cp[-1]))
+     *cp++ = DIR_SEPARATOR;
++#ifndef __amigaos__
+   *cp++ = '.';
++#endif
+   *cp = '\0';
+ 
+   /* Exclude directories that the linker is known to search.  */
+   if (linker
+       && IS_DIR_SEPARATOR (path[0])
+       && ((cp - path == 6
+@@ -7721,22 +7727,24 @@ driver::set_up_specs () const
+ 			      ? gcc_exec_prefix : standard_exec_prefix,
+ 			      machine_suffix,
+ 			      standard_startfile_prefix, NULL),
+ 		      NULL, PREFIX_PRIORITY_LAST, 0, 1);
+ 	}
+ 
++#ifndef __amigaos__
+       /* Sysrooted prefixes are relocated because target_system_root is
+ 	 also relocated by gcc_exec_prefix.  */
+       if (*standard_startfile_prefix_1)
+  	add_sysrooted_prefix (&startfile_prefixes,
+ 			      standard_startfile_prefix_1, "BINUTILS",
+ 			      PREFIX_PRIORITY_LAST, 0, 1);
+       if (*standard_startfile_prefix_2)
+ 	add_sysrooted_prefix (&startfile_prefixes,
+ 			      standard_startfile_prefix_2, "BINUTILS",
+ 			      PREFIX_PRIORITY_LAST, 0, 1);
++#endif
+     }
+ 
+   /* Process any user specified specs in the order given on the command
+      line.  */
+   for (struct user_specs *uptr = user_specs_head; uptr; uptr = uptr->next)
+     {
+diff --git a/gcc/prefix.c b/gcc/prefix.c
+index 1a403e535bdd948d1654798c2fc09f38537c0d57..b2ff668ad2beb6d5a45db171fe09c2b0e1fe68e0 100644
+--- a/gcc/prefix.c
++++ b/gcc/prefix.c
+@@ -326,13 +326,13 @@ update_path (const char *path, const char *key)
+ 
+ #ifdef UPDATE_PATH_HOST_CANONICALIZE
+   /* Perform host dependent canonicalization when needed.  */
+   UPDATE_PATH_HOST_CANONICALIZE (result);
+ #endif
+ 
+-#ifdef DIR_SEPARATOR_2
++#if defined (DIR_SEPARATOR_2) && !defined (__amigaos__)
+   /* Convert DIR_SEPARATOR_2 to DIR_SEPARATOR.  */
+   if (DIR_SEPARATOR_2 != DIR_SEPARATOR)
+     tr (result, DIR_SEPARATOR_2, DIR_SEPARATOR);
+ #endif
+ 
+ #if defined (DIR_SEPARATOR) && !defined (DIR_SEPARATOR_2)
+diff --git a/intl/dcigettext.c b/intl/dcigettext.c
+index a8d4a14d273b153b117b507ec76356635ccd876e..a9cc1066050e10b539149027a5c159f21accfaca 100644
+--- a/intl/dcigettext.c
++++ b/intl/dcigettext.c
+@@ -145,13 +145,15 @@ extern int errno;
+ # define tfind __tfind
+ #else
+ # if !defined HAVE_GETCWD
+ char *getwd ();
+ #  define getcwd(buf, max) getwd (buf)
+ # else
++#   if !defined getcwd
+ char *getcwd ();
++#   endif
+ # endif
+ # ifndef HAVE_STPCPY
+ static char *stpcpy PARAMS ((char *dest, const char *src));
+ # endif
+ # ifndef HAVE_MEMPCPY
+ static void *mempcpy PARAMS ((void *dest, const void *src, size_t n));
+diff --git a/libcpp/line-map.c b/libcpp/line-map.c
+index 8a390d0857be2b43ba94b527079b3394a0bdffe1..598a2bd0e135c5d6e0ee61882eebfd3c410026b0 100644
+--- a/libcpp/line-map.c
++++ b/libcpp/line-map.c
+@@ -965,12 +965,15 @@ linemap_ordinary_map_lookup (const line_maps *set, location_t line)
+ 
+   mn = LINEMAPS_ORDINARY_CACHE (set);
+   mx = LINEMAPS_ORDINARY_USED (set);
+ 
+   cached = LINEMAPS_ORDINARY_MAP_AT (set, mn);
+   /* We should get a segfault if no line_maps have been added yet.  */
++#ifdef __amigaos4__
++  linemap_assert(cached != 0);
++#endif
+   if (line >= MAP_START_LOCATION (cached))
+     {
+       if (mn + 1 == mx || line < MAP_START_LOCATION (&cached[1]))
+ 	return cached;
+     }
+   else
+diff --git a/libgcc/config.host b/libgcc/config.host
+index c529cc40f0c8d536524e2539483e6b148ded4413..560ee514a8758f04afddbd0e6d33609704f5898b 100644
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -1135,12 +1135,15 @@ or1k-*-*)
+ 	tmake_file="$tmake_file or1k/t-or1k"
+ 	tmake_file="$tmake_file t-softfp-sfdf t-softfp"
+ 	;;
+ pdp11-*-*)
+ 	tmake_file="pdp11/t-pdp11 t-fdpbit"
+ 	;;
++powerpc-*-amigaos*)
++	tmake_file="${tmake_file} rs6000/t-savresfgpr rs6000/t-amigaos"
++	;;
+ powerpc-*-darwin*)
+ 	case ${host} in
+ 	*-*-darwin9* | *-*-darwin[12][0-9]*)
+ 	  # libSystem contains unwind information for signal frames since
+ 	  # Darwin 9.
+ 	  ;;
+diff --git a/libgcc/config/rs6000/t-amigaos b/libgcc/config/rs6000/t-amigaos
+new file mode 100644
+index 0000000000000000000000000000000000000000..da1e303eed7e60df883971a610e8904db0df3e23
+--- /dev/null
++++ b/libgcc/config/rs6000/t-amigaos
+@@ -0,0 +1,45 @@
++# We need to enable the altivec in the assembler as
++# crtsavevr.S needs it. Not sure how this is handled
++# on other platforms or if this is a limitiation
++# of our binutils.
++HOST_LIBGCC2_CFLAGS += -Wa,-maltivec
++
++# The shared library needs to be compiled with -fPIC
++
++gcc_s_compile += -fPIC
++
++
++# We want fine grained libraries, so use the new code to build the
++# floating point emulation libraries.
++FPBIT = fp-bit.c
++DPBIT = dp-bit.c
++
++dp-bit.c: $(srcdir)/config/fp-bit.c
++	cat $(srcdir)/config/fp-bit.c > dp-bit.c
++
++fp-bit.c: $(srcdir)/config/fp-bit.c
++	echo '#define FLOAT' > fp-bit.c
++	cat $(srcdir)/config/fp-bit.c >> fp-bit.c
++
++# Build a shared libgcc library.
++# Note that this also builds clib2 shared lib which is not useable at
++# this writing
++#
++# We don't set LIBGCC2_CFLAGS += -fPIC here as this will also
++# produce a position independend static library. The -fPIC is
++# ensured in the special libgcc t-amigaos file.
++#
++SHLIB_DIR = @multilib_dir@
++SHLIB_SLIBDIR_QUAL = @shlib_slibdir_qual@
++SHLIB_OBJS = @shlib_objs@
++SHLIB_EXT = .so
++SHLIB_SONAME = @shlib_base_name@$(SHLIB_EXT)
++SHLIB_LINK = $(GCC_FOR_TARGET) -shared $(SHLIB_OBJS) -nodefaultlibs $(LIBGCC2_CFLAGS) \
++	-Wl,--soname=libgcc$(SHLIB_EXT) \
++	-o $(SHLIB_DIR)/$(SHLIB_SONAME) @multilib_flags@ $(SHLIB_LC)
++
++# Install the shared libgcc library, but ensure that the name is libgcc.so
++SHLIB_INSTALL = \
++	$(mkinstalldirs) $(DESTDIR)$(inst_libdir); \
++	$(INSTALL_DATA) $(SHLIB_DIR)/$(SHLIB_SONAME) \
++	  $(DESTDIR)$(inst_libdir)/libgcc$(SHLIB_EXT);
+diff --git a/libiberty/Makefile.in b/libiberty/Makefile.in
+index d6b302e02fd907ecf042ae309d5ed0b7922937f0..a7d9c6fd8b9780d2cceabd1d8cdd84a29bccf93f 100644
+--- a/libiberty/Makefile.in
++++ b/libiberty/Makefile.in
+@@ -140,12 +140,13 @@ CFILES = alloca.c argv.c asprintf.c atexit.c				\
+ 	make-temp-file.c md5.c memchr.c memcmp.c memcpy.c memmem.c	\
+ 	 memmove.c mempcpy.c memset.c mkstemps.c			\
+ 	objalloc.c obstack.c						\
+ 	partition.c pexecute.c						\
+ 	 pex-common.c pex-djgpp.c pex-msdos.c pex-one.c			\
+ 	 pex-unix.c pex-win32.c						\
++	 pex-amigaos.c		\
+          physmem.c putenv.c						\
+ 	random.c regex.c rename.c rindex.c				\
+ 	rust-demangle.c							\
+ 	safe-ctype.c setenv.c setproctitle.c sha1.c sigsetmask.c        \
+ 	 simple-object.c simple-object-coff.c simple-object-elf.c	\
+ 	 simple-object-mach-o.c simple-object-xcoff.c			\
+@@ -210,12 +211,13 @@ CONFIGURED_OFILES = ./asprintf.$(objext) ./atexit.$(objext)		\
+ 	./getcwd.$(objext) ./getpagesize.$(objext)			\
+ 	 ./gettimeofday.$(objext)					\
+ 	./index.$(objext) ./insque.$(objext)				\
+ 	./memchr.$(objext) ./memcmp.$(objext) ./memcpy.$(objext) 	\
+ 	./memmem.$(objext) ./memmove.$(objext)				\
+ 	 ./mempcpy.$(objext) ./memset.$(objext) ./mkstemps.$(objext)	\
++	./pex-amigaos.$(objext)						\
+ 	./pex-djgpp.$(objext) ./pex-msdos.$(objext)			\
+ 	 ./pex-unix.$(objext) ./pex-win32.$(objext)			\
+ 	 ./putenv.$(objext)						\
+ 	./random.$(objext) ./rename.$(objext) ./rindex.$(objext)	\
+ 	./setenv.$(objext) 						\
+ 	 ./setproctitle.$(objext)					\
+@@ -1135,12 +1137,19 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/pex-win32.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/pex-win32.c $(OUTPUT_OPTION)
+ 
++./pex-amigaos.$(objext): $(srcdir)/pex-amigaos.c config.h $(INCDIR)/ansidecl.h \
++	$(INCDIR)/libiberty.h $(srcdir)/pex-common.h
++	if [ x"$(PICFLAG)" != x ]; then \
++	  $(COMPILE.c) $(PICFLAG) $(srcdir)/pex-amigaos.c -o pic/$@; \
++	else true; fi
++	$(COMPILE.c) $(srcdir)/pex-amigaos.c $(OUTPUT_OPTION)
++
+ ./pexecute.$(objext): $(srcdir)/pexecute.c config.h $(INCDIR)/ansidecl.h \
+ 	$(INCDIR)/libiberty.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/pexecute.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+diff --git a/libiberty/basename.c b/libiberty/basename.c
+index 0f2c069f0ccf5a7d91e4913548e068c247e12efb..6ba5c4aa4f814fbc28f03127d22e91253c980c1b 100644
+--- a/libiberty/basename.c
++++ b/libiberty/basename.c
+@@ -15,32 +15,13 @@ Behavior is undefined if the pathname ends in a directory separator.
+ #ifdef HAVE_CONFIG_H
+ #include "config.h"
+ #endif
+ #include "ansidecl.h"
+ #include "libiberty.h"
+ #include "safe-ctype.h"
+-
+-#ifndef DIR_SEPARATOR
+-#define DIR_SEPARATOR '/'
+-#endif
+-
+-#if defined (_WIN32) || defined (__MSDOS__) || defined (__DJGPP__) || \
+-  defined (__OS2__)
+-#define HAVE_DOS_BASED_FILE_SYSTEM
+-#ifndef DIR_SEPARATOR_2 
+-#define DIR_SEPARATOR_2 '\\'
+-#endif
+-#endif
+-
+-/* Define IS_DIR_SEPARATOR.  */
+-#ifndef DIR_SEPARATOR_2
+-# define IS_DIR_SEPARATOR(ch) ((ch) == DIR_SEPARATOR)
+-#else /* DIR_SEPARATOR_2 */
+-# define IS_DIR_SEPARATOR(ch) \
+-	(((ch) == DIR_SEPARATOR) || ((ch) == DIR_SEPARATOR_2))
+-#endif /* DIR_SEPARATOR_2 */
++#include "filenames.h"
+ 
+ char *
+ basename (const char *name)
+ {
+   const char *base;
+ 
+diff --git a/libiberty/configure b/libiberty/configure
+index 3f82c5bb865cb09edd605138a8e7bf98c32f3f45..7cbaca011bbc042bd035e9f3969c1b155b802afd 100755
+--- a/libiberty/configure
++++ b/libiberty/configure
+@@ -7317,12 +7317,13 @@ fi
+ 
+ # Figure out which version of pexecute to use.
+ case "${host}" in
+      *-*-mingw* | *-*-winnt*)	pexecute=pex-win32  ;;
+      *-*-msdosdjgpp*)		pexecute=pex-djgpp  ;;
+      *-*-msdos*)		pexecute=pex-msdos  ;;
++     *-*-amigaos*)		pexecute=pex-amigaos;;
+      *)				pexecute=pex-unix   ;;
+ esac
+ 
+ 
+ 
+ 
+diff --git a/libiberty/configure.ac b/libiberty/configure.ac
+index 4e2599c14a89bafcb8c7e523b9ce5b3d60b8c0f6..106983ac087aa78ecc9b9e3f38514eacdb53b8f1 100644
+--- a/libiberty/configure.ac
++++ b/libiberty/configure.ac
+@@ -697,12 +697,13 @@ fi
+ 
+ # Figure out which version of pexecute to use.
+ case "${host}" in
+      *-*-mingw* | *-*-winnt*)	pexecute=pex-win32  ;;
+      *-*-msdosdjgpp*)		pexecute=pex-djgpp  ;;
+      *-*-msdos*)		pexecute=pex-msdos  ;;
++     *-*-amigaos*)		pexecute=pex-amigaos ;;
+      *)				pexecute=pex-unix   ;;
+ esac
+ AC_SUBST(pexecute)
+ 
+ libiberty_AC_FUNC_STRNCMP
+ 
+diff --git a/libiberty/lrealpath.c b/libiberty/lrealpath.c
+index d6694c40349916b706d5ba05123d3a9059be3389..af9bd93c76c1c0e2c00059b5ab9465318f2f21ab 100644
+--- a/libiberty/lrealpath.c
++++ b/libiberty/lrealpath.c
+@@ -46,12 +46,13 @@ components will be simplified.  The returned value will be allocated using
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+ #ifdef HAVE_STRING_H
+ #include <string.h>
+ #endif
++#include <stdio.h> /* for MAXPATHLEN */
+ 
+ /* On GNU libc systems the declaration is only visible with _GNU_SOURCE.  */
+ #if defined(HAVE_CANONICALIZE_FILE_NAME) \
+     && defined(NEED_DECLARATION_CANONICALIZE_FILE_NAME)
+ extern char *canonicalize_file_name (const char *);
+ #endif
+@@ -106,13 +107,13 @@ lrealpath (const char *filename)
+      compile time buffer size and no alternative function.  Query the
+      OS, using pathconf(), for the buffer limit.  Care is needed
+      though, some systems do not limit PATH_MAX (return -1 for
+      pathconf()) making it impossible to pass a correctly sized buffer
+      to realpath() (it could always overflow).  On those systems, we
+      skip this.  */
+-#if defined (HAVE_REALPATH) && defined (HAVE_UNISTD_H)
++#if !defined (REALPATH_LIMIT) && defined (HAVE_REALPATH) && defined (HAVE_UNISTD_H)
+   {
+     /* Find out the max path size.  */
+     long path_max = pathconf ("/", _PC_PATH_MAX);
+     if (path_max > 0)
+       {
+ 	/* PATH_MAX is bounded.  */
+diff --git a/libiberty/make-relative-prefix.c b/libiberty/make-relative-prefix.c
+index e3f9f920df4a2b4a8be00e88727d74a42ed46eea..ea9e4a49fa3a3e1be2b04164eee20c9671d379c3 100644
+--- a/libiberty/make-relative-prefix.c
++++ b/libiberty/make-relative-prefix.c
+@@ -62,44 +62,43 @@ relative prefix can be found, return @code{NULL}.
+ #endif
+ 
+ #include <string.h>
+ 
+ #include "ansidecl.h"
+ #include "libiberty.h"
++#include "filenames.h"
+ 
+ #ifndef R_OK
+ #define R_OK 4
+ #define W_OK 2
+ #define X_OK 1
+ #endif
+ 
+-#ifndef DIR_SEPARATOR
+-#  define DIR_SEPARATOR '/'
+-#endif
+-
+ #if defined (_WIN32) || defined (__MSDOS__) \
+     || defined (__DJGPP__) || defined (__OS2__)
+-#  define HAVE_DOS_BASED_FILE_SYSTEM
+-#  define HAVE_HOST_EXECUTABLE_SUFFIX
+-#  define HOST_EXECUTABLE_SUFFIX ".exe"
+-#  ifndef DIR_SEPARATOR_2 
+-#    define DIR_SEPARATOR_2 '\\'
+-#  endif
+-#  define PATH_SEPARATOR ';'
+-#else
+-#  define PATH_SEPARATOR ':'
++# define HAVE_HOST_EXECUTABLE_SUFFIX
++# define HOST_EXECUTABLE_SUFFIX ".exe"
++# define PATH_SEPARATOR ';'
++#endif
++
++#ifdef __amigaos__
++# define PATH_SEPARATOR ':'
++# define DIR_UP ".."
+ #endif
+ 
+-#ifndef DIR_SEPARATOR_2
+-#  define IS_DIR_SEPARATOR(ch) ((ch) == DIR_SEPARATOR)
+-#else
+-#  define IS_DIR_SEPARATOR(ch) \
+-	(((ch) == DIR_SEPARATOR) || ((ch) == DIR_SEPARATOR_2))
++#ifndef PATH_SEPARATOR
++# define PATH_SEPARATOR ':'
+ #endif
+ 
+-#define DIR_UP ".."
++#ifndef DIR_UP
++# define DIR_UP ".."
++#endif
++
++#ifndef DIR_SEPARATOR
++# define DIR_SEPARATOR '/'
++#endif
+ 
+ static char *save_string (const char *, int);
+ static char **split_directories	(const char *, int *);
+ static void free_split_directories (char **);
+ 
+ static char *
+diff --git a/libiberty/make-temp-file.c b/libiberty/make-temp-file.c
+index cb08c27af6f4534be0116224946d036ecd5a8418..fe7a4a91278e058532ab5591ecf4d921f2e50d64 100644
+--- a/libiberty/make-temp-file.c
++++ b/libiberty/make-temp-file.c
+@@ -37,25 +37,26 @@ Boston, MA 02110-1301, USA.  */
+ #include <sys/file.h>   /* May get R_OK, etc. on some systems.  */
+ #endif
+ #if defined(_WIN32) && !defined(__CYGWIN__)
+ #include <windows.h>
+ #endif
+ 
++#ifndef DIR_SEPARATOR
++#define DIR_SEPARATOR '/'
++#endif
++
+ #ifndef R_OK
+ #define R_OK 4
+ #define W_OK 2
+ #define X_OK 1
+ #endif
+ 
+ #include "libiberty.h"
+-extern int mkstemps (char *, int);
++#include "filenames.h"
+ 
+-/* '/' works just fine on MS-DOS based systems.  */
+-#ifndef DIR_SEPARATOR
+-#define DIR_SEPARATOR '/'
+-#endif
++extern int mkstemps (char *, int);
+ 
+ /* Name of temporary file.
+    mktemp requires 6 trailing X's.  */
+ #define TEMP_FILE "XXXXXX"
+ #define TEMP_FILE_LEN (sizeof(TEMP_FILE) - 1)
+ 
+@@ -77,17 +78,19 @@ try_dir (const char *dir, const char *base)
+   if (dir != 0
+       && access (dir, R_OK | W_OK | X_OK) == 0)
+     return dir;
+   return 0;
+ }
+ 
++#ifndef __amigaos__
+ static const char tmp[] = { DIR_SEPARATOR, 't', 'm', 'p', 0 };
+ static const char usrtmp[] =
+ { DIR_SEPARATOR, 'u', 's', 'r', DIR_SEPARATOR, 't', 'm', 'p', 0 };
+ static const char vartmp[] =
+ { DIR_SEPARATOR, 'v', 'a', 'r', DIR_SEPARATOR, 't', 'm', 'p', 0 };
++#endif /* __amigaos__ */
+ 
+ #endif
+ 
+ static char *memoized_tmpdir;
+ 
+ /*
+@@ -126,27 +129,37 @@ choose_tmpdir (void)
+       if (strcmp (P_tmpdir, "\\") == 0)
+ 	base = try_dir ("\\.", base);
+       else
+ 	base = try_dir (P_tmpdir, base);
+ #endif
+ 
++#ifndef __amigaos__
+       /* Try /var/tmp, /usr/tmp, then /tmp.  */
+       base = try_dir (vartmp, base);
+       base = try_dir (usrtmp, base);
+       base = try_dir (tmp, base);
++#else
++      base = try_dir ("T:", base);
++#endif
+       
+       /* If all else fails, use the current directory!  */
+       if (base == 0)
+ 	base = ".";
+       /* Append DIR_SEPARATOR to the directory we've chosen
+ 	 and return it.  */
+       len = strlen (base);
+       tmpdir = XNEWVEC (char, len + 2);
+       strcpy (tmpdir, base);
+-      tmpdir[len] = DIR_SEPARATOR;
+-      tmpdir[len+1] = '\0';
++
++      /* Don't add DIR_SEPARATOR if base already ends with a dir separator,
++         it's unneeded and can cause ill effects on e.g. AmigaOS.  */
++      if (!IS_DIR_SEPARATOR(base[len-1]))
++        {
++          tmpdir[len] = DIR_SEPARATOR;
++          tmpdir[len+1] = '\0';
++        }
+       memoized_tmpdir = tmpdir;
+ #else /* defined(_WIN32) && !defined(__CYGWIN__) */
+       DWORD len;
+ 
+       /* Figure out how much space we need.  */
+       len = GetTempPath(0, NULL);
+diff --git a/libiberty/pex-amigaos.c b/libiberty/pex-amigaos.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..0c61a108764c8501f8a2e9552c7c07499f402b1a
+--- /dev/null
++++ b/libiberty/pex-amigaos.c
+@@ -0,0 +1,325 @@
++/* Utilities to execute a program in a subprocess (possibly linked by pipes
++   with other subprocesses), and wait for it.  Generic AMIGAOS specialization.
++   Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2005
++   Free Software Foundation, Inc.
++
++This file is part of the libiberty library.
++Libiberty is free software; you can redistribute it and/or
++modify it under the terms of the GNU Library General Public
++License as published by the Free Software Foundation; either
++version 2 of the License, or (at your option) any later version.
++
++Libiberty is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++Library General Public License for more details.
++
++You should have received a copy of the GNU Library General Public
++License along with libiberty; see the file COPYING.LIB.  If not,
++write to the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
++Boston, MA 02110-1301, USA.  */
++
++#include "pex-common.h"
++
++#include <stdio.h>
++#include <errno.h>
++#ifdef NEED_DECLARATION_ERRNO
++extern int errno;
++#endif
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
++#include <string.h>
++#include <fcntl.h>
++#include <unistd.h>
++#include <sys/stat.h>
++#include <ctype.h>
++
++/* Use ECHILD if available, otherwise use EINVAL.  */
++#ifdef ECHILD
++#define PWAIT_ERROR ECHILD
++#else
++#define PWAIT_ERROR EINVAL
++#endif
++
++#if !defined(FD_CLOEXEC)
++#define FD_CLOEXEC 1
++#endif
++
++static int pex_amiga_open_read (struct pex_obj *, const char *, int);
++static int pex_amiga_open_write (struct pex_obj *, const char *, int);
++static pid_t pex_amiga_exec_child (struct pex_obj *, int, const char *,
++				 char * const *, char * const *,
++				 int, int, int, int,
++				 const char **, int *);
++static int pex_amiga_close (struct pex_obj *, int);
++static int pex_amiga_wait (struct pex_obj *, long, int *, struct pex_time *,
++			   int, const char **, int *);
++static FILE *pex_amiga_fdopenr (struct pex_obj *, int, int);
++static FILE *pex_amiga_fdopenw (struct pex_obj *, int, int);
++
++/* The list of functions we pass to the common routines.  */
++
++const struct pex_funcs funcs =
++{
++  pex_amiga_open_read,
++  pex_amiga_open_write,
++  pex_amiga_exec_child,
++  pex_amiga_close,
++  pex_amiga_wait,
++  NULL, /* pipe */
++  pex_amiga_fdopenr,
++  pex_amiga_fdopenw,
++  NULL, /* cleanup */
++};
++
++/* Return a newly initialized pex_obj structure.  */
++
++struct pex_obj *
++pex_init (int flags, const char *pname, const char *tempbase)
++{
++  /* AMIGAOS does not support pipes.  */
++  flags &= ~ PEX_USE_PIPES;
++  return pex_init_common (flags, pname, tempbase, &funcs);
++}
++
++/* Open a file for reading.  */
++
++static int
++pex_amiga_open_read (struct pex_obj *obj ATTRIBUTE_UNUSED, const char *name,
++		    int binary ATTRIBUTE_UNUSED)
++{
++  return open (name, O_RDONLY);
++}
++
++/* Open a file for writing.  */
++
++static int
++pex_amiga_open_write (struct pex_obj *obj ATTRIBUTE_UNUSED, const char *name,
++		     int binary ATTRIBUTE_UNUSED)
++{
++  /* Note that we can't use O_EXCL here because gcc may have already
++     created the temporary file via make_temp_file.  */
++  return open (name, O_WRONLY | O_CREAT | O_TRUNC);
++}
++
++/* Close a file.  */
++
++static int
++pex_amiga_close (struct pex_obj *obj ATTRIBUTE_UNUSED, int fd)
++{
++  return close (fd);
++}
++
++/* Execute a child.  */
++
++const unsigned char __shell_escape_character = '\\';
++
++static pid_t
++pex_amiga_exec_child (struct pex_obj *obj, int flags ATTRIBUTE_UNUSED, const char *executable ATTRIBUTE_UNUSED,
++		     char * const * argv, char * const * env ATTRIBUTE_UNUSED,
++                     int in ATTRIBUTE_UNUSED, int out ATTRIBUTE_UNUSED, int errdes ATTRIBUTE_UNUSED,
++		     int toclose ATTRIBUTE_UNUSED, const char **errmsg, int *err)
++{
++  int rc;
++  char *scmd,*s;
++  int i,j,c,len,arglen;
++  int need_quote;
++  int already_have_quote;
++  int escaped;
++  int *statuses;
++
++  len = 0;
++
++  for(i = 0 ; argv[i] != NULL ; i++)
++  {
++    arglen = strlen(argv[i]);
++
++    len += 1 + arglen;
++
++    need_quote = already_have_quote = 0;
++
++    /* Check if this parameter is already surrounded by double quotes.
++       What counts is that the first character is a double quote. We
++       hope that the last character is an unescaped double quote, but
++       don't check for it. */
++    if(argv[i][0] == '\"')
++    {
++      already_have_quote = 1;
++    }
++    else
++    {
++      /* Check if there's a blank space in the argument. If so, we will
++         need to add double quote characters. */
++      for (j = 0 ; j < arglen ; j++)
++      {
++        c = argv[i][j];
++
++        if (isspace(c))
++        {
++          need_quote = 1;
++          break;
++        }
++      }
++
++      /* Make room for the double quote characters that we will have to add. */
++      if(need_quote)
++        len += 2;
++    }
++
++    /* Check if there are " or * characters in the quoted string which
++       may have to be escaped. */
++    if (need_quote || already_have_quote)
++    {
++      for (j = 0 ; j < arglen ; j++)
++      {
++        c = argv[i][j];
++
++        /* We just might have to add an escape character in front of these two. */
++        if (c == '\"' || c == '*')
++	        len++;
++      }
++    }
++  }
++
++  s = scmd = (char *) xmalloc (len+1);
++
++  for(i = 0 ; argv[i] != NULL ; i++)
++  {
++    arglen = strlen(argv[i]);
++
++    need_quote = already_have_quote = 0;
++
++    if (argv[i][0] == '\"')
++    {
++      already_have_quote = 1;
++    }
++    else
++    {
++      for (j = 0 ; j < arglen ; j++)
++      {
++        c = argv[i][j];
++
++        if (isspace(c))
++        {
++          need_quote = 1;
++          break;
++        }
++      }
++    }
++
++    if(s != scmd)
++      (*s++) = ' ';
++
++    if(need_quote)
++      (*s++) = '\"';
++
++    escaped = 0;
++
++    for(j = 0 ; j < arglen ; j++)
++    {
++      c = argv[i][j];
++
++      /* If this is a " or * and the parameter is quoted, try to
++         add an escape character in front of it. */
++      if((c == '\"' || c == '*') && (need_quote || already_have_quote))
++	    {
++        /* Careful, don't escape the first double
++           quote character by mistake. */
++        if(!already_have_quote || j > 0)
++        {
++          /* Don't add an escape character here if the previous character
++             already was an escape character. */
++          if(!escaped)
++            (*s++) = '*';
++	      }
++      }
++
++      (*s++) = c;
++
++      /* Remember if the last character read was an escape character. */
++      if (escaped)
++        escaped = 0;
++      else
++        escaped = (c == __shell_escape_character && c != '*');
++    }
++
++    if(need_quote)
++      (*s++) = '\"';
++  }
++
++  (*s) = '\0';
++
++  rc = system (scmd);
++
++  free (scmd);
++
++  if (rc == -1)
++  {
++    *err = errno;
++    *errmsg = install_error_msg;
++    return -1;
++  }
++
++  /* Save the exit status for later.  When we are called, obj->count
++     is the number of children which have executed before this
++     one.  */
++  statuses = (int *) obj->sysdep;
++  statuses = XRESIZEVEC (int, statuses, obj->count + 1);
++  statuses[obj->count] = (rc << 8); /* Tuck the status away for pwait */
++  obj->sysdep = (void *) statuses;
++
++  return obj->count;
++}
++
++/* Create a pipe.  */
++/*
++static int
++pex_amiga_pipe (struct pex_obj *obj ATTRIBUTE_UNUSED, int *p,
++	       int binary ATTRIBUTE_UNUSED)
++{
++  return pipe (p);
++}
++*/
++
++/* Get a FILE pointer to read from a file descriptor.  */
++
++static FILE *
++pex_amiga_fdopenr (struct pex_obj *obj ATTRIBUTE_UNUSED, int fd,
++		  int binary ATTRIBUTE_UNUSED)
++{
++  return fdopen (fd, "r");
++}
++
++/* Get a FILE pointer to write to a file descriptor.  */
++
++static FILE *
++pex_amiga_fdopenw (struct pex_obj *obj ATTRIBUTE_UNUSED, int fd,
++		  int binary ATTRIBUTE_UNUSED)
++{
++  if (fcntl (fd, F_SETFD, FD_CLOEXEC) < 0)
++    return NULL;
++  return fdopen (fd, "w");
++}
++
++
++/* Wait for a child process to complete.  Actually the child process
++   has already completed, and we just need to return the exit
++   status.  */
++
++static int
++pex_amiga_wait (struct pex_obj *obj, long pid, int *status,
++		struct pex_time *time, int done ATTRIBUTE_UNUSED,
++		const char **errmsg ATTRIBUTE_UNUSED,
++		int *err ATTRIBUTE_UNUSED)
++{
++  int *statuses;
++
++  if (time != NULL)
++    memset (time, 0, sizeof (struct pex_time));
++
++  statuses = (int *) obj->sysdep;
++  *status = statuses[pid];
++
++  return 0;
++}
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 766a0a8d504182f090e2932a86da5ac5b4b24a97..449918a6297cc0ba519165d377667bb5c19e8305 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -73485,12 +73485,171 @@ _ACEOF
+ 
+   fi
+ 
+ 
+ 
+     ;;
++  *-amigaos*)
++    for ac_header in nan.h ieeefp.h endian.h sys/isa_defs.h \
++      machine/endian.h machine/param.h sys/machine.h sys/types.h \
++      fp.h locale.h float.h inttypes.h
++do :
++  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
++ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
++eval as_val=\$$as_ac_Header
++   if test "x$as_val" = x""yes; then :
++  cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
++_ACEOF
++
++fi
++
++done
++
++    SECTION_FLAGS='-ffunction-sections -fdata-sections'
++
++
++  # If we're not using GNU ld, then there's no point in even trying these
++  # tests.  Check for that first.  We should have already tested for gld
++  # by now (in libtool), but require it now just to be safe...
++  test -z "$SECTION_LDFLAGS" && SECTION_LDFLAGS=''
++  test -z "$OPT_LDFLAGS" && OPT_LDFLAGS=''
++
++
++
++  # The name set by libtool depends on the version of libtool.  Shame on us
++  # for depending on an impl detail, but c'est la vie.  Older versions used
++  # ac_cv_prog_gnu_ld, but now it's lt_cv_prog_gnu_ld, and is copied back on
++  # top of with_gnu_ld (which is also set by --with-gnu-ld, so that actually
++  # makes sense).  We'll test with_gnu_ld everywhere else, so if that isn't
++  # set (hence we're using an older libtool), then set it.
++  if test x${with_gnu_ld+set} != xset; then
++    if test x${ac_cv_prog_gnu_ld+set} != xset; then
++      # We got through "ac_require(ac_prog_ld)" and still not set?  Huh?
++      with_gnu_ld=no
++    else
++      with_gnu_ld=$ac_cv_prog_gnu_ld
++    fi
++  fi
++
++  # Start by getting the version number.  I think the libtool test already
++  # does some of this, but throws away the result.
++  glibcxx_ld_is_gold=no
++  if test x"$with_gnu_ld" = x"yes"; then
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ld version" >&5
++$as_echo_n "checking for ld version... " >&6; }
++
++    if $LD --version 2>/dev/null | grep 'GNU gold' >/dev/null 2>&1; then
++      glibcxx_ld_is_gold=yes
++    fi
++    ldver=`$LD --version 2>/dev/null |
++	   sed -e 's/GNU gold /GNU ld /;s/GNU ld version /GNU ld /;s/GNU ld ([^)]*) /GNU ld /;s/GNU ld \([0-9.][0-9.]*\).*/\1/; q'`
++
++    glibcxx_gnu_ld_version=`echo $ldver | \
++	   $AWK -F. '{ if (NF<3) $3=0; print ($1*100+$2)*100+$3 }'`
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $glibcxx_gnu_ld_version" >&5
++$as_echo "$glibcxx_gnu_ld_version" >&6; }
++  fi
++
++  # Set --gc-sections.
++  glibcxx_have_gc_sections=no
++  if test "$glibcxx_ld_is_gold" = "yes"; then
++    if $LD --help 2>/dev/null | grep gc-sections >/dev/null 2>&1; then
++      glibcxx_have_gc_sections=yes
++    fi
++  else
++    glibcxx_gcsections_min_ld=21602
++    if test x"$with_gnu_ld" = x"yes" &&
++	test $glibcxx_gnu_ld_version -gt $glibcxx_gcsections_min_ld ; then
++      glibcxx_have_gc_sections=yes
++    fi
++  fi
++  if test "$glibcxx_have_gc_sections" = "yes"; then
++    # Sufficiently young GNU ld it is!  Joy and bunny rabbits!
++    # NB: This flag only works reliably after 2.16.1. Configure tests
++    # for this are difficult, so hard wire a value that should work.
++
++    ac_test_CFLAGS="${CFLAGS+set}"
++    ac_save_CFLAGS="$CFLAGS"
++    CFLAGS='-Wl,--gc-sections'
++
++    # Check for -Wl,--gc-sections
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ld that supports -Wl,--gc-sections" >&5
++$as_echo_n "checking for ld that supports -Wl,--gc-sections... " >&6; }
++    if test x$gcc_no_link = xyes; then
++  as_fn_error "Link tests are not allowed after GCC_NO_EXECUTABLES." "$LINENO" 5
++fi
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++ int one(void) { return 1; }
++     int two(void) { return 2; }
++
++int
++main ()
++{
++ two();
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  ac_gcsections=yes
++else
++  ac_gcsections=no
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++    if test "$ac_gcsections" = "yes"; then
++      rm -f conftest.c
++      touch conftest.c
++      if $CC -c conftest.c; then
++	if $LD --gc-sections -o conftest conftest.o 2>&1 | \
++	   grep "Warning: gc-sections option ignored" > /dev/null; then
++	  ac_gcsections=no
++	fi
++      fi
++      rm -f conftest.c conftest.o conftest
++    fi
++    if test "$ac_gcsections" = "yes"; then
++      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
++    fi
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
++$as_echo "$ac_gcsections" >&6; }
++
++    if test "$ac_test_CFLAGS" = set; then
++      CFLAGS="$ac_save_CFLAGS"
++    else
++      # this is the suspicious part
++      CFLAGS=''
++    fi
++  fi
++
++  # Set -z,relro.
++  # Note this is only for shared objects.
++  ac_ld_relro=no
++  if test x"$with_gnu_ld" = x"yes"; then
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ld that supports -Wl,-z,relro" >&5
++$as_echo_n "checking for ld that supports -Wl,-z,relro... " >&6; }
++    cxx_z_relo=`$LD -v --help 2>/dev/null | grep "z relro"`
++    if test -n "$cxx_z_relo"; then
++      OPT_LDFLAGS="-Wl,-z,relro"
++      ac_ld_relro=yes
++    fi
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ld_relro" >&5
++$as_echo "$ac_ld_relro" >&6; }
++  fi
++
++  # Set linker optimization flags.
++  if test x"$with_gnu_ld" = x"yes"; then
++    OPT_LDFLAGS="-Wl,-O1 $OPT_LDFLAGS"
++  fi
++
++
++
++
++    ;;
+   *)
+     as_fn_error $? "No support for this host/target combination." "$LINENO" 5
+    ;;
+ esac
+ 
+   fi
+@@ -78615,12 +78774,13 @@ fi
+     TIMESTAMP='$TIMESTAMP'
+     RM='$RM'
+     ofile='$ofile'
+ 
+ 
+ 
++ac_aux_dir='$ac_aux_dir'
+ 
+ 
+ 
+ GCC="$GCC"
+ CC="$CC"
+ acx_cv_header_stdint="$acx_cv_header_stdint"
+diff --git a/libstdc++-v3/configure.ac b/libstdc++-v3/configure.ac
+index 07cf05b6856a06a101dddfef2928ce7c5f75a579..7032cae4bd23d2e2dac5429ab850f563b581d547 100644
+--- a/libstdc++-v3/configure.ac
++++ b/libstdc++-v3/configure.ac
+@@ -552,12 +552,15 @@ fi
+ GLIBCXX_EXPORT_INSTALL_INFO
+ 
+ # Export all the include and flag information to Makefiles.
+ GLIBCXX_EXPORT_INCLUDES
+ GLIBCXX_EXPORT_FLAGS
+ 
++# create libtool - libtool > 2.0:
++LT_OUTPUT
++
+ # Determine what GCC version number to use in filesystem paths.
+ GCC_BASE_VER
+ 
+ dnl In autoconf 2.5x, AC_OUTPUT is replaced by four AC_CONFIG_* macros,
+ dnl which can all be called multiple times as needed, plus one (different)
+ dnl AC_OUTPUT macro.  This one lists the files to be created:
+diff --git a/libstdc++-v3/crossconfig.m4 b/libstdc++-v3/crossconfig.m4
+index fe1828835368dd5c2c16a20cf4abc52739e52f30..c6f71bd425bd2c3ad09d95f001eb3884afdbc96f 100644
+--- a/libstdc++-v3/crossconfig.m4
++++ b/libstdc++-v3/crossconfig.m4
+@@ -302,12 +302,20 @@ dnl # switch to more elaborate tests.
+       frexpl ldexpl log10l logl modfl powl sinl sinhl sqrtl tanl tanhl])
+ dnl # sincosl is the only one missing here, compared with the *l
+ dnl # functions in the list guarded by
+ dnl # long_double_math_on_this_cpu in configure.ac, right after
+ dnl # the expansion of the present macro.
+     ;;
++  *-amigaos*)
++    AC_CHECK_HEADERS([nan.h ieeefp.h endian.h sys/isa_defs.h \
++      machine/endian.h machine/param.h sys/machine.h sys/types.h \
++      fp.h locale.h float.h inttypes.h])
++    SECTION_FLAGS='-ffunction-sections -fdata-sections'
++    AC_SUBST(SECTION_FLAGS)
++    GLIBCXX_CHECK_LINKER_FEATURES
++    ;;
+   *)
+     AC_MSG_ERROR([No support for this host/target combination.])
+    ;;
+ esac
+ ])
+ 
+diff --git a/libstdc++-v3/include/c_global/cstddef b/libstdc++-v3/include/c_global/cstddef
+index ce9cd3e9d3c9d70ac3873273c4651b32a060ae7c..ce8b2f4bbfaefc29036dca9a6586ab07dc46d340 100644
+--- a/libstdc++-v3/include/c_global/cstddef
++++ b/libstdc++-v3/include/c_global/cstddef
+@@ -51,14 +51,17 @@
+ 
+ extern "C++"
+ {
+ #if __cplusplus >= 201103L
+ namespace std
+ {
++/* Needed as clib2 on AmigaOS has no C11 support yet */
++#if __STDC_VERSION__ >= 201112L
+   // We handle size_t, ptrdiff_t, and nullptr_t in c++config.h.
+   using ::max_align_t;
++#endif
+ }
+ #endif // C++11
+ 
+ #if __cplusplus >= 201703L
+ namespace std
+ {
+diff --git a/libstdc++-v3/include/c_std/cstddef b/libstdc++-v3/include/c_std/cstddef
+index a7f0094969cc26636da59503127b504730fbb9ee..266b90b655f31e32873a432c617a589fb2bb3c71 100644
+--- a/libstdc++-v3/include/c_std/cstddef
++++ b/libstdc++-v3/include/c_std/cstddef
+@@ -44,12 +44,15 @@
+ #include <bits/c++config.h>
+ #include <stddef.h>
+ 
+ #if __cplusplus >= 201103L
+ namespace std
+ {
++/* Needed as clib2 on AmigaOS has no C11 support yet */
++#if __STDC_VERSION__ >= 201112L
+   // We handle size_t, ptrdiff_t, and nullptr_t in c++config.h.
+   using ::max_align_t;
++#endif
+ }
+ #endif
+ 
+ #endif // _GLIBCXX_CSTDDEF
+-- 
+2.11.0
+

--- a/gcc/10/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/10/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,0 +1,401 @@
+From 4d988078854a32b86d901305ff753fb332238605 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Fri, 14 Nov 2014 20:03:56 +0100
+Subject: [PATCH 02/33] Added new function attribute "lineartags" and pragma
+ "amigaos tagtype".
+
+Functions that have the lineartags attribute are assumed to be functions
+with tags, in which case type checking is now enabled. That is, the value
+that follow a specific tag is assumed to be a certain type. If this is
+not the case, the compiler will warn.
+
+The compiler can be taught about that types via the new pragma
+which is written before an "enum" or a "static const int" that defines
+the number of the tag.
+
+For instance:
+
+static const int WA_CustomScreen = WA_Dummy + 0x0D;
+
+ or
+
+enum {WA_CustomScreen = WA_Dummy + 0x0D};
+
+is possible now.
+
+It is not very robust yet wrt to catching misuses of the new feature.
+For instance, no check is done that the attribute is applied to varargs
+functions.
+---
+ gcc/c-family/c-pragma.c            |  10 +++
+ gcc/c/c-parser.c                   | 129 +++++++++++++++++++++++++++++++++++++
+ gcc/c/c-typeck.c                   |  26 +++++++-
+ gcc/config/rs6000/amigaos-protos.h |   1 +
+ gcc/config/rs6000/amigaos.c        |  33 ++++++++++
+ 5 files changed, 198 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/c-family/c-pragma.c b/gcc/c-family/c-pragma.c
+index 3c19a85e9f7d4577b4c14cd5abe9a4d6df00d12f..4b5c7539d911fd1c7a31a5cf3ddbcf21092ab2d8 100644
+--- a/gcc/c-family/c-pragma.c
++++ b/gcc/c-family/c-pragma.c
+@@ -1152,12 +1152,21 @@ handle_pragma_message (cpp_reader *ARG_UNUSED(dummy))
+ 
+   if (TREE_STRING_LENGTH (message) > 1)
+     inform (input_location, "%<#pragma message: %s%>",
+ 	    TREE_STRING_POINTER (message));
+ }
+ 
++/* This is queried by the invoker of the handler */
++int was_tagtypepragma;
++/* Tagtype pragma */
++static void
++handle_pragma_tagtype (cpp_reader *reader)
++{
++  was_tagtypepragma = 1;
++}
++
+ /* Mark whether the current location is valid for a STDC pragma.  */
+ 
+ static bool valid_location_for_stdc_pragma;
+ 
+ void
+ mark_valid_location_for_stdc_pragma (bool flag)
+@@ -1570,12 +1579,13 @@ init_pragma (void)
+ 
+   c_register_pragma_with_expansion (0, "redefine_extname",
+ 				    handle_pragma_redefine_extname);
+ 
+   c_register_pragma_with_expansion (0, "message", handle_pragma_message);
+ 
++  c_register_pragma_with_expansion ("amigaos", "tagtype", handle_pragma_tagtype);
+ #ifdef REGISTER_TARGET_PRAGMAS
+   REGISTER_TARGET_PRAGMAS ();
+ #endif
+ 
+   global_sso = default_sso;
+   c_register_pragma (0, "scalar_storage_order", 
+diff --git a/gcc/c/c-parser.c b/gcc/c/c-parser.c
+index 5176549acafa2b0c25be4bb5e75e8c67750b1962..1e9fe21e3cf80790d70081e518f266d4d3d497af 100644
+--- a/gcc/c/c-parser.c
++++ b/gcc/c/c-parser.c
+@@ -95,12 +95,74 @@ set_c_expr_source_range (c_expr *expr,
+ {
+   expr->src_range = src_range;
+   if (expr->value)
+     set_source_range (expr->value, src_range);
+ }
+ 
++static htab_t amigaos_tagdecl_to_type;
++
++struct amigaos_hash_type
++{
++  tree decl;
++  tree type;
++};
++
++static hashval_t
++amigaos_hash_descriptor (const void *p)
++{
++  return htab_hash_pointer (((const amigaos_hash_type *)p)->decl);
++}
++
++static int
++amigaos_eq_descriptor (const void *p1, const void *p2)
++{
++  return ((const amigaos_hash_type *)p1)->decl == ((const amigaos_hash_type *)p2)->decl;
++}
++
++/**
++ * Returns the tag type that is associated with the given type.
++ *
++ * @param type
++ * @return
++ */
++tree amigaos_get_type_associated_tagtype(tree decl)
++{
++  amigaos_hash_type aht = {decl, 0};
++  amigaos_hash_type *faht;
++
++  if (!amigaos_tagdecl_to_type)
++    return NULL;
++
++  faht = (amigaos_hash_type *)htab_find(amigaos_tagdecl_to_type, &aht);
++  if (!faht)
++    return NULL;
++  return faht->type;
++}
++
++static void amigaos_put_type_associated_tagtype(tree decl, tree type)
++{
++  gcc_assert(decl);
++
++  if (!amigaos_tagdecl_to_type)
++    amigaos_tagdecl_to_type = htab_create (10, amigaos_hash_descriptor, amigaos_eq_descriptor, NULL);
++
++  amigaos_hash_type *aht = (amigaos_hash_type *)xmalloc(sizeof(*aht));
++  aht->decl = decl;
++  aht->type = type;
++
++  void **pentry = htab_find_slot (amigaos_tagdecl_to_type, aht, INSERT);
++  gcc_assert(pentry);
++  gcc_assert(*pentry == NULL);
++  *pentry = aht;
++}
++
++/**
++ * Contains the tagtype that is currently processed or NULL_TREE
++ * if no tagtype is processed.
++ */
++static tree amigaos_current_tagtype;
+ 
+ /* Initialization routine for this file.  */
+ 
+ void
+ c_parse_init (void)
+ {
+@@ -2948,12 +3010,15 @@ c_parser_declspecs (c_parser *parser, struct c_declspecs *specs,
+ 	    goto out;
+ 	  attrs_ok = true;
+ 	  seen_type = true;
+ 	  t = c_parser_enum_specifier (parser);
+           invoke_plugin_callbacks (PLUGIN_FINISH_TYPE, t.spec);
+ 	  declspecs_add_type (loc, specs, t);
++	  /* Handle special tagtype enhanced enums */
++	  if (amigaos_current_tagtype != NULL_TREE && t.spec != NULL_TREE)
++	    amigaos_put_type_associated_tagtype(t.spec, amigaos_current_tagtype);
+ 	  break;
+ 	case RID_STRUCT:
+ 	case RID_UNION:
+ 	  if (!typespec_ok)
+ 	    goto out;
+ 	  attrs_ok = true;
+@@ -12306,12 +12371,32 @@ c_parser_pragma_unroll (c_parser *parser)
+     }
+ 
+   c_parser_skip_to_pragma_eol (parser);
+   return unroll;
+ }
+ 
++/**
++ * This function is called whenever a declaration was finished that was preceded
++ * by a tagtype pragma.
++ *
++ * @param gcc_data will be the finished declaration
++ * @param user_data will be the parsed c type of the declaration (c_type_name *)
++ *  that was specified ahead of the declaration via the pragma.
++ */
++static void amigaos_tagtype_finish_decl_callback (void *gcc_data, void *user_data)
++{
++  tree decl = (tree)gcc_data;
++  c_type_name *ctype = (c_type_name*)user_data;
++  tree type = groktypename (ctype, NULL, NULL);
++
++  /* TODO: All sorts of checks */
++
++  /* Now put the association in our own hash table */
++  amigaos_put_type_associated_tagtype(decl, type);
++}
++
+ /* Handle pragmas.  Some OpenMP pragmas are associated with, and therefore
+    should be considered, statements.  ALLOW_STMT is true if we're within
+    the context of a function and such pragmas are to be allowed.  Returns
+    true if we actually parsed such a pragma.  */
+ 
+ static bool
+@@ -12554,12 +12639,56 @@ c_parser_pragma (c_parser *parser, enum pragma_context context, bool *if_p)
+       break;
+     }
+ 
+   c_parser_consume_pragma (parser);
+   c_invoke_pragma_handler (id);
+ 
++  /* If was_tagtypepragma is set, the pragma was a tagtype one,
++   * which, at the moment, cannot easily handled outside of this
++   * file.
++   */
++  extern int was_tagtypepragma;
++  if (was_tagtypepragma)
++  {
++    c_token *tok = c_parser_peek_token (the_parser);
++    enum cpp_ttype ret = tok->type;
++    c_parser_consume_token(parser);
++
++    c_type_name *ctype = c_parser_type_name(parser);
++    tree ctypetree = groktypename (ctype, NULL, NULL);
++
++    /* Make the parsed type available to all functions called from here on */
++    amigaos_current_tagtype = ctypetree;
++
++    tok = c_parser_peek_token (the_parser);
++    ret = tok->type;
++    c_parser_consume_token(parser);
++    c_parser_skip_to_pragma_eol(parser);
++
++    tok = c_parser_peek_token (the_parser);
++    ret = tok->type;
++
++    /* Parse the line that follows. We will register for a PLUGIN_FINISH_DECL event
++     * to minimize contermination
++     */
++    bool old_flag_plugin_added = flag_plugin_added;
++    register_callback ("amigaos-tagtype", PLUGIN_FINISH_DECL,
++                       amigaos_tagtype_finish_decl_callback,
++                       ctype);
++    flag_plugin_added = 1;
++    c_parser_declaration_or_fndef(parser, false, false, true, false, true, NULL, vNULL);
++    unregister_callback ("amigaos-tagtype", PLUGIN_FINISH_DECL);
++    flag_plugin_added = old_flag_plugin_added;
++    /* Reset the variable that is set in the pragma handler */
++    was_tagtypepragma = 0;
++    /* The tagtype has been processed */
++    amigaos_current_tagtype = NULL_TREE;
++    return false;
++  }
++
++
+   /* Skip to EOL, but suppress any error message.  Those will have been
+      generated by the handler routine through calling error, as opposed
+      to calling c_parser_error.  */
+   parser->error = true;
+   c_parser_skip_to_pragma_eol (parser);
+ 
+diff --git a/gcc/c/c-typeck.c b/gcc/c/c-typeck.c
+index ac420bb7c4d3546885de63a14ec8f8826b47bf9f..5cf86f2c26902751c9f2d4e6e6c2b83ea97495f8 100644
+--- a/gcc/c/c-typeck.c
++++ b/gcc/c/c-typeck.c
+@@ -3489,12 +3489,14 @@ convert_arguments (location_t loc, vec<location_t> arg_loc, tree typelist,
+   bool error_args = false;
+   const bool type_generic = fundecl
+     && lookup_attribute ("type generic", TYPE_ATTRIBUTES (TREE_TYPE (fundecl)));
+   bool type_generic_remove_excess_precision = false;
+   bool type_generic_overflow_p = false;
+   tree selector;
++  const bool lineartags = fundecl
++    && lookup_attribute ("lineartags", TYPE_ATTRIBUTES (TREE_TYPE (fundecl)));
+ 
+   /* Change pointer to function to the function itself for
+      diagnostics.  */
+   if (TREE_CODE (function) == ADDR_EXPR
+       && TREE_CODE (TREE_OPERAND (function, 0)) == FUNCTION_DECL)
+     function = TREE_OPERAND (function, 0);
+@@ -3550,13 +3552,13 @@ convert_arguments (location_t loc, vec<location_t> arg_loc, tree typelist,
+ 	  }
+     }
+ 
+   /* Scan the given expressions (VALUES) and types (TYPELIST), producing
+      individual converted arguments.  */
+ 
+-  tree typetail, builtin_typetail, val;
++  tree typetail, builtin_typetail, val, prev_tagtype = NULL_TREE;
+   for (typetail = typelist,
+ 	 builtin_typetail = builtin_typelist,
+ 	 parmnum = 0;
+        values && values->iterate (parmnum, &val);
+        ++parmnum)
+     {
+@@ -3651,12 +3653,34 @@ convert_arguments (location_t loc, vec<location_t> arg_loc, tree typelist,
+ 	      {
+ 		promote_float_arg = false;
+ 		break;
+ 	      }
+ 	}
+ 
++      /* If this is a function call with linear tags try to improve the expected
++       * type on base of recorded tag <-> type mapping, but only if we don't know
++       * the expected type (e.g. on a var) or if the expected type is an integer.
++       * The latter case usually happens on the first tag item.
++       */
++      if (lineartags && (type == NULL_TREE || TREE_CODE(type) == INTEGER_TYPE))
++        {
++          extern tree amigaos_get_type_associated_tagtype(tree type);
++
++          if (prev_tagtype)
++            {
++              type = prev_tagtype;
++              prev_tagtype = NULL_TREE;
++            }
++          else
++            {
++              prev_tagtype = amigaos_get_type_associated_tagtype(val);
++              if (!prev_tagtype)
++                prev_tagtype = amigaos_get_type_associated_tagtype((*origtypes)[parmnum]);
++            }
++        }
++
+       if (type != NULL_TREE)
+ 	{
+ 	  tree origtype = (!origtypes) ? NULL_TREE : (*origtypes)[parmnum];
+ 	  parmval = convert_argument (ploc, function, fundecl, type, origtype,
+ 				      val, valtype, npc, rname, parmnum, argnum,
+ 				      excess_precision, 0);
+diff --git a/gcc/config/rs6000/amigaos-protos.h b/gcc/config/rs6000/amigaos-protos.h
+index eb5f8fc5f3d546b8d8e1cdd8118a3085079df50e..3b8c994cdbd192eaf7112c780f0106a4d96cbb90 100644
+--- a/gcc/config/rs6000/amigaos-protos.h
++++ b/gcc/config/rs6000/amigaos-protos.h
+@@ -27,12 +27,13 @@ extern void amigaos_function_arg_advance (CUMULATIVE_ARGS *, enum machine_mode,
+ extern struct rtx_def *amigaos_function_arg (CUMULATIVE_ARGS *, enum machine_mode, tree, int);
+ extern void amigaos_expand_builtin_va_start (tree valist, rtx nextarg);
+ extern struct rtx_def *amigaos_expand_builtin_saveregs (void);
+ extern void amigaos_init_builtins (void);
+ extern rtx amigaos_expand_builtin (tree, rtx, rtx, enum machine_mode, int, bool*);
+ extern tree amigaos_handle_linearvarargs_attribute (tree *, tree, tree, int, bool*);
++extern tree amigaos_handle_lineartags_attribute (tree *, tree, tree, int, bool*);
+ extern tree amigaos_handle_baserel_restore_attribute (tree *, tree, tree, int, bool*);
+ extern tree amigaos_handle_force_no_baserel_attribute (tree *, tree, tree, int, bool*);
+ extern tree amigaos_handle_check68kfuncptr_attribute (tree *, tree, tree, int, bool*);
+ extern rtx amigaos_legitimize_baserel_address (rtx addr);
+ extern int amigaos_baserel_operand(rtx x);
+ extern int amigaos_not_baserel_tree_p(tree decl);
+diff --git a/gcc/config/rs6000/amigaos.c b/gcc/config/rs6000/amigaos.c
+index ad8c0e64c056129afcd8bfa2a656749a2febfaaa..85c03f28e37d64865360692a14fcc8a197b55395 100644
+--- a/gcc/config/rs6000/amigaos.c
++++ b/gcc/config/rs6000/amigaos.c
+@@ -346,12 +346,45 @@ amigaos_handle_linearvarargs_attribute (tree *node, tree name,
+       *no_add_attrs = true;
+     }
+ 
+   return NULL_TREE;
+ }
+ 
++/* Handle a lineartags attribute. This enables tag verifications */
++tree
++amigaos_handle_lineartags_attribute (tree *node, tree name, tree args, int flags ATTRIBUTE_UNUSED, bool *no_add_attrs)
++{
++  if (TREE_CODE (*node) != FUNCTION_TYPE)
++    {
++      warning (0, "%s attribute only applies to functions",
++	       IDENTIFIER_POINTER (name));
++      *no_add_attrs = true;
++    }
++  tree fn = *node;
++  tree arglist = TYPE_ARG_TYPES(fn);
++  int arg = 0;
++  bool is_varargs = true;
++
++  while (arglist != NULL_TREE)
++    {
++      /* The void_type marks the end of a non-varargs function */
++      if (TREE_VALUE(arglist) == void_type_node)
++        is_varargs = false;
++
++      arglist = TREE_CHAIN (arglist);
++      arg++;
++    }
++
++  if (!is_varargs && arg == 2)
++    {
++      warning (0, "%s attribute only applies to varargs functions or functions with at least two arguments",
++	       IDENTIFIER_POINTER (name));
++    }
++  return NULL_TREE;
++}
++
+ 
+ /* Generate code for base relative access */
+ 
+ rtx
+ amigaos_legitimize_baserel_address (rtx addr)
+ {
+-- 
+2.11.0
+

--- a/gcc/10/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/10/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,0 +1,37 @@
+From 60f695c9b778b745a514694d06c82ddb786a3f51 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Thu, 9 Jul 2015 06:54:37 +0200
+Subject: [PATCH 03/33] Disable .machine directive generation.
+
+It breaks manual args to the assembler with different flavor,
+e.g., -Wa,-m440. This is probably not the right fix.
+
+This reverts parts of a commit from 2015-03-03.
+---
+ gcc/config/rs6000/rs6000.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/gcc/config/rs6000/rs6000.c b/gcc/config/rs6000/rs6000.c
+index 883e8b037572e88bbe43fa24b9c4ad19f1de4cc8..4e27c0f16115d129ccb95daa9949f2472dde483b 100644
+--- a/gcc/config/rs6000/rs6000.c
++++ b/gcc/config/rs6000/rs6000.c
+@@ -5648,15 +5648,13 @@ rs6000_file_start (void)
+ 	putc ('\n', file);
+     }
+ 
+ #ifdef USING_ELFOS_H
+   rs6000_machine = rs6000_machine_from_flags ();
+   emit_asm_machine ();
+-  /* AmigaOS: This was temporarily disabled to not override e.g., -mcpu=440 */
+-  /* Not entirely sure why, but there might be a good reason so consider this
+-   * a FIXME. Refer to patches for gcc <= 9. */
++  /* AmigaOS: FIXME: The 'Disable .machine directive generation' is temporarily disabled. */
+ #endif
+ 
+   if (DEFAULT_ABI == ABI_ELFv2)
+     fprintf (file, "\t.abiversion 2\n");
+ }
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/10/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,0 +1,51 @@
+From 707ac91cc79315eca8685ecbc831d41f26387c7d Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Wed, 2 Dec 2015 20:56:33 +0100
+Subject: [PATCH 04/33] The default link mode is static for AmigaOS.
+
+Changed the g++ driver to reflect this.
+---
+ gcc/cp/g++spec.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/cp/g++spec.c b/gcc/cp/g++spec.c
+index 0ab63bcd2119b4ffdda235c6b49cb53a4eca98ef..fbbf846546185e388303f40d0a70db19dc76c46b 100644
+--- a/gcc/cp/g++spec.c
++++ b/gcc/cp/g++spec.c
+@@ -101,14 +101,14 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
+   /* By default, we throw on the math library if we have one.  */
+   int need_math = (MATH_LIBRARY[0] != '\0');
+ 
+   /* By default, we throw on the time library if we have one.  */
+   int need_time = (TIME_LIBRARY[0] != '\0');
+ 
+-  /* True if we saw -static.  */
+-  int static_link = 0;
++  /* False if we saw -shared.  */
++  int static_link = 1;
+ 
+   /* True if we should add -shared-libgcc to the command-line.  */
+   int shared_libgcc = 1;
+ 
+   /* The total number of arguments with the new stuff.  */
+   unsigned int argc;
+@@ -196,12 +196,16 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
+ 	  break;
+ 
+ 	case OPT_static:
+ 	  static_link = 1;
+ 	  break;
+ 
++	case OPT_shared:
++	  static_link = 0;
++	  break;
++
+ 	case OPT_static_libgcc:
+ 	  shared_libgcc = 0;
+ 	  break;
+ 
+ 	case OPT_static_libstdc__:
+ 	  library = library >= 0 ? 2 : library;
+-- 
+2.11.0
+

--- a/gcc/10/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/10/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,0 +1,71 @@
+From 96a890a4b38d4ec4546c32969d6a796ffc40d3fc Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Wed, 2 Dec 2015 21:39:42 +0100
+Subject: [PATCH 05/33] Disable the usage of /dev/urandom when compiling for
+ AmigaOS.
+
+---
+ gcc/gcc.c    | 3 +++
+ gcc/toplev.c | 2 ++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/gcc/gcc.c b/gcc/gcc.c
+index 97fd5f63a650ff9d5772e4464bbe66a9962c561e..45c0ece73885bac9891c0aadc281ed1f245ea459 100644
+--- a/gcc/gcc.c
++++ b/gcc/gcc.c
+@@ -9714,22 +9714,25 @@ print_asm_header_spec_function (int arg ATTRIBUTE_UNUSED,
+ /* Get a random number for -frandom-seed */
+ 
+ static unsigned HOST_WIDE_INT
+ get_random_number (void)
+ {
+   unsigned HOST_WIDE_INT ret = 0;
++
++#ifndef __amigaos4__
+   int fd; 
+ 
+   fd = open ("/dev/urandom", O_RDONLY); 
+   if (fd >= 0)
+     {
+       read (fd, &ret, sizeof (HOST_WIDE_INT));
+       close (fd);
+       if (ret)
+         return ret;
+     }
++#endif
+ 
+   /* Get some more or less random data.  */
+ #ifdef HAVE_GETTIMEOFDAY
+   {
+     struct timeval tv;
+ 
+diff --git a/gcc/toplev.c b/gcc/toplev.c
+index eaed6f6c78005510af8811f2a5f17ffa159824a0..0b876664290dc9d7ab831996cdf71268cbf40aa5 100644
+--- a/gcc/toplev.c
++++ b/gcc/toplev.c
+@@ -274,20 +274,22 @@ init_local_tick (void)
+ 
+ HOST_WIDE_INT
+ get_random_seed (bool noinit)
+ {
+   if (!random_seed && !noinit)
+     {
++#ifndef __amigaos4__
+       int fd = open ("/dev/urandom", O_RDONLY);
+       if (fd >= 0)
+         {
+           if (read (fd, &random_seed, sizeof (random_seed))
+               != sizeof (random_seed))
+             random_seed = 0;
+           close (fd);
+         }
++#endif
+       if (!random_seed)
+ 	random_seed = local_tick ^ getpid ();
+     }
+   return random_seed;
+ }
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/10/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,0 +1,41 @@
+From ebc1c901ddd8c265d6f27776891d739b0146046d Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Sat, 5 Dec 2015 13:17:26 +0100
+Subject: [PATCH 06/33] Expand arg zero on AmigaOS using the PROGDIR: assign.
+
+This should make sure that the proper relative paths are computed during
+process_command().
+---
+ gcc/gcc.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/gcc/gcc.c b/gcc/gcc.c
+index 45c0ece73885bac9891c0aadc281ed1f245ea459..fc92a9344d0e3e0befd7fbf774c99c8dc6e050f8 100644
+--- a/gcc/gcc.c
++++ b/gcc/gcc.c
+@@ -7389,12 +7389,22 @@ driver::~driver ()
+ int
+ driver::main (int argc, char **argv)
+ {
+   bool early_exit;
+ 
+   set_progname (argv[0]);
++#ifdef __amigaos4__
++  /* Expand the command name on AmigaOS */
++  char *expanded_progdir = lrealpath("/progdir/");
++  if (expanded_progdir)
++    {
++      char *expanded_argv0 = concat(expanded_progdir,"/",progname,NULL);
++      argv[0] = expanded_argv0; /* FIXME: Leak */
++      free(expanded_progdir);
++    }
++#endif
+   expand_at_files (&argc, &argv);
+   decode_argv (argc, const_cast <const char **> (argv));
+   global_initializations ();
+   build_multilib_strings ();
+   set_up_specs ();
+   putenv_COLLECT_AS_OPTIONS (assembler_options);
+-- 
+2.11.0
+

--- a/gcc/10/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/10/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,0 +1,85 @@
+From eb8b8a2708023813b9a42be4c97393b04f4998c3 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Thu, 21 Jan 2016 20:46:59 +0100
+Subject: [PATCH 07/33] Some AmigaOS 4.x compability changes for posix thread
+ support.
+
+---
+ libgcc/gthr-posix.h | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/libgcc/gthr-posix.h b/libgcc/gthr-posix.h
+index 965247602acf11f81c5fa009c7ee48eb55cbacca..b345914381af9df06368bfc576f7a36bb8a50538 100644
+--- a/libgcc/gthr-posix.h
++++ b/libgcc/gthr-posix.h
+@@ -29,12 +29,16 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ /* POSIX threads specific definitions.
+    Easy, since the interface is just one-to-one mapping.  */
+ 
+ #define __GTHREADS 1
+ #define __GTHREADS_CXX0X 1
+ 
++#ifdef __amigaos4__
++#include <exec/types.h>
++#endif
++
+ #include <pthread.h>
+ 
+ #if ((defined(_LIBOBJC) || defined(_LIBOBJC_WEAK)) \
+      || !defined(_GTHREAD_USE_MUTEX_TIMEDLOCK))
+ # include <unistd.h>
+ # if defined(_POSIX_TIMEOUTS) && _POSIX_TIMEOUTS >= 0
+@@ -108,13 +112,15 @@ __gthrw(pthread_join)
+ __gthrw(pthread_equal)
+ __gthrw(pthread_self)
+ __gthrw(pthread_detach)
+ #ifndef __BIONIC__
+ __gthrw(pthread_cancel)
+ #endif
++#ifndef __amigaos4__
+ __gthrw(sched_yield)
++#endif
+ 
+ __gthrw(pthread_mutex_lock)
+ __gthrw(pthread_mutex_trylock)
+ #if _GTHREAD_USE_MUTEX_TIMEDLOCK
+ __gthrw(pthread_mutex_timedlock)
+ #endif
+@@ -445,14 +451,16 @@ __gthread_objc_thread_get_priority (void)
+ }
+ 
+ /* Yield our process time to another thread.  */
+ static inline void
+ __gthread_objc_thread_yield (void)
+ {
++#ifndef __amigaos4__
+   if (__gthread_active_p ())
+     __gthrw_(sched_yield) ();
++#endif
+ }
+ 
+ /* Terminate the current thread.  */
+ static inline int
+ __gthread_objc_thread_exit (void)
+ {
+@@ -687,13 +695,17 @@ __gthread_self (void)
+   return __gthrw_(pthread_self) ();
+ }
+ 
+ static inline int
+ __gthread_yield (void)
+ {
++#ifdef __amigaos4__
++  return 1;
++#else
+   return __gthrw_(sched_yield) ();
++#endif
+ }
+ 
+ static inline int
+ __gthread_once (__gthread_once_t *__once, void (*__func) (void))
+ {
+   if (__gthread_active_p ())
+-- 
+2.11.0
+

--- a/gcc/10/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/10/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,0 +1,624 @@
+From e98583c4a57dfb48c026c739c4779e65535c5d0d Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Fri, 22 Jan 2016 20:04:50 +0100
+Subject: [PATCH 08/33] Added libstc++ support for AmigaOS.
+
+---
+ libstdc++-v3/config/os/amigaos/ctype_base.h        |  59 +++++++
+ .../config/os/amigaos/ctype_configure_char.cc      |  99 ++++++++++++
+ libstdc++-v3/config/os/amigaos/ctype_inline.h      | 173 ++++++++++++++++++++
+ libstdc++-v3/config/os/amigaos/error_constants.h   | 178 +++++++++++++++++++++
+ libstdc++-v3/config/os/amigaos/os_defines.h        |  43 +++++
+ libstdc++-v3/configure.host                        |   3 +
+ 6 files changed, 555 insertions(+)
+ create mode 100644 libstdc++-v3/config/os/amigaos/ctype_base.h
+ create mode 100644 libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+ create mode 100644 libstdc++-v3/config/os/amigaos/ctype_inline.h
+ create mode 100644 libstdc++-v3/config/os/amigaos/error_constants.h
+ create mode 100644 libstdc++-v3/config/os/amigaos/os_defines.h
+
+diff --git a/libstdc++-v3/config/os/amigaos/ctype_base.h b/libstdc++-v3/config/os/amigaos/ctype_base.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..260b6142b6fc6a11a1e5f0bf7820b592d09f285e
+--- /dev/null
++++ b/libstdc++-v3/config/os/amigaos/ctype_base.h
+@@ -0,0 +1,59 @@
++// Locale support -*- C++ -*-
++
++// Copyright (C) 1997-2015 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++//
++// ISO C++ 14882: 22.1  Locales
++//
++
++// Default information, may not be appropriate for specific host.
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  /// @brief  Base class for ctype.
++  struct ctype_base
++  {
++    // Non-standard typedefs.
++    typedef const int* 		__to_type;
++
++    // NB: Offsets into ctype<char>::_M_table force a particular size
++    // on the mask type. Because of this, we don't use an enum.
++    typedef unsigned int 	mask;
++    static const mask upper    	= 1 << 0;
++    static const mask lower 	= 1 << 1;
++    static const mask alpha 	= 1 << 2;
++    static const mask digit 	= 1 << 3;
++    static const mask xdigit 	= 1 << 4;
++    static const mask space 	= 1 << 5;
++    static const mask print 	= 1 << 6;
++    static const mask graph 	= (1 << 2) | (1 << 3) | (1 << 9); // alnum|punct
++    static const mask cntrl 	= 1 << 8;
++    static const mask punct 	= 1 << 9;
++    static const mask alnum 	= (1 << 2) | (1 << 3);  // alpha|digit
++    static const mask blank	= 1 << 10;
++  };
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --git a/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..e6f4895aee78da54bc6b1e01df00816206361c41
+--- /dev/null
++++ b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+@@ -0,0 +1,99 @@
++// Locale support -*- C++ -*-
++
++// Copyright (C) 2011-2015 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file ctype_configure_char.cc */
++
++//
++// ISO C++ 14882: 22.1  Locales
++//
++
++#include <locale>
++#include <cstdlib>
++#include <cstring>
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++// Information as gleaned from /usr/include/ctype.h
++
++  const ctype_base::mask*
++  ctype<char>::classic_table() throw()
++  { return 0; }
++
++  ctype<char>::ctype(__c_locale, const mask* __table, bool __del, 
++		     size_t __refs) 
++  : facet(__refs), _M_del(__table != 0 && __del), 
++  _M_toupper(NULL), _M_tolower(NULL), 
++  _M_table(__table ? __table : classic_table()) 
++  { 
++    memset(_M_widen, 0, sizeof(_M_widen));
++    _M_widen_ok = 0;
++    memset(_M_narrow, 0, sizeof(_M_narrow));
++    _M_narrow_ok = 0;
++  }
++
++  ctype<char>::ctype(const mask* __table, bool __del, size_t __refs) 
++  : facet(__refs), _M_del(__table != 0 && __del), 
++  _M_toupper(NULL), _M_tolower(NULL), 
++  _M_table(__table ? __table : classic_table())
++  { 
++    memset(_M_widen, 0, sizeof(_M_widen));
++    _M_widen_ok = 0;
++    memset(_M_narrow, 0, sizeof(_M_narrow));
++    _M_narrow_ok = 0;
++  }
++
++  char
++  ctype<char>::do_toupper(char __c) const
++  { return ::toupper((int) __c); }
++
++  const char*
++  ctype<char>::do_toupper(char* __low, const char* __high) const
++  {
++    while (__low < __high)
++      {
++	*__low = ::toupper((int) *__low);
++	++__low;
++      }
++    return __high;
++  }
++
++  char
++  ctype<char>::do_tolower(char __c) const
++  { return ::tolower((int) __c); }
++
++  const char* 
++  ctype<char>::do_tolower(char* __low, const char* __high) const
++  {
++    while (__low < __high)
++      {
++	*__low = ::tolower((int) *__low);
++	++__low;
++      }
++    return __high;
++  }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --git a/libstdc++-v3/config/os/amigaos/ctype_inline.h b/libstdc++-v3/config/os/amigaos/ctype_inline.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..cfa0146ae6b70623c2fe63b864ceef7bce0d5fe0
+--- /dev/null
++++ b/libstdc++-v3/config/os/amigaos/ctype_inline.h
+@@ -0,0 +1,173 @@
++// Locale support -*- C++ -*-
++
++// Copyright (C) 2000-2015 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file bits/ctype_inline.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{locale}
++ */
++
++//
++// ISO C++ 14882: 22.1  Locales
++//
++  
++// ctype bits to be inlined go here. Non-inlinable (ie virtual do_*)
++// functions go in ctype.cc
++  
++// The following definitions are portable, but insanely slow. If one
++// cares at all about performance, then specialized ctype
++// functionality should be added for the native os in question: see
++// the config/os/bits/ctype_*.h files.
++
++// Constructing a synthetic "C" table should be seriously considered...
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  bool
++  ctype<char>::
++  is(mask __m, char __c) const
++  { 
++    if (_M_table)
++      return _M_table[static_cast<unsigned char>(__c)] & __m;
++    else
++      {
++	bool __ret = false;
++	const size_t __bitmasksize = 15; 
++	size_t __bitcur = 0; // Lowest bitmask in ctype_base == 0
++	for (; __bitcur <= __bitmasksize; ++__bitcur)
++	  {
++	    const mask __bit = static_cast<mask>(1 << __bitcur);
++	    if (__m & __bit)
++	      {
++		bool __testis;
++		switch (__bit)
++		  {
++		  case space:
++		    __testis = isspace(__c);
++		    break;
++		  case print:
++		    __testis = isprint(__c);
++		    break;
++		  case cntrl:
++		    __testis = iscntrl(__c);
++		    break;
++		  case upper:
++		    __testis = isupper(__c);
++		    break;
++		  case lower:
++		    __testis = islower(__c);
++		    break;
++		  case alpha:
++		    __testis = isalpha(__c);
++		    break;
++		  case digit:
++		    __testis = isdigit(__c);
++		    break;
++		  case punct:
++		    __testis = ispunct(__c);
++		    break;
++		  case xdigit:
++		    __testis = isxdigit(__c);
++		    break;
++		  case alnum:
++		    __testis = isalnum(__c);
++		    break;
++		  case graph:
++		    __testis = isgraph(__c);
++		    break;
++#ifdef _GLIBCXX_USE_C99_CTYPE_TR1
++		  case blank:
++		    __testis = isblank(__c);
++		    break;
++#endif
++		  default:
++		    __testis = false;
++		    break;
++		  }
++		__ret |= __testis;
++	      }
++	  }
++	return __ret;
++      }
++  }
++   
++  const char*
++  ctype<char>::
++  is(const char* __low, const char* __high, mask* __vec) const
++  {
++    if (_M_table)
++      while (__low < __high)
++	*__vec++ = _M_table[static_cast<unsigned char>(*__low++)];
++    else
++      {
++	// Highest bitmask in ctype_base == 11.
++	const size_t __bitmasksize = 15; 
++	for (;__low < __high; ++__vec, ++__low)
++	  {
++	    mask __m = 0;
++	    // Lowest bitmask in ctype_base == 0
++	    size_t __i = 0; 
++	    for (;__i <= __bitmasksize; ++__i)
++	      {
++		const mask __bit = static_cast<mask>(1 << __i);
++		if (this->is(__bit, *__low))
++		  __m |= __bit;
++	      }
++	    *__vec = __m;
++	  }
++      }
++    return __high;
++  }
++
++  const char*
++  ctype<char>::
++  scan_is(mask __m, const char* __low, const char* __high) const
++  {
++    if (_M_table)
++      while (__low < __high
++	     && !(_M_table[static_cast<unsigned char>(*__low)] & __m))
++	++__low;
++    else
++      while (__low < __high && !this->is(__m, *__low))
++	++__low;
++    return __low;
++  }
++
++  const char*
++  ctype<char>::
++  scan_not(mask __m, const char* __low, const char* __high) const
++  {
++    if (_M_table)
++      while (__low < __high
++	     && (_M_table[static_cast<unsigned char>(*__low)] & __m) != 0)
++	++__low;
++    else
++      while (__low < __high && this->is(__m, *__low) != 0)
++	++__low;
++    return __low;
++  }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --git a/libstdc++-v3/config/os/amigaos/error_constants.h b/libstdc++-v3/config/os/amigaos/error_constants.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..74492cf61c875eac28cb8a86d5bfdb3b8807aa16
+--- /dev/null
++++ b/libstdc++-v3/config/os/amigaos/error_constants.h
+@@ -0,0 +1,178 @@
++// Specific definitions for generic platforms  -*- C++ -*-
++
++// Copyright (C) 2007-2015 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file bits/error_constants.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{system_error}
++ */
++
++#ifndef _GLIBCXX_ERROR_CONSTANTS
++#define _GLIBCXX_ERROR_CONSTANTS 1
++
++#include <bits/c++config.h>
++#include <cerrno>
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  enum class errc
++    {
++      address_family_not_supported = 		EAFNOSUPPORT,
++      address_in_use = 				EADDRINUSE,
++      address_not_available = 			EADDRNOTAVAIL,
++      already_connected = 			EISCONN,
++      argument_list_too_long = 			E2BIG,
++      argument_out_of_domain = 			EDOM,
++      bad_address = 				EFAULT,
++      bad_file_descriptor = 			EBADF,
++
++#ifdef _GLIBCXX_HAVE_EBADMSG
++      bad_message = 				EBADMSG,
++#endif
++
++      broken_pipe = 				EPIPE,
++      connection_aborted = 			ECONNABORTED,
++      connection_already_in_progress = 		EALREADY,
++      connection_refused = 			ECONNREFUSED,
++      connection_reset = 			ECONNRESET,
++      cross_device_link = 			EXDEV,
++      destination_address_required = 		EDESTADDRREQ,
++      device_or_resource_busy = 		EBUSY,
++      directory_not_empty = 			ENOTEMPTY,
++      executable_format_error = 		ENOEXEC,
++      file_exists = 	       			EEXIST,
++      file_too_large = 				EFBIG,
++      filename_too_long = 			ENAMETOOLONG,
++      function_not_supported = 			ENOSYS,
++      host_unreachable = 			EHOSTUNREACH,
++
++#ifdef _GLIBCXX_HAVE_EIDRM
++      identifier_removed = 			EIDRM,
++#endif
++
++      illegal_byte_sequence = 			EILSEQ,
++      inappropriate_io_control_operation = 	ENOTTY,
++      interrupted = 				EINTR,
++      invalid_argument = 			EINVAL,
++      invalid_seek = 				ESPIPE,
++      io_error = 				EIO,
++      is_a_directory = 				EISDIR,
++      message_size = 				EMSGSIZE,
++      network_down = 				ENETDOWN,
++      network_reset = 				ENETRESET,
++      network_unreachable = 			ENETUNREACH,
++      no_buffer_space = 			ENOBUFS,
++      no_child_process = 			ECHILD,
++
++#ifdef _GLIBCXX_HAVE_ENOLINK
++      no_link = 				ENOLINK,
++#endif
++
++      no_lock_available = 			ENOLCK,
++
++#ifdef _GLIBCXX_HAVE_ENODATA
++      no_message_available = 			ENODATA, 
++#endif
++
++      no_message = 				ENOMSG, 
++      no_protocol_option = 			ENOPROTOOPT,
++      no_space_on_device = 			ENOSPC,
++
++#ifdef _GLIBCXX_HAVE_ENOSR
++      no_stream_resources = 			ENOSR,
++#endif
++
++      no_such_device_or_address = 		ENXIO,
++      no_such_device = 				ENODEV,
++      no_such_file_or_directory = 		ENOENT,
++      no_such_process = 			ESRCH,
++      not_a_directory = 			ENOTDIR,
++      not_a_socket = 				ENOTSOCK,
++
++#ifdef _GLIBCXX_HAVE_ENOSTR
++      not_a_stream = 				ENOSTR,
++#endif
++
++      not_connected = 				ENOTCONN,
++      not_enough_memory = 			ENOMEM,
++
++#ifdef _GLIBCXX_HAVE_ENOTSUP
++      not_supported = 				ENOTSUP,
++#endif
++
++#ifdef _GLIBCXX_HAVE_ECANCELED
++      operation_canceled = 			ECANCELED,
++#endif
++
++      operation_in_progress = 			EINPROGRESS,
++      operation_not_permitted = 		EPERM,
++      operation_not_supported = 		EOPNOTSUPP,
++      operation_would_block = 			EWOULDBLOCK,
++
++#ifdef _GLIBCXX_HAVE_EOWNERDEAD
++      owner_dead = 				EOWNERDEAD,
++#endif
++
++      permission_denied = 			EACCES,
++
++#ifdef _GLIBCXX_HAVE_EPROTO
++      protocol_error = 				EPROTO,
++#endif
++
++      protocol_not_supported = 			EPROTONOSUPPORT,
++      read_only_file_system = 			EROFS,
++      resource_deadlock_would_occur = 		EDEADLK,
++      resource_unavailable_try_again = 		EAGAIN,
++      result_out_of_range = 			ERANGE,
++
++#ifdef _GLIBCXX_HAVE_ENOTRECOVERABLE
++      state_not_recoverable = 			ENOTRECOVERABLE,
++#endif
++
++#ifdef _GLIBCXX_HAVE_ETIME
++      stream_timeout = 				ETIME,
++#endif
++
++#ifdef _GLIBCXX_HAVE_ETXTBSY
++      text_file_busy = 				ETXTBSY,
++#endif
++
++      timed_out = 				ETIMEDOUT,
++      too_many_files_open_in_system = 		ENFILE,
++      too_many_files_open = 			EMFILE,
++      too_many_links = 				EMLINK,
++      too_many_symbolic_link_levels = 		ELOOP,
++
++#ifdef _GLIBCXX_HAVE_EOVERFLOW
++      value_too_large = 			EOVERFLOW,
++#endif
++
++      wrong_protocol_type = 			EPROTOTYPE
++    };
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++#endif
+diff --git a/libstdc++-v3/config/os/amigaos/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..346f063958cd7e80ebf97be4acee0bdf391cb811
+--- /dev/null
++++ b/libstdc++-v3/config/os/amigaos/os_defines.h
+@@ -0,0 +1,43 @@
++// Specific definitions for AmigaOS -*- C++ -*-
++
++// Copyright (C) 2000-2015 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file bits/os_defines.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{iosfwd}
++ */
++
++#ifndef _GLIBCXX_OS_DEFINES
++#define _GLIBCXX_OS_DEFINES 1
++
++// System-specific #define, typedefs, corrections, etc, go here.  This
++// file will come before all others.
++
++// No ioctl() on AmigaOS
++#define _GLIBCXX_NO_IOCTL 1
++
++#ifdef __NEWLIB__
++#define _GLIBCXX_USE_C99_STDINT_TR1 1
++#endif
++
++#endif
+diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
+index 898db37d9a22a872a62fe6c7ae02c1955b0b66f6..033f4ccfc8fb05b32f89d4f6c493d91fc29f648b 100644
+--- a/libstdc++-v3/configure.host
++++ b/libstdc++-v3/configure.host
+@@ -219,12 +219,15 @@ case "${host_os}" in
+     atomicity_dir="os/aix"
+     ;;
+   aix*)
+     os_include_dir="os/generic"
+     atomicity_dir="cpu/generic"
+     ;;
++  amigaos*)
++    os_include_dir="os/amigaos"
++    ;;
+   bsd*)
+     # Plain BSD attempts to share FreeBSD files.
+     os_include_dir="os/bsd/freebsd"
+     ;;
+   cygwin*)
+     os_include_dir="os/newlib"
+-- 
+2.11.0
+

--- a/gcc/10/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/10/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,0 +1,207 @@
+From 50d8ba568a4389058a26bfb0f724de48eb068f07 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Fri, 3 Mar 2017 08:52:48 +0100
+Subject: [PATCH 09/33] Enable libatomic for ppc-amigaos.
+
+It is not really finished yet.
+---
+ libatomic/config/amigaos/host-config.h |  55 ++++++++++++++++++
+ libatomic/config/amigaos/lock.c        | 102 +++++++++++++++++++++++++++++++++
+ libatomic/configure.tgt                |   4 ++
+ 3 files changed, 161 insertions(+)
+ create mode 100644 libatomic/config/amigaos/host-config.h
+ create mode 100644 libatomic/config/amigaos/lock.c
+
+diff --git a/libatomic/config/amigaos/host-config.h b/libatomic/config/amigaos/host-config.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..879758e4eb5594a79b8ee2d25564b19a6f51cd31
+--- /dev/null
++++ b/libatomic/config/amigaos/host-config.h
+@@ -0,0 +1,55 @@
++/* Copyright (C) 2012-2015 Free Software Foundation, Inc.
++   Contributed by Richard Henderson <rth@redhat.com>.
++
++   This file is part of the GNU Atomic Library (libatomic).
++
++   Libatomic is free software; you can redistribute it and/or modify it
++   under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   Libatomic is distributed in the hope that it will be useful, but WITHOUT ANY
++   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
++   FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++   more details.
++
++   Under Section 7 of GPL version 3, you are granted additional
++   permissions described in the GCC Runtime Library Exception, version
++   3.1, as published by the Free Software Foundation.
++
++   You should have received a copy of the GNU General Public License and
++   a copy of the GCC Runtime Library Exception along with this program;
++   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* Included after all more target-specific host-config.h.  */
++
++
++#ifndef protect_start_end
++# ifdef HAVE_ATTRIBUTE_VISIBILITY
++#  pragma GCC visibility push(hidden)
++# endif
++
++void libat_lock_1 (void *ptr);
++void libat_unlock_1 (void *ptr);
++
++static inline UWORD
++protect_start (void *ptr)
++{
++  libat_lock_1 (ptr);
++  return 0;
++}
++
++static inline void
++protect_end (void *ptr, UWORD dummy UNUSED)
++{
++  libat_unlock_1 (ptr);
++}
++
++# define protect_start_end 1
++# ifdef HAVE_ATTRIBUTE_VISIBILITY
++#  pragma GCC visibility pop
++# endif
++#endif /* protect_start_end */
++
++#include_next <host-config.h>
+diff --git a/libatomic/config/amigaos/lock.c b/libatomic/config/amigaos/lock.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..ffd09f50095429f844bfe6bf7bec8741f56f1a28
+--- /dev/null
++++ b/libatomic/config/amigaos/lock.c
+@@ -0,0 +1,102 @@
++/* Copyright (C) 2012-2015 Free Software Foundation, Inc.
++   Contributed by Richard Henderson <rth@redhat.com>.
++
++   This file is part of the GNU Atomic Library (libatomic).
++
++   Libatomic is free software; you can redistribute it and/or modify it
++   under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   Libatomic is distributed in the hope that it will be useful, but WITHOUT ANY
++   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
++   FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
++   more details.
++
++   Under Section 7 of GPL version 3, you are granted additional
++   permissions described in the GCC Runtime Library Exception, version
++   3.1, as published by the Free Software Foundation.
++
++   You should have received a copy of the GNU General Public License and
++   a copy of the GCC Runtime Library Exception along with this program;
++   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++   <http://www.gnu.org/licenses/>.  */
++
++#include "libatomic_i.h"
++
++#define UWORD UWORD_
++#include <proto/exec.h>
++
++/* The target page size.  Must be no larger than the runtime page size,
++   lest locking fail with virtual address aliasing (i.e. a page mmaped
++   at two locations).  */
++#ifndef PAGE_SIZE
++#define PAGE_SIZE	4096
++#endif
++
++/* The target cacheline size.  This is an optimization; the padding that
++   should be applied to the locks to keep them from interfering.  */
++#ifndef CACHLINE_SIZE
++#define CACHLINE_SIZE	64
++#endif
++
++/* The granularity at which locks are applied.  Almost certainly the
++   cachline size is the right thing to use here.  */
++#ifndef WATCH_SIZE
++#define WATCH_SIZE	CACHLINE_SIZE
++#endif
++
++struct lock
++{
++  struct SignalSemaphore sem;
++  char initialized;
++  char pad[sizeof(struct SignalSemaphore) + 1 < CACHLINE_SIZE
++	   ? CACHLINE_SIZE - sizeof(struct SignalSemaphore) - 1
++	   : 0];
++};
++
++/* TODO: Use a constructor to initialize the semaphore */
++#define NLOCKS		(PAGE_SIZE / WATCH_SIZE)
++static struct lock locks[NLOCKS];
++
++static inline uintptr_t 
++addr_hash (void *ptr)
++{
++  return ((uintptr_t)ptr / WATCH_SIZE) % NLOCKS;
++}
++
++void
++libat_lock_1 (void *ptr)
++{
++  struct lock *l = &locks[addr_hash (ptr)];
++  IExec->Forbid();
++  if (!l->initialized)
++  {
++    IExec->InitSemaphore(&l->sem);
++    l->initialized = 1;
++  }
++  IExec->Permit();
++  IExec->ObtainSemaphore(&l->sem);
++}
++
++void
++libat_unlock_1 (void *ptr)
++{
++  struct lock *l = &locks[addr_hash (ptr)];
++  IExec->ReleaseSemaphore(&l->sem);
++}
++
++#if 0
++
++/* TODO: Implement me when needed */
++void
++libat_lock_n (void *ptr, size_t n)
++{
++}
++
++void
++libat_unlock_n (void *ptr, size_t n)
++{
++}
++
++#endif
+diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
+index 5dd0926d207f1a542a7a7ee4cc00084c3c74bdfd..50464b4a15b9188b72e12bcdc8e046044a41a2da 100644
+--- a/libatomic/configure.tgt
++++ b/libatomic/configure.tgt
+@@ -156,12 +156,16 @@ case "${target}" in
+ 
+   *-*-rtems*)
+ 	XCFLAGS="${configure_tgt_pre_target_cpu_XCFLAGS}"
+ 	config_path="rtems"
+ 	;;
+ 
++  *-*-amigaos*)
++	config_path="${config_path} amigaos"
++	;;
++
+   *-*-elf*)
+ 	# ??? No target OS.  We could be targeting bare-metal kernel-mode,
+ 	# or user-mode for some custom OS.  If the target supports TAS,
+ 	# we can build our own spinlocks, given there are no signals.
+ 	# If the target supports disabling interrupts, we can work in
+ 	# kernel-mode, given the system is not multi-processor.
+-- 
+2.11.0
+

--- a/gcc/10/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/10/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,0 +1,104 @@
+From c603fe72a604eb321cd656263caf8efa23c4b61a Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Wed, 23 May 2018 10:54:19 +0200
+Subject: [PATCH 10/33] Implement libat_lock_n() and libat_unlock_n().
+
+---
+ libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++++++++---------
+ 1 file changed, 46 insertions(+), 12 deletions(-)
+
+diff --git a/libatomic/config/amigaos/lock.c b/libatomic/config/amigaos/lock.c
+index ffd09f50095429f844bfe6bf7bec8741f56f1a28..82dd696f78cc4afa5592c5fb83f33e911c4b94a0 100644
+--- a/libatomic/config/amigaos/lock.c
++++ b/libatomic/config/amigaos/lock.c
+@@ -62,41 +62,75 @@ static struct lock locks[NLOCKS];
+ static inline uintptr_t 
+ addr_hash (void *ptr)
+ {
+   return ((uintptr_t)ptr / WATCH_SIZE) % NLOCKS;
+ }
+ 
+-void
+-libat_lock_1 (void *ptr)
++static void
++libat_lock (struct lock *l)
+ {
+-  struct lock *l = &locks[addr_hash (ptr)];
+   IExec->Forbid();
+   if (!l->initialized)
+   {
+-    IExec->InitSemaphore(&l->sem);
++    IExec->InitSemaphore (&l->sem);
+     l->initialized = 1;
+   }
+   IExec->Permit();
+-  IExec->ObtainSemaphore(&l->sem);
++  IExec->ObtainSemaphore (&l->sem);
++}
++
++static void
++libat_unlock (struct lock *l)
++{
++  IExec->ReleaseSemaphore (&l->sem);
+ }
+ 
+ void
+-libat_unlock_1 (void *ptr)
++libat_lock_1 (void *ptr)
+ {
+-  struct lock *l = &locks[addr_hash (ptr)];
+-  IExec->ReleaseSemaphore(&l->sem);
++  libat_lock (&locks[addr_hash (ptr)]);
+ }
+ 
+-#if 0
++void
++libat_unlock_1 (void *ptr)
++{
++  libat_unlock (&locks[addr_hash (ptr)]);
++}
+ 
+-/* TODO: Implement me when needed */
+ void
+ libat_lock_n (void *ptr, size_t n)
+ {
++  uintptr_t h = addr_hash (ptr);
++  size_t i = 0;
++
++  /* Don't lock more than all the locks we have.  */
++  if (n > PAGE_SIZE)
++    n = PAGE_SIZE;
++
++  do
++    {
++      libat_lock (&locks[h]);
++      if (++h == NLOCKS)
++        h = 0;
++      i += WATCH_SIZE;
++    }
++  while (i < n);
+ }
+ 
+ void
+ libat_unlock_n (void *ptr, size_t n)
+ {
++  uintptr_t h = addr_hash (ptr);
++  size_t i = 0;
++
++  if (n > PAGE_SIZE)
++    n = PAGE_SIZE;
++
++  do
++    {
++      libat_unlock (&locks[h]);
++      if (++h == NLOCKS)
++        h = 0;
++      i += WATCH_SIZE;
++    }
++  while (i < n);
+ }
+-
+-#endif
+-- 
+2.11.0
+

--- a/gcc/10/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/10/patches/0011-Pretend-C99-compatibility.patch
@@ -1,0 +1,111 @@
+From a8cd7842558290a5093c190042a4a6de1129ddc3 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Sat, 4 Mar 2017 07:39:21 +0100
+Subject: [PATCH 11/33] Pretend C99 compatibility.
+
+At least newlib is not fully C99 compatible because it doesn't expose
+various C99 function if __STRICT_ANSI__ is declared. Also it misses
+strtold() (as clib2).
+---
+ libstdc++-v3/config/os/amigaos/os_defines.h | 3 +++
+ libstdc++-v3/include/bits/basic_string.h    | 3 +++
+ libstdc++-v3/include/c_global/cstdlib       | 8 ++++++++
+ 3 files changed, 14 insertions(+)
+
+diff --git a/libstdc++-v3/config/os/amigaos/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
+index 346f063958cd7e80ebf97be4acee0bdf391cb811..6b67630b7be7102a9dfb7c104deac6293a13c017 100644
+--- a/libstdc++-v3/config/os/amigaos/os_defines.h
++++ b/libstdc++-v3/config/os/amigaos/os_defines.h
+@@ -35,9 +35,12 @@
+ 
+ // No ioctl() on AmigaOS
+ #define _GLIBCXX_NO_IOCTL 1
+ 
+ #ifdef __NEWLIB__
+ #define _GLIBCXX_USE_C99_STDINT_TR1 1
++#define _GLIBCXX_USE_C99 1
++/* Temporary until newlib behaves properly */
++#undef __STRICT_ANSI__
+ #endif
+ 
+ #endif
+diff --git a/libstdc++-v3/include/bits/basic_string.h b/libstdc++-v3/include/bits/basic_string.h
+index 0b893bcea8579f53c5331f1f8e11b28a5b425417..7479fdb50caed4413a78a0414ca63a30b63f139c 100644
+--- a/libstdc++-v3/include/bits/basic_string.h
++++ b/libstdc++-v3/include/bits/basic_string.h
+@@ -6583,15 +6583,18 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+   { return __gnu_cxx::__stoa(&std::strtof, "stof", __str.c_str(), __idx); }
+ 
+   inline double
+   stod(const string& __str, size_t* __idx = 0)
+   { return __gnu_cxx::__stoa(&std::strtod, "stod", __str.c_str(), __idx); }
+ 
++#ifndef __amigaos4__
+   inline long double
+   stold(const string& __str, size_t* __idx = 0)
+   { return __gnu_cxx::__stoa(&std::strtold, "stold", __str.c_str(), __idx); }
++#endif
++
+ #endif // _GLIBCXX_USE_C99_STDLIB
+ 
+   // DR 1261. Insufficent overloads for to_string / to_wstring
+ 
+   inline string
+   to_string(int __val)
+diff --git a/libstdc++-v3/include/c_global/cstdlib b/libstdc++-v3/include/c_global/cstdlib
+index f42db41fc5123c2e5c6d33e724d3a954d6e7f74e..8140aedb8fa5bebca8ddaef1242826cd9133e7b5 100644
+--- a/libstdc++-v3/include/c_global/cstdlib
++++ b/libstdc++-v3/include/c_global/cstdlib
+@@ -187,13 +187,17 @@ _GLIBCXX_END_NAMESPACE_VERSION
+ #undef llabs
+ #undef lldiv
+ #undef atoll
+ #undef strtoll
+ #undef strtoull
+ #undef strtof
++
++/* Neigther clib2 nor newlib offers strtoud() */
++#ifndef __amigaos4__
+ #undef strtold
++#endif
+ 
+ namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
+ {
+ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 
+ #if !_GLIBCXX_USE_C99_LONG_LONG_DYNAMIC
+@@ -226,13 +230,15 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ #if !_GLIBCXX_USE_C99_LONG_LONG_DYNAMIC
+   using ::atoll;
+   using ::strtoll;
+   using ::strtoull;
+ #endif
+   using ::strtof;
++#ifndef __amigaos4__
+   using ::strtold;
++#endif
+ 
+ _GLIBCXX_END_NAMESPACE_VERSION
+ } // namespace __gnu_cxx
+ 
+ namespace std
+ {
+@@ -246,13 +252,15 @@ namespace std
+   using ::__gnu_cxx::lldiv;
+ #endif
+   using ::__gnu_cxx::atoll;
+   using ::__gnu_cxx::strtof;
+   using ::__gnu_cxx::strtoll;
+   using ::__gnu_cxx::strtoull;
++#ifndef __amigaos4__
+   using ::__gnu_cxx::strtold;
++#endif
+ } // namespace std
+ 
+ #endif // _GLIBCXX_USE_C99_STDLIB
+ 
+ } // extern "C++"
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/10/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,0 +1,54 @@
+From b4b14e147258590e09ce9c91ca01330311f8d032 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Tue, 3 Apr 2018 19:52:01 +0200
+Subject: [PATCH 12/33] Add amigaos-stdint.h for libatomic.
+
+---
+ gcc/config.gcc                                      | 2 +-
+ gcc/config/{dragonfly-stdint.h => amigaos-stdint.h} | 7 ++++---
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+ copy gcc/config/{dragonfly-stdint.h => amigaos-stdint.h} (90%)
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index e279090d89753ab025c43972d1f6b4f74ec351a9..af40e6e6326c713913008fa1f6ef4745f4591846 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -2860,13 +2860,13 @@ or1k*-*-*)
+ 	;;
+ pdp11-*-*)
+ 	tm_file="${tm_file} newlib-stdint.h"
+ 	use_gcc_stdint=wrap
+ 	;;
+ powerpc-*-amigaos*)
+-	tm_file="${tm_file} dbxelf.h elfos.h rs6000/sysv4.h rs6000/amigaos.h"
++	tm_file="${tm_file} dbxelf.h elfos.h amigaos-stdint.h rs6000/sysv4.h rs6000/amigaos.h"
+ 	tm_p_file="${tm_p_file} rs6000/amigaos-protos.h"
+ 	extra_options="${extra_options} rs6000/sysv4.opt rs6000/amigaos.opt"
+ 	tmake_file="rs6000/t-amigaos"
+ 	extra_objs="$extra_objs amigaos.o"
+ 	use_collect2=no
+ 	;;
+diff --git a/gcc/config/dragonfly-stdint.h b/gcc/config/amigaos-stdint.h
+similarity index 90%
+copy from gcc/config/dragonfly-stdint.h
+copy to gcc/config/amigaos-stdint.h
+index 3b313e6453416098b547513bd4a6cdf62b6c35b9..854009ca098f9dff59be936425a565dd842a3cd7 100644
+--- a/gcc/config/dragonfly-stdint.h
++++ b/gcc/config/amigaos-stdint.h
+@@ -1,9 +1,10 @@
+-/* Definitions for <stdint.h> types for DragonFly systems.
+-   Copyright (C) 2014-2020 Free Software Foundation, Inc.
+-   Contributed by John Marino <gnugcc@marino.st>
++/* Definitions for <stdint.h> types for AmigaOS systems.
++   Copyright (C) 2014-2016 Free Software Foundation, Inc.
++   Based on the types of the dragon fly bsd that was
++   contributed by John Marino <gnugcc@marino.st>
+ 
+ This file is part of GCC.
+ 
+ GCC is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3, or (at your option)
+-- 
+2.11.0
+

--- a/gcc/10/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/10/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,0 +1,165 @@
+From 8706501bad95e45532dea82c853c7322ef4f0cf8 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Wed, 4 Apr 2018 22:48:33 +0200
+Subject: [PATCH 13/33] Rerun make maint-deps in libiberty.
+
+---
+ libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------
+ 1 file changed, 22 insertions(+), 14 deletions(-)
+
+diff --git a/libiberty/Makefile.in b/libiberty/Makefile.in
+index a7d9c6fd8b9780d2cceabd1d8cdd84a29bccf93f..698c41fdd1927931cb6b408d24db199598d32d86 100644
+--- a/libiberty/Makefile.in
++++ b/libiberty/Makefile.in
+@@ -564,13 +564,14 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/atexit.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/atexit.c $(OUTPUT_OPTION)
+ 
+ ./basename.$(objext): $(srcdir)/basename.c config.h $(INCDIR)/ansidecl.h \
+-	$(INCDIR)/libiberty.h $(INCDIR)/safe-ctype.h
++	$(INCDIR)/filenames.h $(INCDIR)/hashtab.h $(INCDIR)/libiberty.h \
++	$(INCDIR)/safe-ctype.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/basename.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/basename.c -o noasan/$@; \
+ 	else true; fi
+@@ -771,13 +772,13 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/filedescriptor.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/filedescriptor.c $(OUTPUT_OPTION)
+ 
+ 
+ ./filename_cmp.$(objext): $(srcdir)/filename_cmp.c config.h $(INCDIR)/ansidecl.h \
+-	$(INCDIR)/filenames.h $(INCDIR)/hashtab.h \
++	$(INCDIR)/filenames.h $(INCDIR)/hashtab.h $(INCDIR)/libiberty.h \
+ 	$(INCDIR)/safe-ctype.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/filename_cmp.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/filename_cmp.c -o noasan/$@; \
+@@ -938,23 +939,25 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/lrealpath.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/lrealpath.c $(OUTPUT_OPTION)
+ 
+ ./make-relative-prefix.$(objext): $(srcdir)/make-relative-prefix.c config.h \
+-	$(INCDIR)/ansidecl.h $(INCDIR)/libiberty.h
++	$(INCDIR)/ansidecl.h $(INCDIR)/filenames.h $(INCDIR)/hashtab.h \
++	$(INCDIR)/libiberty.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/make-relative-prefix.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/make-relative-prefix.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/make-relative-prefix.c $(OUTPUT_OPTION)
+ 
+ ./make-temp-file.$(objext): $(srcdir)/make-temp-file.c config.h \
+-	$(INCDIR)/ansidecl.h $(INCDIR)/libiberty.h
++	$(INCDIR)/ansidecl.h $(INCDIR)/filenames.h $(INCDIR)/hashtab.h \
++	$(INCDIR)/libiberty.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/make-temp-file.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/make-temp-file.c -o noasan/$@; \
+ 	else true; fi
+@@ -1076,12 +1079,22 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/partition.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/partition.c $(OUTPUT_OPTION)
+ 
++./pex-amigaos.$(objext): $(srcdir)/pex-amigaos.c config.h $(INCDIR)/ansidecl.h \
++	$(INCDIR)/libiberty.h $(srcdir)/pex-common.h
++	if [ x"$(PICFLAG)" != x ]; then \
++	  $(COMPILE.c) $(PICFLAG) $(srcdir)/pex-amigaos.c -o pic/$@; \
++	else true; fi
++	if [ x"$(NOASANFLAG)" != x ]; then \
++	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/pex-amigaos.c -o noasan/$@; \
++	else true; fi
++	$(COMPILE.c) $(srcdir)/pex-amigaos.c $(OUTPUT_OPTION)
++
+ ./pex-common.$(objext): $(srcdir)/pex-common.c config.h $(INCDIR)/ansidecl.h \
+ 	$(INCDIR)/libiberty.h $(srcdir)/pex-common.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/pex-common.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+@@ -1118,13 +1131,14 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/pex-one.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/pex-one.c $(OUTPUT_OPTION)
+ 
+ ./pex-unix.$(objext): $(srcdir)/pex-unix.c config.h $(INCDIR)/ansidecl.h \
+-	$(INCDIR)/libiberty.h $(srcdir)/pex-common.h
++	$(INCDIR)/environ.h $(INCDIR)/libiberty.h \
++	$(srcdir)/pex-common.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/pex-unix.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/pex-unix.c -o noasan/$@; \
+ 	else true; fi
+@@ -1137,19 +1151,12 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/pex-win32.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/pex-win32.c $(OUTPUT_OPTION)
+ 
+-./pex-amigaos.$(objext): $(srcdir)/pex-amigaos.c config.h $(INCDIR)/ansidecl.h \
+-	$(INCDIR)/libiberty.h $(srcdir)/pex-common.h
+-	if [ x"$(PICFLAG)" != x ]; then \
+-	  $(COMPILE.c) $(PICFLAG) $(srcdir)/pex-amigaos.c -o pic/$@; \
+-	else true; fi
+-	$(COMPILE.c) $(srcdir)/pex-amigaos.c $(OUTPUT_OPTION)
+-
+ ./pexecute.$(objext): $(srcdir)/pexecute.c config.h $(INCDIR)/ansidecl.h \
+ 	$(INCDIR)/libiberty.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/pexecute.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+@@ -1231,13 +1238,14 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/safe-ctype.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/safe-ctype.c $(OUTPUT_OPTION)
+ 
+-./setenv.$(objext): $(srcdir)/setenv.c config.h $(INCDIR)/ansidecl.h
++./setenv.$(objext): $(srcdir)/setenv.c config.h $(INCDIR)/ansidecl.h \
++	$(INCDIR)/environ.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/setenv.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/setenv.c -o noasan/$@; \
+ 	else true; fi
+@@ -1682,13 +1690,13 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/xexit.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/xexit.c $(OUTPUT_OPTION)
+ 
+ ./xmalloc.$(objext): $(srcdir)/xmalloc.c config.h $(INCDIR)/ansidecl.h \
+-	$(INCDIR)/libiberty.h
++	$(INCDIR)/environ.h $(INCDIR)/libiberty.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/xmalloc.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/xmalloc.c -o noasan/$@; \
+ 	else true; fi
+-- 
+2.11.0
+

--- a/gcc/10/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/10/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,0 +1,208 @@
+From 1fca9e244453b4ade8501665bfbc114a533f5ccd Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Wed, 4 Apr 2018 23:50:48 +0200
+Subject: [PATCH 14/33] Add custom implementation of various env-related
+ functions.
+
+No official clib does support unsetenv() but this is required by newer gcc.
+While there are custom implementation of setenv() and unsetenv(), it is
+unclear how their implementation interacts with the other ones that are
+part of the clib like putenv().
+---
+ libiberty/Makefile.in      | 13 ++++++--
+ libiberty/configure        | 11 +++++++
+ libiberty/configure.ac     |  6 ++++
+ libiberty/setenv-amigaos.c | 74 ++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 102 insertions(+), 2 deletions(-)
+ create mode 100644 libiberty/setenv-amigaos.c
+
+diff --git a/libiberty/Makefile.in b/libiberty/Makefile.in
+index 698c41fdd1927931cb6b408d24db199598d32d86..b34b9cb70584fc3d02d4935d8ed3646313468d54 100644
+--- a/libiberty/Makefile.in
++++ b/libiberty/Makefile.in
+@@ -144,13 +144,13 @@ CFILES = alloca.c argv.c asprintf.c atexit.c				\
+ 	 pex-common.c pex-djgpp.c pex-msdos.c pex-one.c			\
+ 	 pex-unix.c pex-win32.c						\
+ 	 pex-amigaos.c		\
+          physmem.c putenv.c						\
+ 	random.c regex.c rename.c rindex.c				\
+ 	rust-demangle.c							\
+-	safe-ctype.c setenv.c setproctitle.c sha1.c sigsetmask.c        \
++	safe-ctype.c setenv.c setenv-amigaos.c setproctitle.c sha1.c sigsetmask.c        \
+ 	 simple-object.c simple-object-coff.c simple-object-elf.c	\
+ 	 simple-object-mach-o.c simple-object-xcoff.c			\
+          snprintf.c sort.c						\
+ 	 spaces.c splay-tree.c stack-limit.c stpcpy.c stpncpy.c		\
+ 	 strcasecmp.c strchr.c strdup.c strerror.c strncasecmp.c	\
+ 	 strncmp.c strrchr.c strsignal.c strstr.c strtod.c strtol.c	\
+@@ -216,13 +216,13 @@ CONFIGURED_OFILES = ./asprintf.$(objext) ./atexit.$(objext)		\
+ 	 ./mempcpy.$(objext) ./memset.$(objext) ./mkstemps.$(objext)	\
+ 	./pex-amigaos.$(objext)						\
+ 	./pex-djgpp.$(objext) ./pex-msdos.$(objext)			\
+ 	 ./pex-unix.$(objext) ./pex-win32.$(objext)			\
+ 	 ./putenv.$(objext)						\
+ 	./random.$(objext) ./rename.$(objext) ./rindex.$(objext)	\
+-	./setenv.$(objext) 						\
++	./setenv.$(objext) ./setenv-amigaos.$(objext) 			\
+ 	 ./setproctitle.$(objext)					\
+ 	 ./sigsetmask.$(objext) ./snprintf.$(objext)			\
+ 	 ./stpcpy.$(objext) ./stpncpy.$(objext) ./strcasecmp.$(objext)	\
+ 	 ./strchr.$(objext) ./strdup.$(objext) ./strncasecmp.$(objext)	\
+ 	 ./strncmp.$(objext) ./strndup.$(objext) ./strnlen.$(objext)	\
+ 	 ./strrchr.$(objext) ./strstr.$(objext) ./strtod.$(objext)	\
+@@ -1238,12 +1238,21 @@ $(CONFIGURED_OFILES): stamp-picdir stamp-noasandir
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/safe-ctype.c -o noasan/$@; \
+ 	else true; fi
+ 	$(COMPILE.c) $(srcdir)/safe-ctype.c $(OUTPUT_OPTION)
+ 
++./setenv-amigaos.$(objext): $(srcdir)/setenv-amigaos.c
++	if [ x"$(PICFLAG)" != x ]; then \
++	  $(COMPILE.c) $(PICFLAG) $(srcdir)/setenv-amigaos.c -o pic/$@; \
++	else true; fi
++	if [ x"$(NOASANFLAG)" != x ]; then \
++	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/setenv-amigaos.c -o noasan/$@; \
++	else true; fi
++	$(COMPILE.c) $(srcdir)/setenv-amigaos.c $(OUTPUT_OPTION)
++
+ ./setenv.$(objext): $(srcdir)/setenv.c config.h $(INCDIR)/ansidecl.h \
+ 	$(INCDIR)/environ.h
+ 	if [ x"$(PICFLAG)" != x ]; then \
+ 	  $(COMPILE.c) $(PICFLAG) $(srcdir)/setenv.c -o pic/$@; \
+ 	else true; fi
+ 	if [ x"$(NOASANFLAG)" != x ]; then \
+diff --git a/libiberty/configure b/libiberty/configure
+index 7cbaca011bbc042bd035e9f3969c1b155b802afd..882dbd3576f9179c681a1c3a197573c50ac694ae 100755
+--- a/libiberty/configure
++++ b/libiberty/configure
+@@ -6545,12 +6545,23 @@ if test -z "${setobjs}"; then
+   *-*-android*)
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
++  *-*-amigaos*)
++    # current newlib lacks unsetenv(), so we custom versions
++    # of setenv() and unsetenv().
++    case " $LIBOBJS " in
++  *" setenv-amigaos.$ac_objext "* ) ;;
++  *) LIBOBJS="$LIBOBJS setenv-amigaos.$ac_objext"
++ ;;
++esac
++
++    ;;
++
+   *-*-mingw32*)
+     # Under mingw32, sys_nerr and sys_errlist exist, but they are
+     # macros, so the test below won't find them.
+     libiberty_cv_var_sys_nerr=yes
+     libiberty_cv_var_sys_errlist=yes
+     ;;
+diff --git a/libiberty/configure.ac b/libiberty/configure.ac
+index 106983ac087aa78ecc9b9e3f38514eacdb53b8f1..4072943f9814848fa0bab1cda1f5e6629d6a1c87 100644
+--- a/libiberty/configure.ac
++++ b/libiberty/configure.ac
+@@ -607,12 +607,18 @@ if test -z "${setobjs}"; then
+   *-*-android*)
+     # On android, getpagesize is defined in unistd.h as a static inline
+     # function, which AC_CHECK_FUNCS does not handle properly.
+     ac_cv_func_getpagesize=yes
+     ;;
+ 
++  *-*-amigaos*)
++    # current newlib lacks unsetenv(), so we custom versions
++    # of setenv() and unsetenv().
++    AC_LIBOBJ([setenv-amigaos])
++    ;;
++
+   *-*-mingw32*)
+     # Under mingw32, sys_nerr and sys_errlist exist, but they are
+     # macros, so the test below won't find them.
+     libiberty_cv_var_sys_nerr=yes
+     libiberty_cv_var_sys_errlist=yes
+     ;;
+diff --git a/libiberty/setenv-amigaos.c b/libiberty/setenv-amigaos.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..dc9a460737538d74558bb43c21c21e61aa5a3305
+--- /dev/null
++++ b/libiberty/setenv-amigaos.c
+@@ -0,0 +1,74 @@
++/* A custom implementation of various env functions
++ *
++ * This is necessary as no official clib supports unsetenv()
++ * but setenv().
++ */
++#define __USE_INLINE__
++
++#include <proto/dos.h>
++#include <proto/exec.h>
++
++#include <string.h>
++
++
++#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++
++int
++setenv (const char *name, const char *value, int replace)
++{
++	if (!replace)
++	{
++		if (FindVar(name, GVF_LOCAL_ONLY))
++		{
++			return 0;
++		}
++	}
++
++	return !SetVar(name, value, -1, GVF_LOCAL_ONLY);
++}
++
++void
++unsetenv (const char *name)
++{
++	DeleteVar(name, GVF_LOCAL_ONLY);
++}
++
++void
++putenv (char *str)
++{
++	int i;
++
++	if (str[0] == '=')
++	{
++		return;
++	}
++
++	for (i=0; str[i]; i++)
++	{
++		if (str[i] == '=')
++		{
++			char *name = (char*)AllocVec(i + 1, MEMF_ANY);
++			if (name)
++			{
++				strncpy(name, str, i - 1);
++				name[i] = 0;
++
++				setenv(name, &str[i] + 1, 1);
++				FreeVec(name);
++				return;
++			}
++		}
++	}
++}
++
++char *
++getenv (const char *name)
++{
++	struct LocalVar *lvar;
++
++	if (!(lvar = FindVar(name, GVF_LOCAL_ONLY)))
++	{
++		return NULL;
++	}
++	return lvar->lv_Value;
++}
+-- 
+2.11.0
+

--- a/gcc/10/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/10/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,0 +1,45 @@
+From dfa1bf18e166b647c1c876430847cb59675138c3 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Thu, 5 Apr 2018 19:56:45 +0200
+Subject: [PATCH 15/33] Define va_startlinear and va_getlinearva.
+
+These were usually defined in the clibs' stdarg.h. As we have now
+changed the include path order, clibs' stdarg.h is never included.
+---
+ gcc/ginclude/stdarg.h | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/gcc/ginclude/stdarg.h b/gcc/ginclude/stdarg.h
+index 6b122f9ddcf8c362db9c1f66c07965740f94820e..a6c52d17e9ebf8ffe10379ab1c2f5eeb5d31fccc 100644
+--- a/gcc/ginclude/stdarg.h
++++ b/gcc/ginclude/stdarg.h
+@@ -61,12 +61,26 @@ typedef __builtin_va_list __gnuc_va_list;
+    which is safe because it is reserved for the implementation.  */
+ 
+ #ifdef _BSD_VA_LIST
+ #undef _BSD_VA_LIST
+ #endif
+ 
++#if defined(__amigaos4__)
++
++/* AmigaOS4 provides support for var args that all pushed on the stack.
++ * These are the helper macros. */
++#ifndef va_startlinear
++#define va_startlinear(AP,ARG) va_start(AP,ARG)
++#endif
++
++#ifndef va_getlinearva
++#define va_getlinearva(AP,TYPE) ((TYPE)__builtin_getlinearva(AP))
++#endif
++
++#endif
++
+ #if defined(__svr4__) || (defined(_SCO_DS) && !defined(__VA_LIST))
+ /* SVR4.2 uses _VA_LIST for an internal alias for va_list,
+    so we must avoid testing it and setting it here.
+    SVR4 uses _VA_LIST as a flag in stdarg.h, but we should
+    have no conflict with that.  */
+ #ifndef _VA_LIST_
+-- 
+2.11.0
+

--- a/gcc/10/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/10/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,0 +1,32 @@
+From ad98279dd914764418d830c5a71af8942d0eed3d Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Tue, 17 Apr 2018 22:02:09 +0200
+Subject: [PATCH 16/33] Fix r2 restoring in the epilog of baserel-restoring
+ functions.
+
+---
+ gcc/config/rs6000/rs6000-logue.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gcc/config/rs6000/rs6000-logue.c b/gcc/config/rs6000/rs6000-logue.c
+index 93028165d19419c2648e8d34edff345059bb8e38..cf0ec646bbc1ee27471cec591215cc263e099375 100644
+--- a/gcc/config/rs6000/rs6000-logue.c
++++ b/gcc/config/rs6000/rs6000-logue.c
+@@ -4878,13 +4878,13 @@ rs6000_emit_epilogue (enum epilogue_type epilogue_type)
+ #ifdef TARGET_BASEREL
+   if (info->baserel_save_p && TARGET_BASEREL)
+     {
+       rtx addr, mem, reg;
+ 
+       /* Restore r2 */
+-      addr = gen_rtx_PLUS (Pmode, gen_rtx_REG (Pmode, 12),
++      addr = gen_rtx_PLUS (Pmode, frame_reg_rtx,
+ 			   GEN_INT (info->baserel_save_offset + frame_off)); /* or sp_off? */
+       mem = gen_frame_mem (reg_mode, addr);
+ 
+       reg = gen_rtx_REG (reg_mode, 2);
+       emit_move_insn (reg, mem);
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/10/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,0 +1,81 @@
+From 7ef854c8a2bf4a57b3e26aaa308cc15fe9fc5a4e Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Thu, 19 Apr 2018 21:00:30 +0200
+Subject: [PATCH 17/33] Avoid section anchors in the baserel mode.
+
+---
+ gcc/config/rs6000/amigaos-protos.h |  1 +
+ gcc/config/rs6000/amigaos.c        | 17 +++++++++++++++++
+ gcc/config/rs6000/amigaos.h        |  7 +++++++
+ 3 files changed, 25 insertions(+)
+
+diff --git a/gcc/config/rs6000/amigaos-protos.h b/gcc/config/rs6000/amigaos-protos.h
+index 3b8c994cdbd192eaf7112c780f0106a4d96cbb90..5a0b8006e2f6b6b8877e092994567233077594f1 100644
+--- a/gcc/config/rs6000/amigaos-protos.h
++++ b/gcc/config/rs6000/amigaos-protos.h
+@@ -34,9 +34,10 @@ extern tree amigaos_handle_lineartags_attribute (tree *, tree, tree, int, bool*)
+ extern tree amigaos_handle_baserel_restore_attribute (tree *, tree, tree, int, bool*);
+ extern tree amigaos_handle_force_no_baserel_attribute (tree *, tree, tree, int, bool*);
+ extern tree amigaos_handle_check68kfuncptr_attribute (tree *, tree, tree, int, bool*);
+ extern rtx amigaos_legitimize_baserel_address (rtx addr);
+ extern int amigaos_baserel_operand(rtx x);
+ extern int amigaos_not_baserel_tree_p(tree decl);
++extern bool amigaos_use_anchors_for_symbol_p (const_rtx symbol);
+ 
+ //#endif /* TREE_CODE */
+ //#endif /* RTX_CODE */
+diff --git a/gcc/config/rs6000/amigaos.c b/gcc/config/rs6000/amigaos.c
+index 85c03f28e37d64865360692a14fcc8a197b55395..a7cfaaa2ca4ac913d78e3240aa994a65c2e4b03f 100644
+--- a/gcc/config/rs6000/amigaos.c
++++ b/gcc/config/rs6000/amigaos.c
+@@ -495,6 +495,23 @@ amigaos_handle_check68kfuncptr_attribute (tree *node, tree name,
+ 	       IDENTIFIER_POINTER (name));
+       *no_add_attrs = true;
+     }
+ 
+   return NULL_TREE;
+ }
++
++/* Addititionally to the normal anchor (optimization) suppression, suppress
++ * it also in the baserel mode because we don't adjust the anchor access yet.
++ * It would make some sence to support anchros also in baserel mode, because
++ * baserel access is 32 bit.
++ */
++bool
++amigaos_use_anchors_for_symbol_p (const_rtx symbol)
++{
++  if (TARGET_BASEREL)
++  {
++    /* FIXME: For force_no_baserel symbols we could possibly go for anchors */
++    return false;
++  }
++  /* Also check the normal reasons for suppressing.  */
++  return default_use_anchors_for_symbol_p (symbol);
++}
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index 1153ece337930f7bbf5f9978bf6f3faf2138bda6..d339c4280b67d863ec9c60dd38230d7bb2549345 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -400,12 +400,19 @@ do                                   \
+   { "lineartags", 0, 0, false, true, true, false, amigaos_handle_lineartags_attribute, NULL}, \
+   { "baserel_restore", 0, 0, false, true, true, false, amigaos_handle_baserel_restore_attribute, NULL }, \
+   { "force_no_baserel", 0, 0, true, false, false, false, amigaos_handle_force_no_baserel_attribute, NULL }, \
+   { "check68kfuncptr", 0, 0, false, true, true, false, amigaos_handle_check68kfuncptr_attribute, NULL }
+ 
+ /* Overrides */
++
++/* We don't want to use section anchors in baserel mode so we have to override
++ * the decision functions
++ */
++#undef TARGET_USE_ANCHORS_FOR_SYMBOL_P
++#define TARGET_USE_ANCHORS_FOR_SYMBOL_P amigaos_use_anchors_for_symbol_p
++
+ /*
+ #undef INIT_CUMULATIVE_ARGS
+ #define INIT_CUMULATIVE_ARGS(CUM, FNTYPE, LIBNAME, INDIRECT, N_NAMED_ARGS) \
+   amigaos_init_cumulative_args (&CUM, FNTYPE, LIBNAME, FALSE, N_NAMED_ARGS)
+ 
+ #undef INIT_CUMULATIVE_INCOMING_ARGS
+-- 
+2.11.0
+

--- a/gcc/10/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/10/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,0 +1,33 @@
+From 11d4b4699a52475732529a1b9847f60f45855d12 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Fri, 20 Apr 2018 20:04:30 +0200
+Subject: [PATCH 18/33] Respect -nostdinc also for SDK includes.
+
+---
+ gcc/config/rs6000/amigaos.h | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index d339c4280b67d863ec9c60dd38230d7bb2549345..f88bfe5f879cb4ca09f067d907ec36ef0b4c2da3 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -261,15 +261,13 @@
+ %{mcrt=clib2|mcrt=clib2-ts: %(cpp_clib2); \
+ mcrt=ixemul: %(cpp_ixemul); \
+ mcrt=libnix: %(cpp_libnix); \
+ mcrt=newlib: %(cpp_newlib); \
+ mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
+ : %eInvalid C runtime library} \
+--idirafter %(base_sdk)include/include_h \
+--idirafter %(base_sdk)include/netinclude \
+--idirafter %(base_sdk)local/common/include \
++%{!nostdinc: -idirafter %(base_sdk)include/include_h -idirafter %(base_sdk)include/netinclude -idirafter %(base_sdk)local/common/include} \
+ %{mbaserel: %{msdata|msdata=default|msdata=sysv: %e-mbaserel and -msdata options are incompatible}} \
+ %{newlib: %e-newlib is obsolete, use -mcrt=newlib instead}"
+ 
+ #undef LINK_SPEC
+ #define LINK_SPEC "\
+ --defsym __amigaos4__=1 \
+-- 
+2.11.0
+

--- a/gcc/10/patches/0019-Add-_Static_warning.patch
+++ b/gcc/10/patches/0019-Add-_Static_warning.patch
@@ -1,0 +1,141 @@
+From 23398fdb5961282c90959207a50357c14ee1860f Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Tue, 24 Apr 2018 22:46:21 +0200
+Subject: [PATCH 19/33] Add _Static_warning().
+
+This acts very similar to _Static_assert() but produces a warning
+rather than an compiler error.
+---
+ gcc/c-family/c-common.c |  1 +
+ gcc/c-family/c-common.h |  1 +
+ gcc/c/c-parser.c        | 12 ++++++++++--
+ gcc/cp/parser.c         |  3 ++-
+ 4 files changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/gcc/c-family/c-common.c b/gcc/c-family/c-common.c
+index 064c2f263f03b52e953d32d06974e45cc4fd157b..5f88b849d8597d9dae14a1fa6872498d403ab365 100644
+--- a/gcc/c-family/c-common.c
++++ b/gcc/c-family/c-common.c
+@@ -356,12 +356,13 @@ const struct c_common_resword c_common_reswords[] =
+   { "_Decimal64",       RID_DFLOAT64,  D_CONLY },
+   { "_Decimal128",      RID_DFLOAT128, D_CONLY },
+   { "_Fract",           RID_FRACT,     D_CONLY | D_EXT },
+   { "_Accum",           RID_ACCUM,     D_CONLY | D_EXT },
+   { "_Sat",             RID_SAT,       D_CONLY | D_EXT },
+   { "_Static_assert",   RID_STATIC_ASSERT, D_CONLY },
++  { "_Static_warning",  RID_STATIC_WARNING, D_CONLY | D_EXT},
+   { "_Noreturn",        RID_NORETURN,  D_CONLY },
+   { "_Generic",         RID_GENERIC,   D_CONLY },
+   { "_Thread_local",    RID_THREAD,    D_CONLY },
+   { "__FUNCTION__",	RID_FUNCTION_NAME, 0 },
+   { "__PRETTY_FUNCTION__", RID_PRETTY_FUNCTION_NAME, 0 },
+   { "__alignof",	RID_ALIGNOF,	0 },
+diff --git a/gcc/c-family/c-common.h b/gcc/c-family/c-common.h
+index ed39b7764bfe16918f1879549026721cbf6a78f9..49a4eb5674722ddcdc57960b8baa11a2a7b15dc2 100644
+--- a/gcc/c-family/c-common.h
++++ b/gcc/c-family/c-common.h
+@@ -102,12 +102,13 @@ enum rid
+   RID_ASM,       RID_TYPEOF,   RID_ALIGNOF,  RID_ATTRIBUTE,  RID_VA_ARG,
+   RID_EXTENSION, RID_IMAGPART, RID_REALPART, RID_LABEL,      RID_CHOOSE_EXPR,
+   RID_TYPES_COMPATIBLE_P,      RID_BUILTIN_COMPLEX,	     RID_BUILTIN_SHUFFLE,
+   RID_BUILTIN_CONVERTVECTOR,   RID_BUILTIN_TGMATH,
+   RID_BUILTIN_HAS_ATTRIBUTE,
+   RID_DFLOAT32, RID_DFLOAT64, RID_DFLOAT128,
++  RID_STATIC_WARNING,
+ 
+   /* TS 18661-3 keywords, in the same sequence as the TI_* values.  */
+   RID_FLOAT16,
+   RID_FLOATN_NX_FIRST = RID_FLOAT16,
+   RID_FLOAT32,
+   RID_FLOAT64,
+diff --git a/gcc/c/c-parser.c b/gcc/c/c-parser.c
+index 1e9fe21e3cf80790d70081e518f266d4d3d497af..9e68fbab05edfec41c8a0f59a09ff438c659ad8d 100644
+--- a/gcc/c/c-parser.c
++++ b/gcc/c/c-parser.c
+@@ -831,13 +831,13 @@ c_token_starts_declspecs (c_token *token)
+    including standard attributes) or a static assertion, false
+    otherwise.  */
+ static bool
+ c_token_starts_declaration (c_token *token)
+ {
+   if (c_token_starts_declspecs (token)
+-      || token->keyword == RID_STATIC_ASSERT)
++      || token->keyword == RID_STATIC_ASSERT || token->keyword == RID_STATIC_WARNING)
+     return true;
+   else
+     return false;
+ }
+ 
+ /* Return true if the next token from PARSER can start declaration
+@@ -1937,12 +1937,18 @@ c_parser_declaration_or_fndef (c_parser *parser, bool fndef_ok,
+   if (static_assert_ok
+       && c_parser_next_token_is_keyword (parser, RID_STATIC_ASSERT))
+     {
+       c_parser_static_assert_declaration (parser);
+       return;
+     }
++  if (static_assert_ok
++      && c_parser_next_token_is_keyword (parser, RID_STATIC_WARNING))
++    {
++      c_parser_static_assert_declaration (parser);
++      return;
++    }
+   specs = build_null_declspecs ();
+ 
+   /* Handle any standard attributes parsed in the caller.  */
+   if (have_attrs)
+     {
+       declspecs_add_attrs (here, specs, attrs);
+@@ -2639,13 +2645,15 @@ static void
+ c_parser_static_assert_declaration_no_semi (c_parser *parser)
+ {
+   location_t assert_loc, value_loc;
+   tree value;
+   tree string = NULL_TREE;
+ 
+-  gcc_assert (c_parser_next_token_is_keyword (parser, RID_STATIC_ASSERT));
++  bool warning = c_parser_next_token_is_keyword (parser, RID_STATIC_WARNING);
++
++  gcc_assert (c_parser_next_token_is_keyword (parser, RID_STATIC_ASSERT) || warning);
+   assert_loc = c_parser_peek_token (parser)->location;
+   if (flag_isoc99)
+     pedwarn_c99 (assert_loc, OPT_Wpedantic,
+ 		 "ISO C99 does not support %<_Static_assert%>");
+   else
+     pedwarn_c99 (assert_loc, OPT_Wpedantic,
+diff --git a/gcc/cp/parser.c b/gcc/cp/parser.c
+index 1f4a28ff7c0c14c8aab08da07dc0bc3024086531..4e2dc9b37f7972beda895b56c0b05913b7ff5619 100644
+--- a/gcc/cp/parser.c
++++ b/gcc/cp/parser.c
+@@ -151,12 +151,13 @@ enum required_token {
+   RT_NEW, /* new */
+   RT_DELETE, /* delete */
+   RT_RETURN, /* return */
+   RT_WHILE, /* while */
+   RT_EXTERN, /* extern */
+   RT_STATIC_ASSERT, /* static_assert */
++  RT_STATIC_WARNING, /* static_warning */
+   RT_DECLTYPE, /* decltype */
+   RT_OPERATOR, /* operator */
+   RT_CLASS, /* class */
+   RT_TEMPLATE, /* template */
+   RT_NAMESPACE, /* namespace */
+   RT_USING, /* using */
+@@ -13566,13 +13567,13 @@ cp_parser_block_declaration (cp_parser *parser,
+       cp_parser_skip_to_end_of_statement (parser);
+       /* If the next token is now a `;', consume it.  */
+       if (cp_lexer_next_token_is (parser->lexer, CPP_SEMICOLON))
+ 	cp_lexer_consume_token (parser->lexer);
+     }
+   /* If the next token is `static_assert' we have a static assertion.  */
+-  else if (token1->keyword == RID_STATIC_ASSERT)
++  else if (token1->keyword == RID_STATIC_ASSERT || token1->keyword == RID_STATIC_WARNING)
+     cp_parser_static_assert (parser, /*member_p=*/false);
+   /* Anything else must be a simple-declaration.  */
+   else
+     cp_parser_simple_declaration (parser, !statement_p,
+ 				  /*maybe_range_for_decl*/NULL);
+ }
+-- 
+2.11.0
+

--- a/gcc/10/patches/0020-Rename-lineartags-to-checktags.patch
+++ b/gcc/10/patches/0020-Rename-lineartags-to-checktags.patch
@@ -1,0 +1,114 @@
+From 3f98998c2447c96907504ef5e295d71754dd550f Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Fri, 27 Apr 2018 22:48:18 +0200
+Subject: [PATCH 20/33] Rename lineartags to checktags.
+
+The name lineartags would imply linearvarargs but this is not implemented
+or necessary.
+---
+ gcc/c/c-typeck.c                   | 6 +++---
+ gcc/config/rs6000/amigaos-protos.h | 2 +-
+ gcc/config/rs6000/amigaos.c        | 4 ++--
+ gcc/config/rs6000/amigaos.h        | 3 ++-
+ 4 files changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/gcc/c/c-typeck.c b/gcc/c/c-typeck.c
+index 5cf86f2c26902751c9f2d4e6e6c2b83ea97495f8..830221cedd8f76f6c540d0b0e48aaf6016a6557c 100644
+--- a/gcc/c/c-typeck.c
++++ b/gcc/c/c-typeck.c
+@@ -3489,14 +3489,14 @@ convert_arguments (location_t loc, vec<location_t> arg_loc, tree typelist,
+   bool error_args = false;
+   const bool type_generic = fundecl
+     && lookup_attribute ("type generic", TYPE_ATTRIBUTES (TREE_TYPE (fundecl)));
+   bool type_generic_remove_excess_precision = false;
+   bool type_generic_overflow_p = false;
+   tree selector;
+-  const bool lineartags = fundecl
+-    && lookup_attribute ("lineartags", TYPE_ATTRIBUTES (TREE_TYPE (fundecl)));
++  const bool checktags = fundecl
++    && lookup_attribute ("checktags", TYPE_ATTRIBUTES (TREE_TYPE (fundecl)));
+ 
+   /* Change pointer to function to the function itself for
+      diagnostics.  */
+   if (TREE_CODE (function) == ADDR_EXPR
+       && TREE_CODE (TREE_OPERAND (function, 0)) == FUNCTION_DECL)
+     function = TREE_OPERAND (function, 0);
+@@ -3658,13 +3658,13 @@ convert_arguments (location_t loc, vec<location_t> arg_loc, tree typelist,
+ 
+       /* If this is a function call with linear tags try to improve the expected
+        * type on base of recorded tag <-> type mapping, but only if we don't know
+        * the expected type (e.g. on a var) or if the expected type is an integer.
+        * The latter case usually happens on the first tag item.
+        */
+-      if (lineartags && (type == NULL_TREE || TREE_CODE(type) == INTEGER_TYPE))
++      if (checktags && (type == NULL_TREE || TREE_CODE(type) == INTEGER_TYPE))
+         {
+           extern tree amigaos_get_type_associated_tagtype(tree type);
+ 
+           if (prev_tagtype)
+             {
+               type = prev_tagtype;
+diff --git a/gcc/config/rs6000/amigaos-protos.h b/gcc/config/rs6000/amigaos-protos.h
+index 5a0b8006e2f6b6b8877e092994567233077594f1..70351c90a0189cf5032253cb413baf8dc9b9fe43 100644
+--- a/gcc/config/rs6000/amigaos-protos.h
++++ b/gcc/config/rs6000/amigaos-protos.h
+@@ -27,13 +27,13 @@ extern void amigaos_function_arg_advance (CUMULATIVE_ARGS *, enum machine_mode,
+ extern struct rtx_def *amigaos_function_arg (CUMULATIVE_ARGS *, enum machine_mode, tree, int);
+ extern void amigaos_expand_builtin_va_start (tree valist, rtx nextarg);
+ extern struct rtx_def *amigaos_expand_builtin_saveregs (void);
+ extern void amigaos_init_builtins (void);
+ extern rtx amigaos_expand_builtin (tree, rtx, rtx, enum machine_mode, int, bool*);
+ extern tree amigaos_handle_linearvarargs_attribute (tree *, tree, tree, int, bool*);
+-extern tree amigaos_handle_lineartags_attribute (tree *, tree, tree, int, bool*);
++extern tree amigaos_handle_checktags_attribute (tree *, tree, tree, int, bool*);
+ extern tree amigaos_handle_baserel_restore_attribute (tree *, tree, tree, int, bool*);
+ extern tree amigaos_handle_force_no_baserel_attribute (tree *, tree, tree, int, bool*);
+ extern tree amigaos_handle_check68kfuncptr_attribute (tree *, tree, tree, int, bool*);
+ extern rtx amigaos_legitimize_baserel_address (rtx addr);
+ extern int amigaos_baserel_operand(rtx x);
+ extern int amigaos_not_baserel_tree_p(tree decl);
+diff --git a/gcc/config/rs6000/amigaos.c b/gcc/config/rs6000/amigaos.c
+index a7cfaaa2ca4ac913d78e3240aa994a65c2e4b03f..ad9b4897dcb6df114c1a890bbbf6618a2fe72369 100644
+--- a/gcc/config/rs6000/amigaos.c
++++ b/gcc/config/rs6000/amigaos.c
+@@ -346,15 +346,15 @@ amigaos_handle_linearvarargs_attribute (tree *node, tree name,
+       *no_add_attrs = true;
+     }
+ 
+   return NULL_TREE;
+ }
+ 
+-/* Handle a lineartags attribute. This enables tag verifications */
++/* Handle a checktags attribute. This enables tag verifications */
+ tree
+-amigaos_handle_lineartags_attribute (tree *node, tree name, tree args, int flags ATTRIBUTE_UNUSED, bool *no_add_attrs)
++amigaos_handle_checktags_attribute (tree *node, tree name, tree args, int flags ATTRIBUTE_UNUSED, bool *no_add_attrs)
+ {
+   if (TREE_CODE (*node) != FUNCTION_TYPE)
+     {
+       warning (0, "%s attribute only applies to functions",
+ 	       IDENTIFIER_POINTER (name));
+       *no_add_attrs = true;
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index f88bfe5f879cb4ca09f067d907ec36ef0b4c2da3..d4812d8f618c2758bf95ec998f6aa53ee9bcb6fc 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -392,13 +392,14 @@ do                                   \
+ 
+ /* AmigaOS specific attribute */
+ /* { name, min_len, max_len, decl_req, type_req, fn_type_req,
+        affects_type_identity, handler, exclude } */
+ #define SUBTARGET_ATTRIBUTE_TABLE \
+   { "linearvarargs", 0, 0, false, true,  true, false, amigaos_handle_linearvarargs_attribute, NULL}, \
+-  { "lineartags", 0, 0, false, true, true, false, amigaos_handle_lineartags_attribute, NULL}, \
++  { "checktags", 0, 0, false, true, true, false, amigaos_handle_checktags_attribute, NULL}, \
++  { "tagtype", 1, 1, false, false, false, false, amigaos_handle_tagtype_attribute, NULL}, \
+   { "baserel_restore", 0, 0, false, true, true, false, amigaos_handle_baserel_restore_attribute, NULL }, \
+   { "force_no_baserel", 0, 0, true, false, false, false, amigaos_handle_force_no_baserel_attribute, NULL }, \
+   { "check68kfuncptr", 0, 0, false, true, true, false, amigaos_handle_check68kfuncptr_attribute, NULL }
+ 
+ /* Overrides */
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/10/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,0 +1,88 @@
+From 6f97164c6fae5e41cd9dd02e4cabc28cdcaa84a3 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Sat, 28 Apr 2018 08:09:58 +0200
+Subject: [PATCH 21/33] Fix order of AmigaOS PPC sections in the documentation.
+
+---
+ gcc/doc/extend.texi |  4 ++--
+ gcc/doc/invoke.texi | 10 +++++-----
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/gcc/doc/extend.texi b/gcc/doc/extend.texi
+index 5ccde910fc4c1b9320a09f55f69898120ea946a9..9466c857b276d1eab3cd7117cc7dcf102cbb2acd 100644
+--- a/gcc/doc/extend.texi
++++ b/gcc/doc/extend.texi
+@@ -7893,15 +7893,15 @@ For full documentation of the struct attributes please see the
+ documentation in @ref{x86 Variable Attributes}.
+ 
+ @cindex @code{altivec} variable attribute, PowerPC
+ For documentation of @code{altivec} attribute please see the
+ documentation in @ref{PowerPC Type Attributes}.
+ 
+-@subsection AmigaOS PPC Variable Attributes
++@subsection AmigaOS PowerPC Variable Attributes
+ 
+-One attribute is currently defined for AmigaOS PPC.
++One attribute is currently defined for AmigaOS PowerPC.
+ 
+ @table @code
+ @item force_no_baserel
+ @cindex forcing a variable not to be addressed base relative
+ 
+ This attribute forces access to a variable in code compiled with
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index 690266503976613fe712b16f03c39a1bb4508383..0e5f96587968e925eb81d16a8f99dd9e46aa768d 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -1387,13 +1387,13 @@ See RS/6000 and PowerPC Options.
+ -mtarget-align  -mno-target-align @gol
+ -mlongcalls  -mno-longcalls}
+ 
+ @emph{zSeries Options}
+ See S/390 and zSeries Options.
+ 
+-@emph{AmigaOS PPC options}
++@emph{AmigaOS PowerPC options}
+ @gccoptlist{-mcrt=@var{crt}  -mbaserel  -mno-baserel @gol
+ -mcheck68kfuncptr}
+ 
+ @item Code Generation Options
+ @xref{Code Gen Options,,Options for Code Generation Conventions}.
+ @gccoptlist{-fcall-saved-@var{reg}  -fcall-used-@var{reg} @gol
+@@ -16785,13 +16785,13 @@ platform.
+ * VMS Options::
+ * VxWorks Options::
+ * x86 Options::
+ * x86 Windows Options::
+ * Xstormy16 Options::
+ * Xtensa Options::
+-* AmigaOS PPC options::
++* AmigaOS PowerPC options::
+ * zSeries Options::
+ @end menu
+ 
+ @node AArch64 Options
+ @subsection AArch64 Options
+ @cindex AArch64 Options
+@@ -30434,15 +30434,15 @@ These options are defined for Xstormy16:
+ @table @gcctabopt
+ @item -msim
+ @opindex msim
+ Choose startup files and linker script suitable for the simulator.
+ @end table
+ 
+-@node AmigaOS PPC options
+-@subsection AmigaOS PPC options
+-@cindex AmigaOS PPC options
++@node AmigaOS PowerPC options
++@subsection AmigaOS PowerPC options
++@cindex AmigaOS PowerPC options
+ 
+ @table @gcctabopt
+ 
+ @item -mcrt=@var{crt}
+ @opindex mcrt
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/10/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,0 +1,71 @@
+From a8afdef494aa74af9f6027c06e05e0dfb582a93f Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Sun, 29 Apr 2018 00:08:22 +0200
+Subject: [PATCH 22/33] Provide a documentation for checktags and tagtype
+ attributes.
+
+---
+ gcc/doc/extend.texi | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/gcc/doc/extend.texi b/gcc/doc/extend.texi
+index 9466c857b276d1eab3cd7117cc7dcf102cbb2acd..0a4aded9e28977f4df1a7c6cb8d21a8c7b9d6f44 100644
+--- a/gcc/doc/extend.texi
++++ b/gcc/doc/extend.texi
+@@ -4071,12 +4071,24 @@ int VARARGS68K __amigaos4_check68k_trampoline(int num_args,
+     va_end(args);
+ 
+     return(result);
+ @}
+ @end smallexample
+ 
++@anchor{checktags}
++@item checktags
++@cindex @code{checktags} function attribute
++The @code{checktags} tells the some parameters of the function are
++taglists. In turn it will enable tag-type checking at compile-time, by
++leveraging the extra information provded to enum-defined tags to which
++a @code{tagtype} attribute is associated. The check assumes that if a
++parameter is an integer constant to which a type is associated, then
++it must be followed by an argument of that type. If that is not the
++case, the usual compiling warning about mismatched types will be
++emitted.
++
+ @item weak
+ @cindex @code{weak} function attribute
+ The @code{weak} attribute causes a declaration of an external symbol
+ to be emitted as a weak symbol rather than a global.  This is primarily
+ useful in defining library functions that can be overridden in user code,
+ though it can also be used with non-function declarations.  The overriding
+@@ -8735,12 +8747,28 @@ is used anywhere in the source file.  This is useful when identifying
+ enumerators that are expected to be removed in a future version of a
+ program.  The warning also includes the location of the declaration
+ of the deprecated enumerator, to enable users to easily find further
+ information about why the enumerator is deprecated, or what they should
+ do instead.  Note that the warnings only occurs for uses.
+ 
++@item tagtype
++@cindex @code{tagtype} enumerator attribute
++The @code{tagtype} attribute will associate an additional type to the
++enumerator constant that is leveraged by the compiler for
++@code{checktags}-attributed functions. For example, to define
++@code{WA_CustomScreen} and to teach that it it should be followed by a
++@code{struct Screen *} in that class of functions use:
++
++@smallexample
++enum @{
++  WA_CustomScreen __attribute__((tagtype(struct Screen *)))
++@};
++@end smallexample
++
++For more information, @pxref{checktags}.
++
+ @end table
+ 
+ @node Statement Attributes
+ @section Statement Attributes
+ @cindex Statement Attributes
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0023-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/10/patches/0023-Adapt-libssp-for-AmigaOS.patch
@@ -1,0 +1,68 @@
+From 2b445a6d08530c52ad4f411a30cb574dc2b94e4e Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Tue, 22 May 2018 23:14:01 +0200
+Subject: [PATCH 23/33] Adapt libssp for AmigaOS.
+
+---
+ libssp/ssp.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/libssp/ssp.c b/libssp/ssp.c
+index 28f3e9cc64a2c4faf573ee5878e5ac62e1e7f189..180bb3eb6ab5bb79745a64966286b76f20a7fc42 100644
+--- a/libssp/ssp.c
++++ b/libssp/ssp.c
+@@ -55,12 +55,14 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ /* Native win32 apps don't know about /dev/tty but can print directly
+    to the console using  "CONOUT$"   */
+ #if defined (_WIN32) && !defined (__CYGWIN__)
+ #include <windows.h>
+ #include <wincrypt.h>
+ # define _PATH_TTY "CONOUT$"
++#elif defined (__amigaos4__)
++# define _PATH_TTY "CONSOLE:"
+ #else
+ # define _PATH_TTY "/dev/tty"
+ #endif
+ #endif
+ #ifdef HAVE_SYSLOG_H
+ # include <syslog.h>
+@@ -86,13 +88,13 @@ __guard_setup (void)
+         {
+            CryptReleaseContext(hprovider, 0);
+            return;
+         }
+       CryptReleaseContext(hprovider, 0);
+     }
+-#else
++#elif !defined(__amigaos4__)
+   int fd = open ("/dev/urandom", O_RDONLY);
+   if (fd != -1)
+     {
+       ssize_t size = read (fd, &__stack_chk_guard,
+                            sizeof (__stack_chk_guard));
+       close (fd);
+@@ -145,19 +147,19 @@ fail (const char *msg1, size_t msg1len, const char *msg3)
+             break;
+           buf += wrote;
+           len -= wrote;
+         }
+       close (fd);
+     }
+-
++#ifndef __amigaos4__
+ #ifdef HAVE_SYSLOG_H
+   /* Only send the error to syslog if there was no tty available.  */
+   else
+     syslog (LOG_CRIT, "%s", msg3);
+ #endif /* HAVE_SYSLOG_H */
+-
++#endif
+   /* Try very hard to exit.  Note that signals may be blocked preventing
+      the first two options from working.  The use of volatile is here to
+      prevent optimizers from "knowing" that __builtin_trap is called first,
+      and that it doesn't return, and so "obviously" the rest of the code
+      is dead.  */
+   {
+-- 
+2.11.0
+

--- a/gcc/10/patches/0024-Add-amigaos-thread-model.patch
+++ b/gcc/10/patches/0024-Add-amigaos-thread-model.patch
@@ -1,0 +1,2078 @@
+From e59621574d851dfffcb3a866195fe9e310fa404c Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Fri, 4 May 2018 18:22:24 +0200
+Subject: [PATCH 24/33] Add amigaos thread model.
+
+It is work in progress.
+---
+ config/gthr.m4                 |    1 +
+ gcc/config.host                |    1 +
+ gcc/config/rs6000/amigaos.h    |    8 +-
+ gcc/config/rs6000/amigaos.opt  |   18 +
+ gcc/config/rs6000/x-amigaos    |   16 +
+ gcc/configure                  |    2 +-
+ gcc/configure.ac               |    2 +-
+ gcc/doc/invoke.texi            |    9 +-
+ libgcc/config/rs6000/t-amigaos |    5 +
+ libgcc/configure               |    1 +
+ libgcc/gthr-amigaos-asserts.h  |    8 +
+ libgcc/gthr-amigaos-native.c   | 1017 ++++++++++++++++++++++++++++++++++++++++
+ libgcc/gthr-amigaos-posix.c    |  233 +++++++++
+ libgcc/gthr-amigaos-single.c   |  141 ++++++
+ libgcc/gthr-amigaos.h          |  347 ++++++++++++++
+ libstdc++-v3/configure         |    1 +
+ 16 files changed, 1805 insertions(+), 5 deletions(-)
+ create mode 100644 gcc/config/rs6000/x-amigaos
+ create mode 100644 libgcc/gthr-amigaos-asserts.h
+ create mode 100644 libgcc/gthr-amigaos-native.c
+ create mode 100644 libgcc/gthr-amigaos-posix.c
+ create mode 100644 libgcc/gthr-amigaos-single.c
+ create mode 100644 libgcc/gthr-amigaos.h
+
+diff --git a/config/gthr.m4 b/config/gthr.m4
+index 4b937306ad0802c013aa4862eafeefaa597bd590..84d29116c9a06ce37b8ed0bd46cf46eed6a252d6 100644
+--- a/config/gthr.m4
++++ b/config/gthr.m4
+@@ -9,12 +9,13 @@ dnl Define header location by thread model
+ 
+ dnl usage: GCC_AC_THREAD_HEADER([thread_model])
+ AC_DEFUN([GCC_AC_THREAD_HEADER],
+ [
+ case $1 in
+     aix)	thread_header=config/rs6000/gthr-aix.h ;;
++    amigaos)	thread_header=gthr-amigaos.h ;;
+     dce)	thread_header=config/pa/gthr-dce.h ;;
+     gcn)	thread_header=config/gcn/gthr-gcn.h ;;
+     lynx)	thread_header=config/gthr-lynx.h ;;
+     mipssde)	thread_header=config/mips/gthr-mipssde.h ;;
+     posix)	thread_header=gthr-posix.h ;;
+     rtems)	thread_header=config/gthr-rtems.h ;;
+diff --git a/gcc/config.host b/gcc/config.host
+index 52e682d365625d3b257838699a9dd1a107bf57f4..83dbc9545842a3295955d88132b4ad8c71b7c7c5 100644
+--- a/gcc/config.host
++++ b/gcc/config.host
+@@ -257,12 +257,13 @@ case ${host} in
+     ;;
+   powerpc-*-amigaos*) # AmigaOS 4
+     prefix=/gcc
+     local_prefix=/gcc
+     host_can_use_collect2=no
+     host_xm_defines=HOST_LACKS_INODE_NUMBERS
++    host_xmake_file="${host_xmake_file} rs6000/x-amigaos"
+     ;;
+   powerpc-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-ppc-darwin.o"
+     host_xmake_file="${host_xmake_file} rs6000/x-darwin"
+     ;;
+   powerpc64-*-darwin*)
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index d4812d8f618c2758bf95ec998f6aa53ee9bcb6fc..ec0146c4b8c05eb300f8928e475641123c3f5632 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -272,13 +272,13 @@ mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
+ #define LINK_SPEC "\
+ --defsym __amigaos4__=1 \
+ %{!shared: %{!use-dynld: -Bstatic}} \
+ -q -d %{h*} %{v:-V} %{G*} \
+ %{Wl,*:%*} %{YP,*} %{R*} \
+ %{Qy:} %{!Qn:-Qy} \
+-%(link_shlib) %(link_text) \
++%(link_thread) %(link_shlib) %(link_text) \
+ %{mbaserel: %{msdata|msdata=default|msdata=sysv: %e-mbaserel and -msdata options are incompatible}} \
+ %{mcrt=clib2|mcrt=clib2-ts: %(link_clib2); \
+ mcrt=ixemul: %(link_ixemul); \
+ mcrt=libnix: %(link_libnix); \
+ mcrt=newlib: %(link_newlib); \
+ mcrt=default|!mcrt=*: %(link_amiga_default); \
+@@ -294,12 +294,15 @@ mcrt=default|!mcrt=*: %(link_amiga_default); \
+ #define LINK_TEXT ""
+ #endif
+ 
+ #define LINK_SHLIB "\
+ %{shared:-shared -dy --defsym __dynld_version__=1} %{!shared: %{static:-static}} %{use-dynld: -dy}"
+ 
++#define LINK_THREAD "\
++%s%{athread=native:gthr-amigaos-native.o;athread=single:gthr-amigaos-single.o;athread=pthread:gthr-amigaos-pthread.o}"
++
+ #undef STARTFILE_SPEC
+ #define STARTFILE_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(startfile_clib2); \
+ mcrt=ixemul: %(startfile_ixemul); \
+ mcrt=libnix: %(startfile_libnix); \
+ mcrt=newlib: %(startfile_newlib); \
+@@ -356,13 +359,14 @@ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+   {"lib_subdir_newlib", LIB_SUBDIR_NEWLIB_SPEC}, \
+   {"link_newlib", LINK_NEWLIB_SPEC}, \
+   {"startfile_newlib", STARTFILE_NEWLIB_SPEC}, \
+   {"endfile_newlib", ENDFILE_NEWLIB_SPEC}, \
+   /* used in link spec  */ \
+   {"link_text", LINK_TEXT}, \
+-  {"link_shlib", LINK_SHLIB},
++  {"link_shlib", LINK_SHLIB}, \
++  {"link_thread", LINK_THREAD},
+ 
+ #undef DEFAULT_VTABLE_THUNKS
+ #ifndef USE_GNULIBC_1
+ #define DEFAULT_VTABLE_THUNKS 1
+ #endif
+ 
+diff --git a/gcc/config/rs6000/amigaos.opt b/gcc/config/rs6000/amigaos.opt
+index 93d74f10bea8c1b23c82a9650bb0c3c153464ba7..1980ef231d7f849309ce24062d41992e01d77288 100644
+--- a/gcc/config/rs6000/amigaos.opt
++++ b/gcc/config/rs6000/amigaos.opt
+@@ -32,6 +32,24 @@ mcheck68kfuncptr
+ Target Report Var(CHECK68KFUNCPTR)
+ Generate target checking for function pointers
+ 
+ use-dynld
+ Target Driver
+ Generated binary employs the dynamic linker for shared objects.
++
++Enum
++Name(athread) Type(int) UnknownError(argument %qs to %<-athread%> not recognized)
++
++EnumValue
++Enum(athread) String(single) Value(0)
++
++EnumValue
++Enum(athread) String(native) Value(1)
++
++EnumValue
++Enum(athread) String(pthread) Value(2)
++
++athread=
++Driver RejectNegative Joined Enum(athread)
++Specifies the thread implementation that is linked to the final binary.
++
++; This comment is to ensure we retain the blank line above.
+diff --git a/gcc/config/rs6000/x-amigaos b/gcc/config/rs6000/x-amigaos
+new file mode 100644
+index 0000000000000000000000000000000000000000..a3dd2195809c2ce1fbab8be854f3c987dccc039b
+--- /dev/null
++++ b/gcc/config/rs6000/x-amigaos
+@@ -0,0 +1,16 @@
++# AmigaOS-specific makefile fragment that is included when building a compiler
++# that runs on AmigaOS
++
++ALL_EXECUTABLES=\
++	$(COMPILERS) \
++	gcov$(exeext) \
++	gcov-dump$(exeext) \
++	gcov-tool$(exeext) \
++	lto-wrapper$(exeext) \
++	cpp$(exeext) \
++	xgcc$(exeext) \
++	xg++$(exeext)
++
++# We use the native amiga thread implementation and additionally remove all
++# unneeded sections
++$(ALL_EXECUTABLES) : override LDFLAGS += -athread=native -Wl,--gc-sections
+\ No newline at end of file
+diff --git a/gcc/configure b/gcc/configure
+index 8fe9c91fd7c2d5681d5fb9d1150b7027b9c6bbf1..2c9fb39d5394ebed0e91c03e8ca8a6f345c240bf 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -12210,13 +12210,13 @@ case ${enable_threads} in
+     target_thread_file='single'
+     ;;
+   yes)
+     # default
+     target_thread_file='single'
+     ;;
+-  aix | dce | lynx | mipssde | posix | rtems | \
++  aix | amigaos | dce | lynx | mipssde | posix | rtems | \
+   single | tpf | vxworks | win32)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+     echo "${enable_threads} is an unknown thread package" 1>&2
+     exit 1
+diff --git a/gcc/configure.ac b/gcc/configure.ac
+index 84dceb8074ab4615316e09f1f339ed93eca6d6e9..10f5f85f76f553474b71ff793b829ff2997fe236 100644
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -1802,13 +1802,13 @@ case ${enable_threads} in
+     target_thread_file='single'
+     ;;
+   yes)
+     # default
+     target_thread_file='single'
+     ;;
+-  aix | dce | lynx | mipssde | posix | rtems | \
++  aix | amigaos | dce | lynx | mipssde | posix | rtems | \
+   single | tpf | vxworks | win32)
+     target_thread_file=${enable_threads}
+     ;;
+   *)
+     echo "${enable_threads} is an unknown thread package" 1>&2
+     exit 1
+diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
+index 0e5f96587968e925eb81d16a8f99dd9e46aa768d..15d9ef151f350a6655f202dfd04a79ddefdca159 100644
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -1389,13 +1389,13 @@ See RS/6000 and PowerPC Options.
+ 
+ @emph{zSeries Options}
+ See S/390 and zSeries Options.
+ 
+ @emph{AmigaOS PowerPC options}
+ @gccoptlist{-mcrt=@var{crt}  -mbaserel  -mno-baserel @gol
+--mcheck68kfuncptr}
++-mcheck68kfuncptr -athread=@var{ti}}
+ 
+ @item Code Generation Options
+ @xref{Code Gen Options,,Options for Code Generation Conventions}.
+ @gccoptlist{-fcall-saved-@var{reg}  -fcall-used-@var{reg} @gol
+ -ffixed-@var{reg}  -fexceptions @gol
+ -fnon-call-exceptions  -fdelete-dead-exceptions  -funwind-tables @gol
+@@ -17465,12 +17465,19 @@ Compile for GCN5 Vega 20 devices (gfx906).
+ Specify how many @var{bytes} of stack space will be requested for each GPU
+ thread (wave-front).  Beware that there may be many threads and limited memory
+ available.  The size of the stack allocation may also have an impact on
+ run-time performance.  The default is 32KB when using OpenACC or OpenMP, and
+ 1MB otherwise.
+ 
++@item -athread
++@opindex athread
++
++This option specified which thread implementation should be linked to
++the final executable. You can choose among @samp{single}, @samp{native},
++and @samp{pthread}.
++
+ @end table
+ 
+ @node ARC Options
+ @subsection ARC Options
+ @cindex ARC options
+ 
+diff --git a/libgcc/config/rs6000/t-amigaos b/libgcc/config/rs6000/t-amigaos
+index da1e303eed7e60df883971a610e8904db0df3e23..fa9d22e72161436c81f6a9f687ddaa752f01a966 100644
+--- a/libgcc/config/rs6000/t-amigaos
++++ b/libgcc/config/rs6000/t-amigaos
+@@ -40,6 +40,11 @@ SHLIB_LINK = $(GCC_FOR_TARGET) -shared $(SHLIB_OBJS) -nodefaultlibs $(LIBGCC2_CF
+ 
+ # Install the shared libgcc library, but ensure that the name is libgcc.so
+ SHLIB_INSTALL = \
+ 	$(mkinstalldirs) $(DESTDIR)$(inst_libdir); \
+ 	$(INSTALL_DATA) $(SHLIB_DIR)/$(SHLIB_SONAME) \
+ 	  $(DESTDIR)$(inst_libdir)/libgcc$(SHLIB_EXT);
++
++EXTRA_PARTS += gthr-amigaos-native.o gthr-amigaos-single.o gthr-amigaos-pthread.o
++
++gthr-amigaos-%.o: $(srcdir)/gthr-amigaos-%.c $(srcdir)/gthr-amigaos.h
++	$(gcc_compile) -c $<
+diff --git a/libgcc/configure b/libgcc/configure
+index 26bf75789e0d999fd5edbdc6e93d356474b298be..740a832b28a5bc86865ffbc13df84304a579b4cd 100755
+--- a/libgcc/configure
++++ b/libgcc/configure
+@@ -5636,12 +5636,13 @@ tm_file="${tm_file_}"
+ 
+ 
+ # Map from thread model to thread header.
+ 
+ case $target_thread_file in
+     aix)	thread_header=config/rs6000/gthr-aix.h ;;
++    amigaos)	thread_header=gthr-amigaos.h ;;
+     dce)	thread_header=config/pa/gthr-dce.h ;;
+     gcn)	thread_header=config/gcn/gthr-gcn.h ;;
+     lynx)	thread_header=config/gthr-lynx.h ;;
+     mipssde)	thread_header=config/mips/gthr-mipssde.h ;;
+     posix)	thread_header=gthr-posix.h ;;
+     rtems)	thread_header=config/gthr-rtems.h ;;
+diff --git a/libgcc/gthr-amigaos-asserts.h b/libgcc/gthr-amigaos-asserts.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..bb6005cd52ef75cc7bfbc276d5d56ec54ed633cd
+--- /dev/null
++++ b/libgcc/gthr-amigaos-asserts.h
+@@ -0,0 +1,8 @@
++#ifndef __cplusplus
++_Static_assert(__atomic_always_lock_free(sizeof(uint32_t), 0), "Access to uint32_t is not lock free");
++_Static_assert(__atomic_always_lock_free(sizeof(char), 0), "Access to char is not lock free");
++_Static_assert(sizeof(__gthread_once_t) >= sizeof(__internal_gthread_once_t), "__gthread_once_t not large enough!");
++_Static_assert(sizeof(__gthread_mutex_t) >= sizeof(__internal_gthread_mutex_t), "__gthread_mutex_t not large enough!");
++_Static_assert(sizeof(__gthread_recursive_mutex_t) >= sizeof(__internal_gthread_mutex_t), "__gthread_recursive_mutex_t not large enough!");
++_Static_assert(sizeof(__gthread_cond_t) >= sizeof(__internal_gthread_cond_t), "__gthread_recursive_mutex_t not large enough!");
++#endif
+diff --git a/libgcc/gthr-amigaos-native.c b/libgcc/gthr-amigaos-native.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..3806359eed9a80027a7b37e79d148cded12ce7b9
+--- /dev/null
++++ b/libgcc/gthr-amigaos-native.c
+@@ -0,0 +1,1017 @@
++/**
++ * This is the native implementation of gcc threads abstraction. The advantage
++ * over the pthreads one is that no pthreads.library is needed.
++ *
++ * (c) 2018 by Sebastian Bauer
++ */
++#define __NOLIBBASE__
++#define __NOGLOBALIFACE__
++
++#include "gthr-amigaos.h"
++
++#include <assert.h>
++#include <errno.h>
++#include <stdint.h>
++#include <string.h>
++#include <sys/time.h>
++
++#include <proto/dos.h>
++#include <proto/exec.h>
++#include <proto/timer.h>
++
++/******************************************************************************/
++
++#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++
++/******************************************************************************/
++
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
++/******************************************************************************/
++
++typedef struct
++{
++  union
++  {
++    __gthread_once_t gonce;
++    struct
++    {
++      char done;
++      char started;
++    } i;
++  } u;
++} __internal_gthread_once_t;
++
++typedef struct
++{
++  union
++  {
++    __gthread_mutex_t gmutex;
++    struct
++    {
++      struct SignalSemaphore sem;
++      uint8_t recursive;
++      uint8_t acquired;
++    } i;
++  } u;
++} __internal_gthread_mutex_t;
++
++typedef struct
++{
++  union
++  {
++    __gthread_cond_t gcond;
++    struct
++    {
++      struct threadentry *first_in_cond_wait_list;
++    } i;
++  } u;
++} __internal_gthread_cond_t;
++
++/******************************************************************************/
++
++#include "gthr-amigaos-asserts.h"
++
++/******************************************************************************/
++
++static struct ExecIFace *iexec = 0;
++static struct DOSIFace *idos = 0;
++static struct Library *DOSBase;
++
++static __gthread_once_t libs_once = __GTHREAD_ONCE_INIT;
++
++/**
++ * The init function to open all necessary libs.
++ */
++static void init_libs(void)
++{
++  struct ExecBase *SysBase = *(struct ExecBase **)4;
++  iexec = (struct ExecIFace *)SysBase->MainInterface;
++  DOSBase = iexec->OpenLibrary("dos.library", 0);
++  idos = (struct DOSIFace *)iexec->GetInterface(DOSBase, "main", 1, NULL);
++}
++
++/******************************************************************************/
++
++/* We keep the entries of each key organized as a single linked list */
++struct threadentry
++{
++  struct threadentry *next;
++
++  struct Process *process;
++  int id;
++
++  struct MsgPort *timer_port;
++  struct TimeRequest *timer_io;
++  struct ITimer *itimer;
++
++  /* The task that is going to join us */
++  struct Task *joiner_task;
++
++  /* The call to entry() has already been returned */
++  int finished;
++
++  /* Valid if finished is set */
++  void *result;
++
++  /* Thread is detached (and cannot be joined) */
++  int detached;
++
++  void *(*entry) (void*);
++  void *args;
++
++  /* The next thread in the condition wait list. A thread can only be in one
++   * cond wait list so we can embed the linking in this structure.
++   */
++  struct threadentry *next_in_cond_wait_list;
++};
++
++typedef struct threadentry threadentry_t;
++
++typedef struct
++{
++  struct SignalSemaphore sem;
++
++  /* Singlely-linked list of threads */
++  threadentry_t *threads;
++
++  int next_thread_id;
++} threadstore_t;
++
++/******************************************************************************/
++
++static void
++__gthread_close_timer(threadentry_t *thr);
++
++/******************************************************************************/
++
++int
++__gthread_active_p (void)
++{
++  /* Thread-system is always active as we have to be explicitly linked to the
++   * final binary.
++   */
++  return 1;
++}
++
++/******************************************************************************/
++
++int
++__gthread_once (__gthread_once_t *__once, void (*__func) (void))
++{
++  __internal_gthread_once_t *once = (__internal_gthread_once_t *)__once;
++
++  if (__once == NULL || __func == NULL)
++    return EINVAL;
++
++  if (__atomic_load_1(&once->u.i.done, __ATOMIC_SEQ_CST))
++    return 0;
++
++  if (!__atomic_test_and_set(&once->u.i.started, __ATOMIC_SEQ_CST))
++    {
++      /* Started flag was not set so call func now */
++      __func();
++
++      /* Remember that we are done now. And make all effects prior to this
++       * store visible to all the other clients that will read that we are
++       * actually done.
++       */
++      __atomic_store_1(&once->u.i.done, 1, __ATOMIC_SEQ_CST);
++    }
++  else
++    {
++      while (!__atomic_load_1(&once->u.i.done, __ATOMIC_SEQ_CST))
++        {
++          /* Allow the other thread to progress quickly but iexec may be not available */
++          struct ExecBase *SysBase = *(struct ExecBase **)4;
++          struct ExecIFace *ie = (struct ExecIFace *)SysBase->MainInterface;
++          ie->Reschedule();
++        }
++    }
++  return 0;
++}
++
++/******************************************************************************/
++
++/* We keep the entries of each key organized as a single linked list */
++struct keyentry
++{
++  struct keyentry *next;
++  struct Task *task;
++  const void *data;
++};
++
++typedef struct keyentry keyentry_t;
++
++struct key
++{
++  keyentry_t *first;
++  void (*destroy) (void *);
++};
++
++typedef struct
++{
++  struct SignalSemaphore sem;
++
++  /* Each key is a single slot */
++  struct key *keys;
++
++  /* How many new keys */
++  int num_key_entries;
++
++  /* How many keys are allocated in total */
++  int num_key_entries_allocated;
++
++  /* Pool from which all key entries are allocated */
++  APTR keyentry_pool;
++
++  int num_threads;
++} keystore_t;
++
++static keystore_t *keystore;
++static __gthread_once_t keystore_once = __GTHREAD_ONCE_INIT;
++
++/**
++ * Initialize our keystore.
++ */
++static void init_keystore(void)
++{
++  if (!(keystore = (keystore_t *)iexec->AllocVec (sizeof(*keystore), MEMF_CLEAR)))
++    return;
++  iexec->InitSemaphore(&keystore->sem);
++
++  if (!(keystore->keyentry_pool = iexec->AllocSysObjectTags (ASOT_ITEMPOOL, ASOITEM_ItemSize, sizeof(keyentry_t), TAG_DONE)))
++    goto bailout;
++  return;
++bailout:
++  if (keystore)
++    iexec->FreeVec (keystore);
++  keystore = NULL;
++}
++
++int __gthread_key_create (__gthread_key_t *__key, void (*destroy) (void *))
++{
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  /* Initialize our private keystore, but only once */
++  __gthread_once (&keystore_once, init_keystore);
++
++  if (!keystore)
++    return ENOMEM;
++
++  iexec->ObtainSemaphore (&keystore->sem);
++  if (keystore->num_key_entries >= keystore->num_key_entries_allocated)
++    {
++      struct key *new_keys;
++      int new_num_key_entries_allocated = keystore->num_key_entries_allocated * 2 + 4;
++
++      if (!(new_keys = (struct key *)iexec->AllocVec (sizeof(*new_keys) * new_num_key_entries_allocated, 0)))
++        {
++          iexec->ReleaseSemaphore (&keystore->sem);
++          return ENOMEM;
++        }
++      if (keystore->keys)
++        {
++          memcpy (new_keys, keystore->keys, keystore->num_key_entries * sizeof(*new_keys));
++          iexec->FreeVec (keystore->keys);
++        }
++      keystore->keys = new_keys;
++      keystore->num_key_entries_allocated = new_num_key_entries_allocated;
++    }
++  keystore->keys[keystore->num_key_entries].first = NULL;
++  keystore->keys[keystore->num_key_entries].destroy = destroy;
++
++  __key->id = keystore->num_key_entries++;
++
++  iexec->ReleaseSemaphore (&keystore->sem);
++  return 0;
++}
++
++int
++__gthread_key_delete (__gthread_key_t __key)
++{
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  iexec->ObtainSemaphore (&keystore->sem);
++
++  /* TODO: Free the occupied storage for each entry */
++  keystore->keys[__key.id].first = NULL;
++
++  iexec->ReleaseSemaphore (&keystore->sem);
++  return 0;
++}
++
++/**
++ * Find the key entry that corresponds to id and task.
++ *
++ * @return the key entry or NULL.
++ */
++static keyentry_t *find_keyentry (int id, struct Task *task)
++{
++  keyentry_t *entry;
++  entry = keystore->keys[id].first;
++  while (entry)
++    {
++      if (entry->task == task)
++          break;
++      entry = entry->next;
++    }
++  return entry;
++}
++
++void *
++__gthread_getspecific (__gthread_key_t __key)
++{
++  struct Task *this_task;
++  keyentry_t *entry;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  this_task = iexec->FindTask(NULL);
++
++  iexec->ObtainSemaphoreShared (&keystore->sem);
++  entry = find_keyentry(__key.id, this_task);
++  iexec->ReleaseSemaphore (&keystore->sem);
++  return entry?((void*)entry->data):NULL;
++}
++
++int
++__gthread_setspecific (__gthread_key_t __key, const void *__v)
++{
++  struct Task *this_task;
++  keyentry_t *entry;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  this_task = iexec->FindTask(NULL);
++
++  iexec->ObtainSemaphore (&keystore->sem);
++  if (!(entry = find_keyentry(__key.id, this_task)))
++    {
++      /* Specific not found for this task, allocate a new entry */
++      if (!(entry = (keyentry_t *)iexec->ItemPoolAlloc(keystore->keyentry_pool)))
++        {
++          iexec->ReleaseSemaphore (&keystore->sem);
++          return ENOMEM;
++        }
++      entry->task = this_task;
++      /* entry->data will be set in the following */
++      entry->next = keystore->keys[__key.id].first;
++      keystore->keys[__key.id].first = entry;
++    }
++  entry->data = __v;
++  iexec->ReleaseSemaphore (&keystore->sem);
++  return 0;
++}
++
++/******************************************************************************/
++
++int
++__gthread_mutex_destroy (__gthread_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_mutex_init (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  iexec->InitSemaphore (&mx->u.i.sem);
++  mx->u.i.recursive = 0;
++  mx->u.i.acquired = 0;
++  return 0;
++}
++
++int
++__gthread_mutex_lock (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  iexec->ObtainSemaphore (&mx->u.i.sem);
++  if (!mx->u.i.recursive && mx->u.i.acquired)
++    {
++      /* Deadlock */
++      iexec->DebugPrintF("threadimpl: non-recursive mutex_lock() called twice on the same thread.\n");
++      iexec->ReleaseSemaphore (&mx->u.i.sem);
++      return EBUSY;
++    }
++  mx->u.i.acquired++;
++  return 0;
++}
++
++int
++__gthread_mutex_trylock (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  if (iexec->AttemptSemaphore (&mx->u.i.sem))
++    {
++      if (!mx->u.i.recursive && mx->u.i.acquired)
++        {
++          iexec->ReleaseSemaphore (&mx->u.i.sem);
++          return EBUSY;
++        }
++      mx->u.i.acquired++;
++      return 0;
++    }
++  return EBUSY;
++}
++
++int
++__gthread_mutex_unlock (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  mx->u.i.acquired--;
++  iexec->ReleaseSemaphore (&mx->u.i.sem);
++  return 0;
++}
++
++/******************************************************************************/
++
++int
++__gthread_recursive_mutex_init (__gthread_recursive_mutex_t *__mutex)
++{
++  int err;
++  if (!(err = __gthread_mutex_init ((__gthread_mutex_t*)__mutex)))
++    {
++      __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++      mx->u.i.recursive = 1;
++    }
++  return err;
++}
++
++int
++__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex)
++{
++  return __gthread_mutex_lock ((__gthread_mutex_t*)__mutex);
++}
++
++int
++__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex)
++{
++  return __gthread_mutex_trylock ((__gthread_mutex_t*)__mutex);
++}
++
++int
++__gthread_recursive_mutex_unlock (__gthread_recursive_mutex_t *__mutex)
++{
++  return __gthread_mutex_unlock ((__gthread_mutex_t*)__mutex);
++}
++
++int
++__gthread_recursive_mutex_destroy (__gthread_recursive_mutex_t *__mutex)
++{
++  return __gthread_mutex_destroy ((__gthread_mutex_t*)__mutex);
++}
++
++/******************************************************************************/
++
++static threadstore_t *threadstore;
++static __gthread_once_t threadstore_once = __GTHREAD_ONCE_INIT;
++
++/**
++ * Allocate data structure for a new thread and prepare it with
++ * a new id.
++ */
++static threadentry_t *__gthread_new_threadentry (void)
++{
++  threadentry_t *thr;
++  int thr_id;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  if (!(thr = (threadentry_t *)iexec->AllocVec (sizeof (*thr), MEMF_CLEAR)))
++    return NULL;
++
++  iexec->ObtainSemaphore (&threadstore->sem);
++  thr_id = threadstore->next_thread_id++;
++  iexec->ReleaseSemaphore (&threadstore->sem);
++
++  thr->id = thr_id;
++
++  return thr;
++}
++
++/**
++ * Initialize our threadstore.
++ */
++static void init_threadstore (void)
++{
++  threadentry_t *thr;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  if (!(threadstore = (threadstore_t *)iexec->AllocVec (sizeof(*threadstore), MEMF_CLEAR)))
++    return;
++  iexec->InitSemaphore (&threadstore->sem);
++
++  /* Create thread structure for this thread (aka root thread) */
++  if (!(thr = __gthread_new_threadentry ()))
++    goto bailout;
++  thr->process = (struct Process*)iexec->FindTask(NULL);
++
++  threadstore->threads = thr;
++  return;
++bailout:
++  if (threadstore)
++    iexec->FreeVec (threadstore);
++  threadstore = NULL;
++}
++
++static int __gthread_entry(STRPTR args UNUSED, int32 length UNUSED, APTR execbase UNUSED)
++{
++  struct Task *task;
++  threadentry_t *thr;
++  int i;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  task = iexec->FindTask (NULL);
++  thr = (threadentry_t *)((struct Process*)task)->pr_Task.tc_UserData;
++
++  /* Wait for the parent task to enqueue the process in the global list */
++  while (!(iexec->Wait (SIGBREAKF_CTRL_F) & SIGBREAKF_CTRL_F));
++
++  thr->result = thr->entry(thr->args);
++
++  /* Invoke destructors of all non-NULL thread specifics */
++  iexec->ObtainSemaphore (&keystore->sem);
++  for (i = 0; i < keystore->num_key_entries; i++)
++    {
++      void (*destroy)(void *);
++      keyentry_t *key;
++
++      if (!(destroy = keystore->keys[i].destroy))
++        continue;
++
++      if (!(key = find_keyentry (i, task)))
++        continue;
++
++      if (key->data)
++        destroy ((void *)key->data);
++    }
++  iexec->ReleaseSemaphore (&keystore->sem);
++
++  __gthread_close_timer (thr);
++
++  thr->finished = 1;
++  return 0;
++}
++
++int
++__gthread_create (__gthread_t *thread, void *(*func) (void*), void *args)
++{
++  threadentry_t *threadentry;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  /* Initialize our private threadstore, but only once */
++  __gthread_once (&threadstore_once, init_threadstore);
++
++  if (!threadstore)
++    return ENOMEM;
++
++  if (!(threadentry = __gthread_new_threadentry ()))
++    return ENOMEM;
++
++  threadentry->entry = func;
++  threadentry->args = args;
++
++  threadentry->process = idos->CreateNewProcTags (
++                NP_Entry, __gthread_entry,
++                NP_Child, TRUE,
++                NP_UserData, (int32)threadentry,
++                NP_Input, idos->Input(),
++                NP_Output, idos->Output(),
++                NP_Error, idos->ErrorOutput(),
++                NP_CloseInput,  FALSE,
++                NP_CloseOutput, FALSE,
++                NP_CloseError, FALSE,
++                TAG_DONE);
++
++  iexec->ObtainSemaphore (&threadstore->sem);
++  threadentry->next = threadstore->threads;
++  threadstore->threads = threadentry;
++  iexec->ReleaseSemaphore (&threadstore->sem);
++
++  /* Signal that we have enqueued the task */
++  iexec->Signal (&threadentry->process->pr_Task, SIGBREAKF_CTRL_F);
++
++  *thread = threadentry->id;
++  return 0;
++}
++
++static threadentry_t *find_threadentry_by_process (struct Process *process)
++{
++  threadentry_t *thr;
++  thr = threadstore->threads;
++  while (thr)
++    {
++      if (thr->process == process)
++          break;
++      thr = thr->next;
++    }
++  return thr;
++}
++
++static threadentry_t *find_threadentry_by_id (__gthread_t id)
++{
++  threadentry_t *thr;
++  thr = threadstore->threads;
++  while (thr)
++    {
++      if (thr->id == id)
++          break;
++      thr = thr->next;
++    }
++  return thr;
++}
++
++int
++__gthread_join (__gthread_t thread, void **value_ptr)
++{
++  threadentry_t *thr;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  if (!(thr = find_threadentry_by_id (thread)))
++    return ESRCH;
++
++  /* FIXME: This is very ugly, use SIGF_SINGLE */
++  while (!thr->finished)
++    idos->Delay (1);
++
++  if (value_ptr)
++    *value_ptr = thr->result;
++  return 0;
++}
++
++int
++__gthread_detach (__gthread_t thread)
++{
++  threadentry_t *thr = find_threadentry_by_id (thread);
++  thr->detached = 1;
++  return 0;
++}
++
++int
++__gthread_equal (__gthread_t t1, __gthread_t t2)
++{
++  return t1 == t2;
++}
++
++__gthread_t
++__gthread_self (void)
++{
++  struct Task *task;
++  threadentry_t *thr;
++  __gthread_t id;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  /* Initialize our private threadstore, but only once */
++  __gthread_once (&threadstore_once, init_threadstore);
++
++  task = iexec->FindTask(NULL);
++  iexec->ObtainSemaphoreShared (&threadstore->sem);
++  if ((thr = find_threadentry_by_process ((struct Process *)task)))
++    {
++      id = thr->id;
++    }
++  else
++    /* FIXME: Record this thread */
++    id = -1;
++
++  iexec->ReleaseSemaphore (&threadstore->sem);
++  return id;
++}
++
++int
++__gthread_yield (void)
++{
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  iexec->Reschedule();
++  return 0;
++}
++
++void
++__gthread_close_timer(threadentry_t *thr)
++{
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  if (thr->timer_io)
++    {
++      if (thr->timer_io->Request.io_Device)
++        {
++          iexec->CloseDevice (&thr->timer_io->Request);
++        }
++      iexec->FreeSysObject (ASOT_IOREQUEST, thr->timer_io);
++      thr->timer_io = NULL;
++    }
++
++  if (thr->timer_port)
++    {
++      iexec->DeleteMsgPort (thr->timer_port);
++      thr->timer_port = NULL;
++    }
++}
++
++static int
++__gthread_open_timer(threadentry_t **thr_p)
++{
++  threadentry_t *thr;
++  struct Task *task;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  task = iexec->FindTask(NULL);
++
++  iexec->ObtainSemaphoreShared (&threadstore->sem);
++  if (!(thr = find_threadentry_by_process((struct Process*)task)))
++    {
++      /* This is not our thread */
++      iexec->ReleaseSemaphore (&threadstore->sem);
++      return -1;
++    }
++  iexec->ReleaseSemaphore (&threadstore->sem);
++
++  /* Only we can open the timer device */
++  if (!thr->timer_port)
++    {
++      if (!(thr->timer_port = iexec->CreateMsgPort ()))
++        goto bailout;
++
++      if (!(thr->timer_io = (struct TimeRequest *)iexec->AllocSysObjectTags (ASOT_IOREQUEST,
++          ASOIOR_Size, sizeof(struct TimeRequest),
++          ASOIOR_ReplyPort, thr->timer_port,
++          TAG_END)))
++        goto bailout;
++
++      if (iexec->OpenDevice(TIMERNAME, UNIT_MICROHZ, &thr->timer_io->Request, 0))
++        goto bailout;
++    }
++
++  *thr_p = thr;
++  return 0;
++bailout:
++  __gthread_close_timer(thr);
++  return -1;
++}
++
++/******************************************************************************/
++
++/**
++ * Remove the given thread from the condition wait list.
++ */
++static void
++__gthread_remove_thread_from_cond_wait_list (__internal_gthread_cond_t *cond, threadentry_t *thr)
++{
++  threadentry_t *cur_thr, *prev_thr;
++
++  prev_thr = NULL;
++  cur_thr = cond->u.i.first_in_cond_wait_list;
++  while (cur_thr)
++    {
++      if (cur_thr == thr)
++        {
++          if (!prev_thr)
++            cond->u.i.first_in_cond_wait_list = cur_thr->next_in_cond_wait_list;
++          else
++            prev_thr->next_in_cond_wait_list = cur_thr->next_in_cond_wait_list;
++          break;
++        }
++
++      prev_thr = cur_thr;
++      cur_thr = cur_thr->next_in_cond_wait_list;
++    }
++}
++
++int
++__gthread_cond_init (__gthread_cond_t *cond)
++{
++  memset(cond, 0, sizeof(*cond));
++  return 0;
++}
++
++int
++__gthread_cond_signal (__gthread_cond_t *__cond)
++{
++  __internal_gthread_cond_t *cond = (__internal_gthread_cond_t *)__cond;
++  threadentry_t *thr;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  /* Most of the time, we are called with the same mutex being locked that is
++   * supplied to __gthread_cond_wait(). However,  most of the time is not always,
++   * so we have to make the lists manipulation atomic on our own.
++   */
++  iexec->ObtainSemaphore (&threadstore->sem);
++
++  if ((thr = cond->u.i.first_in_cond_wait_list))
++    {
++      /* Remove us from the list, then signal */
++      cond->u.i.first_in_cond_wait_list = thr->next_in_cond_wait_list;
++      thr->next_in_cond_wait_list = NULL;
++
++      iexec->Signal (&thr->process->pr_Task, SIGF_SINGLE);
++    }
++
++  iexec->ReleaseSemaphore (&threadstore->sem);
++
++  return 0;
++}
++
++int
++__gthread_cond_broadcast (__gthread_cond_t *__cond)
++{
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  /* Initialize our private threadstore, but only once */
++  __gthread_once (&threadstore_once, init_threadstore);
++
++  __internal_gthread_cond_t *cond = (__internal_gthread_cond_t *)__cond;
++  threadentry_t *thr;
++
++  /* See __gthread_cond_signal() */
++  iexec->ObtainSemaphore (&threadstore->sem);
++
++  thr = cond->u.i.first_in_cond_wait_list;
++  cond->u.i.first_in_cond_wait_list = NULL;
++
++  while (thr)
++    {
++      threadentry_t *next_thr = thr->next_in_cond_wait_list;
++
++      thr->next_in_cond_wait_list = NULL;
++
++      iexec->Signal (&thr->process->pr_Task, SIGF_SINGLE);
++
++      thr = next_thr;
++    }
++
++  iexec->ReleaseSemaphore (&threadstore->sem);
++
++  return 0;
++}
++
++/**
++ * Prepare cond_wait.
++ */
++static void
++__gthread_cond_wait_prepare (threadentry_t *self_thr, __internal_gthread_cond_t *cond, __gthread_mutex_t *mutex)
++{
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  /* Enqueue us into this thread's dedicated cond wait list */
++  iexec->ObtainSemaphore (&threadstore->sem);
++  self_thr->next_in_cond_wait_list = cond->u.i.first_in_cond_wait_list;
++  cond->u.i.first_in_cond_wait_list = self_thr;
++
++  /* Along the way, clear SIGF_SINGLE bit to avoid spurious signals */
++  iexec->SetSignal (0L, SIGF_SINGLE);
++
++  iexec->ReleaseSemaphore (&threadstore->sem);
++
++  /* TODO: Set a condition variable, which the notifier is supposed to change
++   * to avoid more suspsious signals. However, the caller is supposed to check
++   * the condition anyway, so suspsious wakes are perhaps acceptable.
++   */
++  __gthread_mutex_unlock (mutex);
++}
++
++int
++__gthread_cond_wait (__gthread_cond_t *__cond, __gthread_mutex_t *mutex)
++{
++  __internal_gthread_cond_t *cond = (__internal_gthread_cond_t *)__cond;
++  __gthread_t self = __gthread_self ();
++  threadentry_t *self_thr;
++
++  if (!(self_thr = find_threadentry_by_id (self)))
++    return EINVAL;
++
++  __gthread_cond_wait_prepare (self_thr, cond, mutex);
++
++  /* Wait for anyone notifiying us */
++  while (!(iexec->Wait (SIGF_SINGLE) & SIGF_SINGLE));
++
++  __gthread_mutex_lock (mutex);
++
++  /* Receiving the proper SIGF_SINGLE also means that we have been removed from
++   * the cond's waiting list
++   */
++  return 0;
++}
++
++int
++__gthread_cond_timedwait (__gthread_cond_t *__cond,
++                          __gthread_mutex_t *mutex,
++                          const __gthread_time_t *abs_timeout)
++{
++  __internal_gthread_cond_t *cond = (__internal_gthread_cond_t *)__cond;
++  threadentry_t *self_thr;
++  uint32_t timer_mask;
++  struct timeval tv_now;
++  uint32_t sigs;
++  int borrow = 0;
++  int err;
++
++  /* Initialize libs */
++  __gthread_once (&libs_once, init_libs);
++
++  gettimeofday(&tv_now, 0);
++
++  /* Some timer arithmetics. TODO: Verify this! */
++  if (tv_now.tv_usec <= (uint32_t)(abs_timeout->nanoseconds / 1000))
++    tv_now.tv_usec = abs_timeout->nanoseconds / 1000 - tv_now.tv_usec;
++  else
++    {
++      tv_now.tv_usec = 1000000 + abs_timeout->nanoseconds / 1000 - tv_now.tv_usec;
++      borrow = 1;
++    }
++
++  if (tv_now.tv_sec + borrow <= (uint32_t)(abs_timeout->seconds))
++    tv_now.tv_sec = abs_timeout->seconds - (tv_now.tv_sec + borrow);
++  else
++    {
++      tv_now.tv_sec = 0;
++      tv_now.tv_usec = 1;
++    }
++
++  if ((err = __gthread_open_timer (&self_thr)))
++    return err;
++
++  self_thr->timer_io->Request.io_Command = TR_ADDREQUEST;
++  self_thr->timer_io->Time.Seconds = tv_now.tv_sec;
++  self_thr->timer_io->Time.Microseconds = tv_now.tv_usec;
++  iexec->SendIO (&self_thr->timer_io->Request);
++
++  __gthread_cond_wait_prepare (self_thr, cond, mutex);
++
++  /* Wait for anyone notifiying us or a timeout, note that according to
++   * some docs we should not wait on other signals when using SIGF_SINGLE,
++   * but we do it nonetheless.  */
++  timer_mask = 1UL << self_thr->timer_port->mp_SigBit;
++  sigs = iexec->Wait (SIGF_SINGLE | timer_mask);
++
++  if (!(iexec->CheckIO (&self_thr->timer_io->Request)))
++    iexec->AbortIO (&self_thr->timer_io->Request);
++  iexec->WaitIO (&self_thr->timer_io->Request);
++
++  __gthread_mutex_lock (mutex);
++
++  /* Receiving the proper SIGF_SINGLE also means that we have been removed from
++   * the cond's waiting list, but if this was a timeout, we have not yet been
++   * removed. So we remove ourselves. This is safe, even if we have been removed.
++   */
++  if (!(sigs & SIGF_SINGLE))
++    {
++      iexec->ObtainSemaphore (&threadstore->sem);
++      __gthread_remove_thread_from_cond_wait_list (cond, self_thr);
++      iexec->ReleaseSemaphore (&threadstore->sem);
++    }
++  return err;
++}
++
++int
++__gthread_cond_destroy (__gthread_cond_t *__cond UNUSED)
++{
++  return 0;
++}
++
++#ifdef __cplusplus
++}
++#endif
+diff --git a/libgcc/gthr-amigaos-posix.c b/libgcc/gthr-amigaos-posix.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..53caa3c686d42a39324ce79c0555611263f0b141
+--- /dev/null
++++ b/libgcc/gthr-amigaos-posix.c
+@@ -0,0 +1,233 @@
++/**
++ * This is the posix.libraray-based implementation of gcc threads abstraction.
++ */
++
++#include "gthr-amigaos.h"
++
++#include <pthread.h>
++#include <proto/exec.h>
++
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
++/******************************************************************************/
++
++typedef struct
++{
++  union
++  {
++    __gthread_once_t gonce;
++    pthread_once_t ponce;
++  } u;
++} __internal_gthread_once_t;
++
++typedef struct
++{
++  union
++  {
++    __gthread_mutex_t gmutex;
++    pthread_mutex_t pmutex;
++  } u;
++} __internal_gthread_mutex_t;
++
++typedef struct
++{
++  union
++  {
++    __gthread_cond_t gcond;
++    pthread_cond_t pcond;
++  } u;
++} __internal_gthread_cond_t;
++
++
++/******************************************************************************/
++
++#include "gthr-amigaos-asserts.h"
++
++/******************************************************************************/
++
++int
++__gthread_active_p (void)
++{
++  /* Thread-system is always active as we have to be explicitly linked to the
++   * final binary.
++   */
++  return 1;
++}
++
++int
++__gthread_once (__gthread_once_t *__once, void (*__func) (void))
++{
++  __internal_gthread_once_t *once = (__internal_gthread_once_t *)__once;
++
++  if (__gthread_active_p ())
++    return pthread_once (&once->u.ponce, __func);
++  else
++    return -1;
++}
++
++int
++__gthread_key_create (__gthread_key_t *__key, void (*__func) (void *))
++{
++  int err;
++  pthread_key_t key;
++
++  if ((err = pthread_key_create (&key, __func)))
++    return err;
++  __key->id = key;
++  return 0;
++}
++
++int
++__gthread_key_delete (__gthread_key_t __key)
++{
++  return pthread_key_delete (__key.id);
++}
++
++void *
++__gthread_getspecific (__gthread_key_t __key)
++{
++  return pthread_getspecific (__key.id);
++}
++
++int
++__gthread_setspecific (__gthread_key_t __key, const void *__v)
++{
++  return pthread_setspecific (__key.id, __v);
++}
++
++int
++__gthread_mutex_init (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  return pthread_mutex_init (&mx->u.pmutex, 0);
++}
++
++int
++__gthread_mutex_destroy (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  return pthread_mutex_destroy (&mx->u.pmutex);
++}
++
++int
++__gthread_mutex_lock (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  return pthread_mutex_lock (&mx->u.pmutex);
++}
++
++int
++__gthread_mutex_trylock (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  return pthread_mutex_trylock (&mx->u.pmutex);
++}
++
++int
++__gthread_mutex_unlock (__gthread_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  return pthread_mutex_unlock (&mx->u.pmutex);
++}
++
++int
++__gthread_recursive_mutex_init (__gthread_recursive_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++
++  pthread_mutexattr_t attr;
++  int err;
++
++  if ((err = pthread_mutexattr_init (&attr)))
++    return err;
++  if ((err = pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE)))
++    goto bailout;
++  if ((err = pthread_mutex_init (&mx->u.pmutex, &attr)))
++    goto bailout;
++  return pthread_mutexattr_destroy (&attr);
++bailout:
++  pthread_mutexattr_destroy (&attr);
++  return err;
++}
++
++int
++__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++  return pthread_mutex_lock (&mx->u.pmutex);
++}
++
++int
++__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++  return pthread_mutex_trylock (&mx->u.pmutex);
++}
++
++int
++__gthread_recursive_mutex_unlock (__gthread_recursive_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++  return pthread_mutex_unlock (&mx->u.pmutex);
++}
++
++int
++__gthread_recursive_mutex_destroy (__gthread_recursive_mutex_t *__mutex)
++{
++  __internal_gthread_mutex_t *mx = (__internal_gthread_mutex_t *)__mutex;
++  return pthread_mutex_destroy (&mx->u.pmutex);
++}
++
++int
++__gthread_create (__gthread_t *thread, void *(*func) (void*), void *args)
++{
++  int err;
++  pthread_t pthread;
++
++  if ((err =  pthread_create (&pthread, NULL, func, args)))
++    return err;
++  *thread = pthread;
++  return 0;
++}
++
++int
++__gthread_join (__gthread_t thread, void **value_ptr)
++{
++  return pthread_join (thread, value_ptr);
++}
++
++int
++__gthread_detach (__gthread_t thread)
++{
++  return pthread_detach (thread);
++}
++
++int
++__gthread_equal (__gthread_t t1, __gthread_t t2)
++{
++  return pthread_equal (t1, t2);
++}
++
++__gthread_t __gthread_self (void)
++{
++  return pthread_self ();
++}
++
++int
++__gthread_yield (void)
++{
++  IExec->Reschedule();
++  return 0;
++}
++
++#ifdef __cplusplus
++}
++#endif
+diff --git a/libgcc/gthr-amigaos-single.c b/libgcc/gthr-amigaos-single.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..d68a3e019fbac94a93a420fcf59476d2563fccbf
+--- /dev/null
++++ b/libgcc/gthr-amigaos-single.c
+@@ -0,0 +1,141 @@
++/**
++ * This is the single-thread implementation of gcc threads abstraction.
++ */
++
++#include "gthr-amigaos.h"
++
++#define UNUSED __attribute__((__unused__))
++
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
++int
++__gthread_active_p (void)
++{
++  return 0;
++}
++
++int
++__gthread_once (__gthread_once_t *__once UNUSED, void (*__func) (void) UNUSED)
++{
++  return 0;
++}
++
++int UNUSED
++__gthread_key_create (__gthread_key_t *__key UNUSED, void (*__func) (void *) UNUSED)
++{
++  return 0;
++}
++
++int UNUSED
++__gthread_key_delete (__gthread_key_t __key UNUSED)
++{
++  return 0;
++}
++
++void *
++__gthread_getspecific (__gthread_key_t __key UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_setspecific (__gthread_key_t __key UNUSED, const void *__v UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_mutex_init (__gthread_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_mutex_destroy (__gthread_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_mutex_lock (__gthread_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_mutex_trylock (__gthread_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_mutex_unlock (__gthread_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_recursive_mutex_init (__gthread_recursive_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_recursive_mutex_unlock (__gthread_recursive_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_recursive_mutex_destroy (__gthread_recursive_mutex_t *__mutex UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_create (__gthread_t *thread, void *(*func) (void*), void *args UNUSED)
++{
++  return 0;
++}
++
++int
++__gthread_join (__gthread_t thread, void **value_ptr)
++{
++  return 0;
++}
++
++int
++__gthread_detach (__gthread_t thread)
++{
++  return 0;
++}
++
++int
++__gthread_equal (__gthread_t t1, __gthread_t t2)
++{
++  return 0;
++}
++
++__gthread_t __gthread_self (void)
++{
++  return 0;
++}
++
++#ifdef __cplusplus
++}
++#endif
+diff --git a/libgcc/gthr-amigaos.h b/libgcc/gthr-amigaos.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..123d3512abed0a43a8c019bbce0d83f0128a89ec
+--- /dev/null
++++ b/libgcc/gthr-amigaos.h
+@@ -0,0 +1,347 @@
++/* Threads compatibility routines for libgcc2 and libobjc.  */
++/* Compile this one with gcc.  */
++/* Copyright (C) 1997-2018 Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify it under
++the terms of the GNU General Public License as published by the Free
++Software Foundation; either version 3, or (at your option) any later
++version.
++
++GCC is distributed in the hope that it will be useful, but WITHOUT ANY
++WARRANTY; without even the implied warranty of MERCHANTABILITY or
++FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++for more details.
++
++Under Section 7 of GPL version 3, you are granted additional
++permissions described in the GCC Runtime Library Exception, version
++3.1, as published by the Free Software Foundation.
++
++You should have received a copy of the GNU General Public License and
++a copy of the GCC Runtime Library Exception along with this program;
++see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++<http://www.gnu.org/licenses/>.  */
++
++#ifndef GCC_GTHR_AMIGAOS_H
++#define GCC_GTHR_AMIGAOS_H
++
++#include <stdlib.h>
++#include <stdint.h>
++
++typedef struct { int data1, data2; } __gthread_once_t;
++
++typedef struct { long unsigned int id; } __gthread_key_t;
++
++/* Should cover at least as much data as the maximum of sizeof(struct SignalSemaphore)
++ * and sizeof(pthread_mutex_t)
++ */
++typedef struct { char data[48]; } __gthread_mutex_t;
++typedef struct { char data[48]; } __gthread_recursive_mutex_t;
++
++typedef struct { char data[8]; } __gthread_cond_t;
++
++typedef int __gthread_t;
++typedef struct { int seconds; long nanoseconds;} __gthread_time_t;
++
++#define __GTHREADS 1
++#define __GTHREADS_CXX0X 1
++
++#define __GTHREAD_ONCE_INIT {0,0}
++//#define __GTHREAD_MUTEX_INIT 0
++#define __GTHREAD_MUTEX_INIT_FUNCTION(mx) __gthread_mutex_init(mx)
++//#define __GTHREAD_RECURSIVE_MUTEX_INIT 0
++#define __GTHREAD_RECURSIVE_MUTEX_INIT_FUNCTION(mx) __gthread_recursive_mutex_init(mx)
++
++//#define __GTHREAD_COND_INIT 0
++#define __GTHREAD_COND_INIT_FUNCTION(cond) __gthread_cond_init(cond)
++
++#ifdef __cplusplus
++extern "C"
++{
++#endif
++
++#ifdef _LIBOBJC
++
++#ifndef UNUSED
++#define UNUSED __attribute__((__unused__))
++#define UNUSED_DEFINED
++#endif
++
++/* Thread local storage for a single thread */
++static void *thread_local_storage = NULL;
++
++/* Backend initialization functions */
++
++/* Initialize the threads subsystem.  */
++static inline int
++__gthread_objc_init_thread_system (void)
++{
++  /* No thread support available */
++  return -1;
++}
++
++/* Close the threads subsystem.  */
++static inline int
++__gthread_objc_close_thread_system (void)
++{
++  /* No thread support available */
++  return -1;
++}
++
++/* Backend thread functions */
++
++/* Create a new thread of execution.  */
++static inline objc_thread_t
++__gthread_objc_thread_detach (void (* func)(void *), void * arg UNUSED)
++{
++  /* No thread support available */
++  return NULL;
++}
++
++/* Set the current thread's priority.  */
++static inline int
++__gthread_objc_thread_set_priority (int priority UNUSED)
++{
++  /* No thread support available */
++  return -1;
++}
++
++/* Return the current thread's priority.  */
++static inline int
++__gthread_objc_thread_get_priority (void)
++{
++  return OBJC_THREAD_INTERACTIVE_PRIORITY;
++}
++
++/* Yield our process time to another thread.  */
++static inline void
++__gthread_objc_thread_yield (void)
++{
++  return;
++}
++
++/* Terminate the current thread.  */
++static inline int
++__gthread_objc_thread_exit (void)
++{
++  /* No thread support available */
++  /* Should we really exit the program */
++  /* exit (&__objc_thread_exit_status); */
++  return -1;
++}
++
++/* Returns an integer value which uniquely describes a thread.  */
++static inline objc_thread_t
++__gthread_objc_thread_id (void)
++{
++  /* No thread support, use 1.  */
++  return (objc_thread_t) 1;
++}
++
++/* Sets the thread's local storage pointer.  */
++static inline int
++__gthread_objc_thread_set_data (void *value)
++{
++  thread_local_storage = value;
++  return 0;
++}
++
++/* Returns the thread's local storage pointer.  */
++static inline void *
++__gthread_objc_thread_get_data (void)
++{
++  return thread_local_storage;
++}
++
++/* Backend mutex functions */
++
++/* Allocate a mutex.  */
++static inline int
++__gthread_objc_mutex_allocate (objc_mutex_t mutex UNUSED)
++{
++  return 0;
++}
++
++/* Deallocate a mutex.  */
++static inline int
++__gthread_objc_mutex_deallocate (objc_mutex_t mutex UNUSED)
++{
++  return 0;
++}
++
++/* Grab a lock on a mutex.  */
++static inline int
++__gthread_objc_mutex_lock (objc_mutex_t mutex UNUSED)
++{
++  /* There can only be one thread, so we always get the lock */
++  return 0;
++}
++
++/* Try to grab a lock on a mutex.  */
++static inline int
++__gthread_objc_mutex_trylock (objc_mutex_t mutex UNUSED)
++{
++  /* There can only be one thread, so we always get the lock */
++  return 0;
++}
++
++/* Unlock the mutex */
++static inline int
++__gthread_objc_mutex_unlock (objc_mutex_t mutex UNUSED)
++{
++  return 0;
++}
++
++/* Backend condition mutex functions */
++
++/* Allocate a condition.  */
++static inline int
++__gthread_objc_condition_allocate (objc_condition_t condition UNUSED)
++{
++  return 0;
++}
++
++/* Deallocate a condition.  */
++static inline int
++__gthread_objc_condition_deallocate (objc_condition_t condition UNUSED)
++{
++  return 0;
++}
++
++/* Wait on the condition */
++static inline int
++__gthread_objc_condition_wait (objc_condition_t condition UNUSED,
++			       objc_mutex_t mutex UNUSED)
++{
++  return 0;
++}
++
++/* Wake up all threads waiting on this condition.  */
++static inline int
++__gthread_objc_condition_broadcast (objc_condition_t condition UNUSED)
++{
++  return 0;
++}
++
++/* Wake up one thread waiting on this condition.  */
++static inline int
++__gthread_objc_condition_signal (objc_condition_t condition UNUSED)
++{
++  return 0;
++}
++
++#ifndef UNUSED_DEFINED
++#undef UNUSED
++#endif
++
++#else /* _LIBOBJC */
++
++int
++__gthread_active_p (void);
++
++int
++__gthread_once (__gthread_once_t *__once, void (*__func) (void));
++
++int
++__gthread_key_create (__gthread_key_t *__key, void (*destroy) (void *));
++
++int
++__gthread_key_delete (__gthread_key_t __key);
++
++void *
++__gthread_getspecific (__gthread_key_t __key);
++
++int
++__gthread_setspecific (__gthread_key_t __key, const void *__v);
++
++int
++__gthread_mutex_init (__gthread_mutex_t *__mutex);
++
++int
++__gthread_mutex_destroy (__gthread_mutex_t *__mutex);
++
++int
++__gthread_mutex_lock (__gthread_mutex_t *__mutex);
++
++int
++__gthread_mutex_trylock (__gthread_mutex_t *__mutex);
++
++int
++__gthread_mutex_unlock (__gthread_mutex_t *__mutex);
++
++int
++__gthread_recursive_mutex_init (__gthread_recursive_mutex_t *__mutex);
++
++int
++__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex);
++
++int
++__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex);
++
++int
++__gthread_recursive_mutex_unlock (__gthread_recursive_mutex_t *__mutex);
++
++int
++__gthread_recursive_mutex_destroy (__gthread_recursive_mutex_t *__mutex);
++
++/******************************************************************************/
++
++int
++__gthread_cond_init (__gthread_cond_t *cond);
++
++int
++__gthread_cond_signal (__gthread_cond_t *__cond);
++
++int
++__gthread_cond_broadcast (__gthread_cond_t *cond);
++
++int
++__gthread_cond_wait (__gthread_cond_t *cond, __gthread_mutex_t *mutex);
++
++int
++__gthread_cond_wait_recursive (__gthread_cond_t *cond,
++                               __gthread_recursive_mutex_t *mutex);
++
++int
++__gthread_cond_timedwait (__gthread_cond_t *cond,
++                            __gthread_mutex_t *mutex,
++                            const __gthread_time_t *abs_timeout);
++
++int
++__gthread_cond_destroy (__gthread_cond_t *__cond);
++
++/******************************************************************************/
++
++int
++__gthread_create (__gthread_t *thread, void *(*func) (void*), void *args);
++
++int
++__gthread_join (__gthread_t thread, void **value_ptr);
++
++int
++__gthread_detach (__gthread_t thread);
++
++int
++__gthread_equal (__gthread_t t1, __gthread_t t2);
++
++__gthread_t
++__gthread_self (void);
++
++int
++__gthread_yield (void);
++
++int
++__gthread_mutex_timedlock (__gthread_mutex_t *m, const __gthread_time_t *abs_timeout);
++
++int
++__gthread_recursive_mutex_timedlock (__gthread_recursive_mutex_t *m,
++                                    const __gthread_time_t *abs_time);
++
++#endif /* _LIBOBJC */
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* ! GCC_GTHR_AMIGAOS_H */
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 449918a6297cc0ba519165d377667bb5c19e8305..66fc04319848b72978faffc8feb9a0f6b40852a6 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -15635,12 +15635,13 @@ $as_echo_n "checking for thread model used by GCC... " >&6; }
+   target_thread_file=`$CXX -v 2>&1 | sed -n 's/^Thread model: //p'`
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $target_thread_file" >&5
+ $as_echo "$target_thread_file" >&6; }
+ 
+ case $target_thread_file in
+     aix)	thread_header=config/rs6000/gthr-aix.h ;;
++    amigaos)	thread_header=gthr-amigaos.h ;;
+     dce)	thread_header=config/pa/gthr-dce.h ;;
+     gcn)	thread_header=config/gcn/gthr-gcn.h ;;
+     lynx)	thread_header=config/gthr-lynx.h ;;
+     mipssde)	thread_header=config/mips/gthr-mipssde.h ;;
+     posix)	thread_header=gthr-posix.h ;;
+     rtems)	thread_header=config/gthr-rtems.h ;;
+-- 
+2.11.0
+

--- a/gcc/10/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/10/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,0 +1,264 @@
+From 4144a15f9b77556506bd8e00ab72de7655228eb3 Mon Sep 17 00:00:00 2001
+From: Sebastian Bauer <mail@sebastianbauer.info>
+Date: Sat, 27 Oct 2018 08:06:21 +0200
+Subject: [PATCH 25/33] Add aregparam attribute for functions for the m68k
+ backend.
+
+These can be used to pass arguments to directly named registers.
+This patch is based on changes that can be found in the mooli/gcc-amiga
+GitHub repository.
+---
+ gcc/config/m68k/m68k-protos.h |   7 +++
+ gcc/config/m68k/m68k.c        | 111 +++++++++++++++++++++++++++++++++++++++++-
+ gcc/config/m68k/m68k.h        |  27 ++++++----
+ 3 files changed, 134 insertions(+), 11 deletions(-)
+
+diff --git a/gcc/config/m68k/m68k-protos.h b/gcc/config/m68k/m68k-protos.h
+index 1c502d7709a619ba6539753b5e712f5bc15eafd8..e97441cc0cf1c7fd8a5704c0426f79188903b308 100644
+--- a/gcc/config/m68k/m68k-protos.h
++++ b/gcc/config/m68k/m68k-protos.h
+@@ -111,6 +111,13 @@ extern const char *m68k_cpp_cpu_ident (const char *);
+ extern const char *m68k_cpp_cpu_family (const char *);
+ extern void init_68881_table (void);
+ extern rtx m68k_legitimize_call_address (rtx);
+ extern rtx m68k_legitimize_sibcall_address (rtx);
+ extern int m68k_hard_regno_rename_ok(unsigned int, unsigned int);
+ extern poly_int64 m68k_push_rounding (poly_int64);
++
++
++#ifdef TREE_CODE
++#ifdef RTX_CODE /* inside TREE_CODE */
++extern void m68k_init_cumulative_args (CUMULATIVE_ARGS*, tree, rtx, tree, int);
++#endif /* RTX_CODE inside TREE_CODE */
++#endif /* TREE_CODE */
+diff --git a/gcc/config/m68k/m68k.c b/gcc/config/m68k/m68k.c
+index 67b109447b3a5282bbf90566f74afd31045e1a95..ac18865dd7136b2af7b127f99d6f698e2764a507 100644
+--- a/gcc/config/m68k/m68k.c
++++ b/gcc/config/m68k/m68k.c
+@@ -361,12 +361,14 @@ static void m68k_asm_final_postscan_insn (FILE *, rtx_insn *insn, rtx [], int);
+ #define TARGET_ASM_FINAL_POSTSCAN_INSN m68k_asm_final_postscan_insn
+ 
+ static const struct attribute_spec m68k_attribute_table[] =
+ {
+   /* { name, min_len, max_len, decl_req, type_req, fn_type_req,
+        affects_type_identity, handler, exclude } */
++  { "aregparam", 1, 16, false, false, false, false,
++    m68k_handle_fndecl_attribute, NULL },
+   { "interrupt", 0, 0, true,  false, false, false,
+     m68k_handle_fndecl_attribute, NULL },
+   { "interrupt_handler", 0, 0, true,  false, false, false,
+     m68k_handle_fndecl_attribute, NULL },
+   { "interrupt_thread", 0, 0, true,  false, false, false,
+     m68k_handle_fndecl_attribute, NULL },
+@@ -1382,18 +1384,102 @@ m68k_reg_present_p (const_rtx parallel, unsigned int regno)
+ 	return true;
+     }
+ 
+   return false;
+ }
+ 
++/* Map register names from strings to their index used through code the
++ * rest of the code. */
++
++static int m68k_register (const char *regname)
++{
++  if (regname[0] == 'a' || regname[0] == 'A')
++    {
++      if (regname[1] >= '0' && regname[1] <= '7' && !regname[2])
++        return regname[1] - '0' + A0_REG;
++    }
++  else if (regname[0] == 'd' || regname[0] == 'D')
++    {
++      if (regname[1] >= '0' && regname[1] <= '7' && !regname[2])
++        return regname[1] - '0' + D0_REG;
++    }
++  return -1;
++}
++
++/* Store the registers mentioned in the aregparam attribute in the
++ * order of their appearance in the regparams array but not more
++ * than regparams_max_count. Return the number of actually written
++ * entries */
++
++static int
++m68k_regparams (tree fndecl, int *regparams, int regparams_max_count)
++{
++  int regparams_count = 0;
++
++  if (fndecl == NULL_TREE)
++    return 0;
++  if (TREE_CODE (fndecl) != FUNCTION_DECL)
++    return 0;
++
++  tree attrs = DECL_ATTRIBUTES (fndecl);
++
++  tree attr;
++  if ((attr = lookup_attribute ("aregparam", attrs)))
++    {
++      /* Scan list of registers */
++      tree parms = TREE_VALUE (attr);
++      while (parms != NULL_TREE)
++        {
++          if (TREE_CODE (parms) == TREE_LIST)
++            {
++              if (regparams_count == regparams_max_count)
++                return regparams_count;
++
++              tree reg = TREE_VALUE (parms);
++              if (TREE_CODE (reg) == STRING_CST)
++                {
++                  const char *regname = TREE_STRING_POINTER (reg);
++                  int regno = m68k_register(regname);
++
++                  if (regno != -1)
++                    {
++                      regparams[regparams_count] = regno;
++                      regparams_count++;
++                    } else
++                    {
++                      error ("Unknown register %s", regname);
++                    }
++                } else if (TREE_CODE(reg) == INTEGER_CST)
++                {
++                  int regno = tree_to_shwi(reg);
++                  if (regno >= 0 && regno < 16)
++                    {
++                      regparams[regparams_count] = regno;
++                      regparams_count++;
++                    } else
++                    {
++                      error ("Register value must be between 0 and 16 (inclusive), it was %d", regno);
++                    }
++                }
++            }
++
++            parms = TREE_CHAIN(parms);
++        }
++    }
++  return regparams_count;
++}
++
+ /* Implement TARGET_FUNCTION_OK_FOR_SIBCALL_P.  */
+ 
+ static bool
+ m68k_ok_for_sibcall_p (tree decl, tree exp)
+ {
+   enum m68k_function_kind kind;
++  int regparams_count;
++  int regparams[24];
++  int i;
+   
+   /* We cannot use sibcalls for nested functions because we use the
+      static chain register for indirect calls.  */
+   if (CALL_EXPR_STATIC_CHAIN (exp))
+     return false;
+ 
+@@ -1414,12 +1500,21 @@ m68k_ok_for_sibcall_p (tree decl, tree exp)
+       if (!(rtx_equal_p (cfun_value, call_value)
+ 	    || (REG_P (cfun_value)
+ 		&& m68k_reg_present_p (call_value, REGNO (cfun_value)))))
+ 	return false;
+     }
+ 
++  /* Also don't optimize if the sibling uses non-clobber registers */
++  regparams_count = m68k_regparams (decl, regparams, sizeof (regparams) / sizeof (regparams[0]));
++  for (i = 0; i < regparams_count; i++)
++    {
++      static const char call_used_registers[] = CALL_USED_REGISTERS;
++      if (!call_used_registers[regparams[i]])
++        return false;
++    }
++
+   kind = m68k_get_function_kind (current_function_decl);
+   if (kind == m68k_fk_normal_function)
+     /* We can always sibcall from a normal function, because it's
+        undefined if it is calling an interrupt function.  */
+     return true;
+ 
+@@ -1428,24 +1523,38 @@ m68k_ok_for_sibcall_p (tree decl, tree exp)
+   if (decl && m68k_get_function_kind (decl) == kind)
+     return true;
+   
+   return false;
+ }
+ 
+-/* On the m68k all args are always pushed.  */
++
++/* On the m68k all args are always pushed, except if the function is attributed
++   with aregparam which can be used to select the registers specificly */
++
++void
++m68k_init_cumulative_args (m68k_args *cum, tree fntype, rtx_def *, tree fndecl, int caller)
++{
++  memset(cum, 0, sizeof(*cum));
++
++  cum->regparams_count = m68k_regparams (fndecl, cum->regparams, sizeof(cum->regparams)/sizeof(cum->regparams[0]));
++}
+ 
+ static rtx
+ m68k_function_arg (cumulative_args_t, const function_arg_info &)
+ {
++  // FIXME: 'Add aregparam attribute for functions for the m68k backend.'
++  // could not be applied.
+   return NULL_RTX;
+ }
+ 
+ static void
+ m68k_function_arg_advance (cumulative_args_t cum_v,
+ 			   const function_arg_info &arg)
+ {
++  // FIXME: 'Add aregparam attribute for functions for the m68k backend.'
++  // could not be applied.
+   CUMULATIVE_ARGS *cum = get_cumulative_args (cum_v);
+ 
+   *cum += (arg.promoted_size_in_bytes () + 3) & ~3;
+ }
+ 
+ /* Convert X to a legitimate function call memory reference and return the
+diff --git a/gcc/config/m68k/m68k.h b/gcc/config/m68k/m68k.h
+index 85e8f8472a730aa38c87747adcb6ff0ac4d6b978..dfe11b38b99a8a46cf14c2748a4fecb03c262ece 100644
+--- a/gcc/config/m68k/m68k.h
++++ b/gcc/config/m68k/m68k.h
+@@ -484,22 +484,29 @@ extern enum reg_class regno_reg_class[];
+ 
+ /* Define this to be true when FUNCTION_VALUE_REGNO_P is true for
+    more than one register.
+    XXX This macro is m68k specific and used only for m68kemb.h.  */
+ #define NEEDS_UNTYPED_CALL 0
+ 
+-/* On the m68k, all arguments are usually pushed on the stack.  */
+-#define FUNCTION_ARG_REGNO_P(N) 0
+-
+-/* On the m68k, this is a single integer, which is a number of bytes
+-   of arguments scanned so far.  */
+-#define CUMULATIVE_ARGS int
+-
+-/* On the m68k, the offset starts at 0.  */
+-#define INIT_CUMULATIVE_ARGS(CUM, FNTYPE, LIBNAME, INDIRECT, N_NAMED_ARGS) \
+- ((CUM) = 0)
++/* On the m68k, all arguments can be passed via registers via aregparam
++ * attribute. Usually, they are passed on the stack though.
++.*/
++#define FUNCTION_ARG_REGNO_P(N) 1
++
++typedef struct m68k_args {
++    int bytes;			/* bytes of arguments scanned so far */
++    int regparams[24];		/* maximal 24 registers, i.e., A0-A7,D0-D7,FP0-FP7 */
++    size_t regparams_count;	/* number of valid entries of regparams */
++    size_t regparams_next;	/* index to regparams which to use next */
++} CUMULATIVE_ARGS;
++ /* Initialize a variable CUM of type CUMULATIVE_ARGS
++   for a call to a function whose data type is FNTYPE.
++   For a library call, FNTYPE is 0.  */
++#define INIT_CUMULATIVE_ARGS(CUM, FNTYPE, LIBNAME, FNDECL, N_NAMED_ARGS) \
++    m68k_init_cumulative_args (&(CUM), (FNTYPE), (LIBNAME), (FNDECL), \
++	(N_NAMED_ARGS) != -1)
+ 
+ #define FUNCTION_PROFILER(FILE, LABELNO)  \
+   asm_fprintf (FILE, "\tlea %LLP%d,%Ra0\n\tjsr mcount\n", (LABELNO))
+ 
+ #define EXIT_IGNORE_STACK 1
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0026-gcc10-Don-t-use-poisoned-define.patch
+++ b/gcc/10/patches/0026-gcc10-Don-t-use-poisoned-define.patch
@@ -1,0 +1,32 @@
+From 3c55e3e48b2b180fd10c1b4ad0483102ec5b7fca Mon Sep 17 00:00:00 2001
+From: "ola.soder@axis.com" <ola.soder@axis.com>
+Date: Sat, 2 Jan 2021 17:22:55 +0100
+Subject: [PATCH 26/33] gcc10: Don't use poisoned define.
+
+---
+ gcc/config/rs6000/amigaos.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index ec0146c4b8c05eb300f8928e475641123c3f5632..19dacdc885e71ef81186b3f990173dade2bd517a 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -16,15 +16,12 @@
+    You should have received a copy of the GNU General Public License
+    along with GCC; see the file COPYING.  If not, write to the
+    Free Software Foundation, 59 Temple Place - Suite 330, Boston,
+    MA 02111-1307, USA.  */
+ 
+ 
+-/* Don't assume anything about the header files. */
+-#define NO_IMPLICIT_EXTERN_C
+-
+ #undef MD_EXEC_PREFIX
+ #undef MD_STARTFILE_PREFIX
+ 
+ /* Make CPU default to 604e. FIXME: Make this 750 later */
+ #undef PROCESSOR_DEFAULT
+ #define PROCESSOR_DEFAULT PROCESSOR_PPC604e
+-- 
+2.11.0
+

--- a/gcc/10/patches/0027-gcc10-Remove-unused-variable.patch
+++ b/gcc/10/patches/0027-gcc10-Remove-unused-variable.patch
@@ -1,0 +1,45 @@
+From b818ed0fcd076d014203e07b8bae9dd614d88964 Mon Sep 17 00:00:00 2001
+From: "ola.soder@axis.com" <ola.soder@axis.com>
+Date: Sat, 2 Jan 2021 17:25:51 +0100
+Subject: [PATCH 27/33] gcc10: Remove unused variable.
+
+---
+ gcc/c/c-parser.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/gcc/c/c-parser.c b/gcc/c/c-parser.c
+index 9e68fbab05edfec41c8a0f59a09ff438c659ad8d..e7c9c5ddfb4824284ab2e9bb2bf995720ba6107a 100644
+--- a/gcc/c/c-parser.c
++++ b/gcc/c/c-parser.c
+@@ -12655,28 +12655,25 @@ c_parser_pragma (c_parser *parser, enum pragma_context context, bool *if_p)
+    * file.
+    */
+   extern int was_tagtypepragma;
+   if (was_tagtypepragma)
+   {
+     c_token *tok = c_parser_peek_token (the_parser);
+-    enum cpp_ttype ret = tok->type;
+     c_parser_consume_token(parser);
+ 
+     c_type_name *ctype = c_parser_type_name(parser);
+     tree ctypetree = groktypename (ctype, NULL, NULL);
+ 
+     /* Make the parsed type available to all functions called from here on */
+     amigaos_current_tagtype = ctypetree;
+ 
+     tok = c_parser_peek_token (the_parser);
+-    ret = tok->type;
+     c_parser_consume_token(parser);
+     c_parser_skip_to_pragma_eol(parser);
+ 
+     tok = c_parser_peek_token (the_parser);
+-    ret = tok->type;
+ 
+     /* Parse the line that follows. We will register for a PLUGIN_FINISH_DECL event
+      * to minimize contermination
+      */
+     bool old_flag_plugin_added = flag_plugin_added;
+     register_callback ("amigaos-tagtype", PLUGIN_FINISH_DECL,
+-- 
+2.11.0
+

--- a/gcc/10/patches/0028-gcc10-Remove-tagtype-attribute.patch
+++ b/gcc/10/patches/0028-gcc10-Remove-tagtype-attribute.patch
@@ -1,0 +1,33 @@
+From 0d8d3dce74382cd5680c3c1c7375a82ba4a3645c Mon Sep 17 00:00:00 2001
+From: "ola.soder@axis.com" <ola.soder@axis.com>
+Date: Sat, 2 Jan 2021 22:05:59 +0100
+Subject: [PATCH 28/33] gcc10: Remove tagtype attribute.
+
+The 'Add tagtype attribute that can be passed to enum' patch needs
+to be adapted. Temporarily disable the patch since adaptation requires
+in-depth understanding of what the patch does.
+---
+ gcc/config/rs6000/amigaos.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index 19dacdc885e71ef81186b3f990173dade2bd517a..1731d3263ced055f39eb150e375392d055acd125 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -394,13 +394,12 @@ do                                   \
+ /* AmigaOS specific attribute */
+ /* { name, min_len, max_len, decl_req, type_req, fn_type_req,
+        affects_type_identity, handler, exclude } */
+ #define SUBTARGET_ATTRIBUTE_TABLE \
+   { "linearvarargs", 0, 0, false, true,  true, false, amigaos_handle_linearvarargs_attribute, NULL}, \
+   { "checktags", 0, 0, false, true, true, false, amigaos_handle_checktags_attribute, NULL}, \
+-  { "tagtype", 1, 1, false, false, false, false, amigaos_handle_tagtype_attribute, NULL}, \
+   { "baserel_restore", 0, 0, false, true, true, false, amigaos_handle_baserel_restore_attribute, NULL }, \
+   { "force_no_baserel", 0, 0, true, false, false, false, amigaos_handle_force_no_baserel_attribute, NULL }, \
+   { "check68kfuncptr", 0, 0, false, true, true, false, amigaos_handle_check68kfuncptr_attribute, NULL }
+ 
+ /* Overrides */
+ 
+-- 
+2.11.0
+

--- a/gcc/10/patches/0029-gcc10-Define-CC1_SPEC.patch
+++ b/gcc/10/patches/0029-gcc10-Define-CC1_SPEC.patch
@@ -1,0 +1,42 @@
+From 07a1773d49b29cc0cad2774d9a712ccbe8c72ec1 Mon Sep 17 00:00:00 2001
+From: "ola.soder@axis.com" <ola.soder@axis.com>
+Date: Sat, 2 Jan 2021 22:07:45 +0100
+Subject: [PATCH 29/33] gcc10: Define CC1_SPEC.
+
+---
+ gcc/config/rs6000/amigaos.h | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index 1731d3263ced055f39eb150e375392d055acd125..eacc455e168c4bf46522151148bc72c09a199485 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -79,12 +79,25 @@
+ %{mcpu=860: -mppc} \
+ %{mcpu=970: -mpower4 -maltivec} \
+ %{mcpu=G5: -mpower4 -maltivec} \
+ %{mcpu=8540: -me500} \
+ %{maltivec: -maltivec}"
+ 
++#undef CC1_SPEC
++#define        CC1_SPEC "%{G*} %(cc1_cpu)" \
++"%{g: %{!fno-eliminate-unused-debug-symbols: -feliminate-unused-debug-symbols}} \
++%{g1: %{!fno-eliminate-unused-debug-symbols: -feliminate-unused-debug-symbols}} \
++%{msdata: -msdata=default} \
++%{mno-sdata: -msdata=none} \
++%{!mbss-plt: %{!msecure-plt: %(cc1_secure_plt_default)}} \
++%{profile: -p} \
++%{faltivec:-maltivec -include altivec.h} %{fno-altivec:-mno-altivec} \
++%<faltivec %<fno-altivec \
++%{vec:-maltivec -include altivec.h} %{fno-vec:-mno-altivec} \
++%<fvec %<fno-vec "
++
+ #define IS_MCRT(MCRTNAME) \
+   (strcmp(amigaos_crt, MCRTNAME) == 0)
+ 
+ /* Make most of the definitions from other compilers available */
+ #undef TARGET_OS_CPP_BUILTINS
+ #define TARGET_OS_CPP_BUILTINS()                \
+-- 
+2.11.0
+

--- a/gcc/10/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
+++ b/gcc/10/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
@@ -1,0 +1,34 @@
+From 32ce32a050ce146a80b64da4495e2bb9c5b8246d Mon Sep 17 00:00:00 2001
+From: "ola.soder@axis.com" <ola.soder@axis.com>
+Date: Fri, 8 Jan 2021 01:02:33 +0100
+Subject: [PATCH 30/33] gcc10: Link lto-dump with -athread=native.
+
+---
+ gcc/config/rs6000/x-amigaos | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/rs6000/x-amigaos b/gcc/config/rs6000/x-amigaos
+index a3dd2195809c2ce1fbab8be854f3c987dccc039b..6d9efb985ff5619c741e44edaf5431b99585b007 100644
+--- a/gcc/config/rs6000/x-amigaos
++++ b/gcc/config/rs6000/x-amigaos
+@@ -3,14 +3,15 @@
+ 
+ ALL_EXECUTABLES=\
+ 	$(COMPILERS) \
+ 	gcov$(exeext) \
+ 	gcov-dump$(exeext) \
+ 	gcov-tool$(exeext) \
++	lto-dump$(exeext) \
+ 	lto-wrapper$(exeext) \
+ 	cpp$(exeext) \
+ 	xgcc$(exeext) \
+ 	xg++$(exeext)
+ 
+ # We use the native amiga thread implementation and additionally remove all
+ # unneeded sections
+-$(ALL_EXECUTABLES) : override LDFLAGS += -athread=native -Wl,--gc-sections
+\ No newline at end of file
++$(ALL_EXECUTABLES) : override LDFLAGS += -athread=native -Wl,--gc-sections
+-- 
+2.11.0
+

--- a/gcc/10/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
+++ b/gcc/10/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
@@ -1,0 +1,55 @@
+From fbeccff7905239df1110729f8f383df85adda8aa Mon Sep 17 00:00:00 2001
+From: "ola.soder@axis.com" <ola.soder@axis.com>
+Date: Fri, 8 Jan 2021 14:03:50 +0100
+Subject: [PATCH 31/33] gcc10: Expose max_align_t when using clib2.
+
+---
+ libstdc++-v3/include/c_global/cstddef | 3 ---
+ libstdc++-v3/include/c_std/cstddef    | 3 ---
+ 2 files changed, 6 deletions(-)
+
+diff --git a/libstdc++-v3/include/c_global/cstddef b/libstdc++-v3/include/c_global/cstddef
+index ce8b2f4bbfaefc29036dca9a6586ab07dc46d340..ce9cd3e9d3c9d70ac3873273c4651b32a060ae7c 100644
+--- a/libstdc++-v3/include/c_global/cstddef
++++ b/libstdc++-v3/include/c_global/cstddef
+@@ -51,17 +51,14 @@
+ 
+ extern "C++"
+ {
+ #if __cplusplus >= 201103L
+ namespace std
+ {
+-/* Needed as clib2 on AmigaOS has no C11 support yet */
+-#if __STDC_VERSION__ >= 201112L
+   // We handle size_t, ptrdiff_t, and nullptr_t in c++config.h.
+   using ::max_align_t;
+-#endif
+ }
+ #endif // C++11
+ 
+ #if __cplusplus >= 201703L
+ namespace std
+ {
+diff --git a/libstdc++-v3/include/c_std/cstddef b/libstdc++-v3/include/c_std/cstddef
+index 266b90b655f31e32873a432c617a589fb2bb3c71..a7f0094969cc26636da59503127b504730fbb9ee 100644
+--- a/libstdc++-v3/include/c_std/cstddef
++++ b/libstdc++-v3/include/c_std/cstddef
+@@ -44,15 +44,12 @@
+ #include <bits/c++config.h>
+ #include <stddef.h>
+ 
+ #if __cplusplus >= 201103L
+ namespace std
+ {
+-/* Needed as clib2 on AmigaOS has no C11 support yet */
+-#if __STDC_VERSION__ >= 201112L
+   // We handle size_t, ptrdiff_t, and nullptr_t in c++config.h.
+   using ::max_align_t;
+-#endif
+ }
+ #endif
+ 
+ #endif // _GLIBCXX_CSTDDEF
+-- 
+2.11.0
+

--- a/gcc/10/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
+++ b/gcc/10/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
@@ -1,0 +1,38 @@
+From d917f0d6f55ab73b8c230777106075396257971d Mon Sep 17 00:00:00 2001
+From: "ola.soder@axis.com" <ola.soder@axis.com>
+Date: Sun, 7 Feb 2021 19:38:47 +0100
+Subject: [PATCH 32/33] gcc10: Don't define __STRICT_ANSI__.
+
+Doing so hides C99 features when configuring libstdc++.
+---
+ libstdc++-v3/config/os/amigaos/os_defines.h | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/libstdc++-v3/config/os/amigaos/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
+index 6b67630b7be7102a9dfb7c104deac6293a13c017..3f2d894b6c28e493e38c114da8d4f8528c4e3a12 100644
+--- a/libstdc++-v3/config/os/amigaos/os_defines.h
++++ b/libstdc++-v3/config/os/amigaos/os_defines.h
+@@ -36,11 +36,18 @@
+ // No ioctl() on AmigaOS
+ #define _GLIBCXX_NO_IOCTL 1
+ 
+ #ifdef __NEWLIB__
+ #define _GLIBCXX_USE_C99_STDINT_TR1 1
+ #define _GLIBCXX_USE_C99 1
+-/* Temporary until newlib behaves properly */
+-#undef __STRICT_ANSI__
+ #endif
+ 
++#undef __STRICT_ANSI__
++/* GCC defines this macro if, and only if, the -ansi switch, or a
++ * -std switch specifying strict conformance to some version of ISO C
++ * or ISO C++, was specified when GCC was invoked. This macro exists
++ * primarily to direct GNU libc's header files to restrict their
++ * definitions to the minimal set found in the 1989 C standard. If
++ * -std is set to > c++98 when building with clib2, configure will be
++ * tricked into believing that existing C99 features are missing. */
++
+ #endif
+-- 
+2.11.0
+

--- a/gcc/10/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
+++ b/gcc/10/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
@@ -1,0 +1,345 @@
+From 23cc0620a5480dd4d0763e20a9084d12be3f6c0f Mon Sep 17 00:00:00 2001
+From: "ola.soder@axis.com" <ola.soder@axis.com>
+Date: Mon, 15 Mar 2021 15:55:11 +0100
+Subject: [PATCH 33/33] gcc10: Fix libstdc++v3 paths.
+
+---
+ libstdc++-v3/src/c++17/fs_ops.cc  |  17 +++++-
+ libstdc++-v3/src/c++17/fs_path.cc | 108 +++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 122 insertions(+), 3 deletions(-)
+
+diff --git a/libstdc++-v3/src/c++17/fs_ops.cc b/libstdc++-v3/src/c++17/fs_ops.cc
+index 81c84dfb557aa3d5064779ae05b5ffbee31bf8f0..9f063eb191a19ec5d6027c11aa6328f833a659f1 100644
+--- a/libstdc++-v3/src/c++17/fs_ops.cc
++++ b/libstdc++-v3/src/c++17/fs_ops.cc
+@@ -135,25 +135,36 @@ fs::absolute(const path& p, error_code& ec)
+ 
+ namespace
+ {
+ #ifdef _GLIBCXX_FILESYSTEM_IS_WINDOWS
+   inline bool is_dot(wchar_t c) { return c == L'.'; }
+ #else
+-  inline bool is_dot(char c) { return c == '.'; }
++  inline bool is_dot(char c)
++  {
++#ifdef __amigaos4__
++      return c == '\0';
++#else
++      return c == '.';
++#endif
++  }
+ #endif
+ 
+   inline bool is_dot(const fs::path& path)
+   {
+     const auto& filename = path.native();
+     return filename.size() == 1 && is_dot(filename[0]);
+   }
+ 
+   inline bool is_dotdot(const fs::path& path)
+   {
+     const auto& filename = path.native();
++#ifdef __amigaos4__
++    return filename.size() == 1 && filename[0] == '/';
++#else
+     return filename.size() == 2 && is_dot(filename[0]) && is_dot(filename[1]);
++#endif
+   }
+ 
+   struct free_as_in_malloc
+   {
+     void operator()(void* p) const { ::free(p); }
+   };
+@@ -1622,14 +1633,18 @@ fs::path fs::temp_directory_path(error_code& ec)
+   p = std::move(buf);
+ #else
+   const char* tmpdir = nullptr;
+   const char* env[] = { "TMPDIR", "TMP", "TEMP", "TEMPDIR", nullptr };
+   for (auto e = env; tmpdir == nullptr && *e != nullptr; ++e)
+     tmpdir = ::getenv(*e);
++#ifdef __amigaos4__
++  p = tmpdir ? tmpdir : "T:";
++#else
+   p = tmpdir ? tmpdir : "/tmp";
+ #endif
++#endif
+   auto st = status(p, ec);
+   if (ec)
+     p.clear();
+   else if (!is_directory(st))
+     {
+       p.clear();
+diff --git a/libstdc++-v3/src/c++17/fs_path.cc b/libstdc++-v3/src/c++17/fs_path.cc
+index edfb91fc6c5ea41d0c72e31687d3b1b2fc973ace..4eb48e28461f9300524db4fee0304f527253de2f 100644
+--- a/libstdc++-v3/src/c++17/fs_path.cc
++++ b/libstdc++-v3/src/c++17/fs_path.cc
+@@ -77,12 +77,38 @@ struct path::_Parser
+   {
+     pos = 0;
+     pair<cmpt, cmpt> root;
+ 
+     const size_t len = input.size();
+ 
++    /* From the MorphOS SDK */
++#ifdef __amigaos4__
++    // look for root name (:)
++    if (input[0] == ':')
++    {
++        // got root directory
++        root.first.str = input.substr(0, 1);
++        root.first.type = _Type::_Root_dir;
++        ++pos;
++    }
++    // look for volume/device designator
++    else if (len > 1)
++    {
++        const auto despos = input.find_first_of(':', 1);
++        if (despos != input.npos)
++        {
++            // got volume/device designator
++            root.first.str = input.substr(0, despos);
++            root.first.type = _Type::_Root_name;
++
++            root.second.str = input.substr(despos, 1);
++            root.second.type = _Type::_Root_dir;
++            pos = despos + 1;
++        }
++    }
++#else
+     // look for root name or root directory
+     if (len && is_dir_sep(input[0]))
+       {
+ #if SLASHSLASH_IS_ROOTNAME
+ 	// look for root name, such as "//foo"
+ 	if (len > 2 && input[1] == input[0])
+@@ -134,12 +160,13 @@ struct path::_Parser
+ 	    root.second.str = input.substr(2, 1);
+ 	    root.second.type = _Type::_Root_dir;
+ 	  }
+ 	pos = input.find_first_not_of(L"/\\", 2);
+       }
+ #endif
++#endif
+ 
+     if (root.second.valid())
+       last_type = root.second.type;
+     else
+       last_type = root.first.type;
+ 
+@@ -156,12 +183,51 @@ struct path::_Parser
+ 
+     const int last_pos = pos;
+ 
+     cmpt f;
+     if (pos != input.npos)
+       {
++    /* From the MorphOS SDK */
++#ifdef __amigaos4__
++    // foo/bar////bleh
++    // =>
++    // 1. "foo" 2, "bar///" 3. "bleh"
++    pos = input.find_first_of(sep, pos);
++    if (pos != input.npos)
++    {
++        const auto end = input.find_first_not_of(sep, pos);
++        if (end == input.npos)
++        {
++            if (pos == last_pos)
++                // "work:/[/...]" met, include these chars as is
++                f.str = input.substr(last_pos, input.length() - last_pos);
++            else
++                // Remove last / as the path ends to one
++                f.str = input.substr(last_pos, input.length() - 1 - last_pos);
++        }
++        else
++        {
++            if (pos == last_pos)
++                // "work:/[/...]something" met, include these chars as is
++                f.str = input.substr(last_pos, end - last_pos);
++            else
++                f.str = input.substr(last_pos, end - 1 - last_pos);
++        }
++        f.type = _Type::_Filename;
++        pos = end;
++    }
++    else if (last_type == _Type::_Filename || last_type == _Type::_Root_dir ||
++            (last_pos == 0 && !input.empty()))
++    {
++        if (last_pos < input.length())
++        {
++            f.str = input.substr(last_pos);
++            f.type = _Type::_Filename;
++        }
++    }
++#else
+ 	pos = input.find_first_not_of(sep, pos);
+ 	if (pos != input.npos)
+ 	  {
+ 	    const auto end = input.find_first_of(sep, pos);
+ 	    f.str = input.substr(pos, end - pos);
+ 	    f.type = _Type::_Filename;
+@@ -173,12 +239,13 @@ struct path::_Parser
+ 	    // [fs.path.itr]/4 An empty element, if trailing non-root
+ 	    // directory-separator present.
+ 	    __glibcxx_assert(is_dir_sep(input.back()));
+ 	    f.str = input.substr(input.length(), 0);
+ 	    f.type = _Type::_Filename;
+ 	  }
++#endif
+       }
+     last_type = f.type;
+     return f;
+   }
+ 
+   string_view_type::size_type
+@@ -932,15 +999,17 @@ path::operator+=(const path& p)
+ 	  orig_filenamelen = back._M_pathname.length();
+ 	  back._M_pathname += it->_M_pathname;
+ 	  extra = it->_M_pathname;
+ 	  ++it;
+ 	}
+     }
++#ifndef __amigaos4__
+   else if (is_dir_sep(_M_pathname.back()) && _M_type() == _Type::_Multi
+       && _M_cmpts.back()._M_type() == _Type::_Filename)
+     orig_filenamelen = 0; // current path has empty filename at end
++#endif
+ 
+   int capacity = 0;
+   if (_M_type() == _Type::_Multi)
+     capacity += _M_cmpts.size();
+   else
+     capacity += 1;
+@@ -1650,24 +1719,39 @@ path::has_filename() const noexcept
+     }
+   return false;
+ }
+ 
+ namespace
+ {
+-  inline bool is_dot(fs::path::value_type c) { return c == dot; }
++  inline bool is_dot(fs::path::value_type c)
++  {
++#ifdef __amigaos4__
++      return c == '\0';
++#else
++      return c == dot;
++#endif
++  }
+ 
+   inline bool is_dot(const fs::path& path)
+   {
+     const auto& filename = path.native();
++#ifdef __amigaos4__
++    return filename.size() == 0;
++#else
+     return filename.size() == 1 && is_dot(filename[0]);
++#endif
+   }
+ 
+   inline bool is_dotdot(const fs::path& path)
+   {
+     const auto& filename = path.native();
++#ifdef __amigaos4__
++    return filename.size() == 1 && filename[0] == '/';
++#else
+     return filename.size() == 2 && is_dot(filename[0]) && is_dot(filename[1]);
++#endif
+   }
+ } // namespace
+ 
+ path
+ path::lexically_normal() const
+ {
+@@ -1756,23 +1840,25 @@ path::lexically_normal() const
+ 	ret += '/'; // using operator/=('/') would replace whole of ret
+ #endif
+       else
+ 	ret /= p;
+     }
+ 
++#ifndef __amigaos4__
+   if (ret._M_cmpts.size() >= 2)
+     {
+       auto back = std::prev(ret.end());
+       // If the last filename is dot-dot, ...
+       if (back->empty() && is_dotdot(*std::prev(back)))
+ 	// ... remove any trailing directory-separator.
+ 	ret = ret.parent_path();
+     }
+   // If the path is empty, add a dot.
+   else if (ret.empty())
+     ret = ".";
++#endif
+ 
+   return ret;
+ }
+ 
+ path
+ path::lexically_relative(const path& base) const
+@@ -1796,29 +1882,41 @@ path::lexically_relative(const path& base) const
+   if (!base.empty())
+     for (auto i = b, end = base.end(); i != end; ++i)
+       if (i->_M_type() == _Type::_Filename && is_disk_designator(i->native()))
+ 	return ret;
+ #endif
+   if (a == end() && b == base.end())
++#ifdef __amigaos4__
++    ret = "";
++#else
+     ret = ".";
++#endif
+   else
+   {
+     int n = 0;
+     for (; b != base.end(); ++b)
+     {
+       const path& p = *b;
+       if (is_dotdot(p))
+ 	--n;
+       else if (!p.empty() && !is_dot(p))
+ 	++n;
+     }
+     if (n == 0 && (a == end() || a->empty()))
++#ifdef __amigaos4__
++      ret = "";
++#else
+       ret = ".";
++#endif
+     else if (n >= 0)
+     {
++#ifdef __amigaos4__
++      const path dotdot("/");
++#else
+       const path dotdot("..");
++#endif
+       while (n--)
+ 	ret /= dotdot;
+       for (; a != end(); ++a)
+ 	ret /= *a;
+     }
+   }
+@@ -1869,13 +1967,19 @@ path::_M_split_cmpts()
+ 
+   if (_M_pathname.empty())
+     {
+       _M_cmpts.type(_Type::_Filename);
+       return;
+     }
+-  if (_M_pathname.length() == 1 && _M_pathname[0] == preferred_separator)
++  if (_M_pathname.length() == 1 &&
++#ifdef __amigaos4__
++      _M_pathname[0] == ':'
++#else
++      _M_pathname[0] == preferred_separator
++#endif
++     )
+     {
+       _M_cmpts.type(_Type::_Root_dir);
+       return;
+     }
+ 
+   _Parser parser(_M_pathname);
+-- 
+2.11.0
+

--- a/gcc/series
+++ b/gcc/series
@@ -3,3 +3,4 @@
 6	releases/gcc-6.4.0	http://ftp.gnu.org/gnu/gcc/gcc-6.4.0/gcc-6.4.0.tar.xz
 8	releases/gcc-8.4.0	http://ftp.gnu.org/gnu/gcc/gcc-8.4.0/gcc-8.4.0.tar.xz
 9	releases/gcc-9.1.0	http://ftp.gnu.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz
+10	releases/gcc-10.3.0	http://github.com/gcc-mirror/gcc/archive/refs/tags/releases/gcc-10.3.0.tar.gz


### PR DESCRIPTION
Two patches haven't been applied. At least one of them is 68k specific
and can't be applied due to changes in the upstream 68k support. Refer
to patch 0028 and line 201 and 210 in patch 0025.