### PR TITLE
The clean-clib2 target will fail if downloads dir is missing.

### DIFF
--- a/native-build/makefile
+++ b/native-build/makefile
@@ -461,7 +461,7 @@ upload-release: native-dist
 
 .PHONY: clean-clib2
 clean-clib2:
-	$(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 clean
+	test ! -d $(CLIB2_DIR) && true || $(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 clean
 
 #
 # Cleanup gcc only


### PR DESCRIPTION
Running clean-all multiple times will fail since clean-clib2
assumes that the downloads directory exists.