### PR TITLE
clib2: Type mismatch when missing some builtins.

### DIFF
--- a/native-build/makefile
+++ b/native-build/makefile
@@ -47,7 +47,7 @@ COREUTILS_VERSION=5.2.1
 DIST_VERSION=$(shell date +%Y%m%d)-$(shell git rev-list --count HEAD)
 
 CLIB2_URL=https://github.com/sodero/clib2
-CLIB2_SHA1=247ad4b725cf88b847aede6bcc95f2c8fa1c863f
+CLIB2_SHA1=35b79b254874948bfeca6cecbbc417c43d042567
 CLIB2_RELEASE_ARCHIVE_NAME=adtools-os4-clib2-$(DIST_VERSION).lha
 
 CROSS_PREFIX?=$(ROOT_DIR)/root-cross


### PR DESCRIPTION
When using a compiler without __builtin_fpclassify, __builtin_isfinite or __builtin_ignbit there was a type mismatch in include/math.h