### PR TITLE
Fix to exception raised by Callable in call_once

### DIFF
--- a/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
-From 9399e81d8102f3f66ce6b6022aa2876b0aab3405 Mon Sep 17 00:00:00 2001
+From a065f15c8bb17b6717633ef513e4c2f12f152499 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/35] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/36] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |   1 +
@@ -3521,5 +3521,5 @@ index 6568adfca2089c116ae2cbdfa8c933aa76fdddf8..16fa6bf68690127c7a735979108b1add
  
  #endif // _GLIBCXX_CSTDDEF
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
-From 308e3f7dd36415e09893aafdc6fd248c33b2b67d Mon Sep 17 00:00:00 2001
+From 5901f8aec0e2f6a0f826903cd483cc1b10f63aeb Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/35] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/36] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions
@@ -397,5 +397,5 @@ index ad8c0e64c056129afcd8bfa2a656749a2febfaaa..85c03f28e37d64865360692a14fcc8a1
  amigaos_legitimize_baserel_address (rtx addr)
  {
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
-From a50bea1109a578bceca29ef3c83c67cdacb42254 Mon Sep 17 00:00:00 2001
+From 07718db105d776cff50b4cd8102132c88ea7c002 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/35] Disable .machine directive generation.
+Subject: [PATCH 03/36] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.
@@ -33,5 +33,5 @@ index 085f7b9c49035ef350361921e29cd7d737497b67..27337ed6de1e09b5d6e27b9533610888
  }
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From aaf565b9a1969dec6df652b191931f60486a4289 Mon Sep 17 00:00:00 2001
+From f7398a949dd5201e983c7d8188d497e548112123 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/35] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/36] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---
@@ -47,5 +47,5 @@ index 3c9bd1490b4ae14462f628a84f5207f1f9cf345f..8039884af0ca0aa105acee03864d0e2f
  	case OPT_static_libstdc__:
  	  library = library >= 0 ? 2 : library;
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
-From 745abd8ce37a2a49484323513c2928291ad8932e Mon Sep 17 00:00:00 2001
+From e6ec2d752903863da6dcf190e18c73e346b6b253 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/35] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/36] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---
@@ -67,5 +67,5 @@ index d8cc254adef2677798354697af5d7eb957c03c9a..9856a8009e42f37defb131ea38284dcf
  }
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
-From 18f9b577bbf71a8c75719b80aaa17fe78f55bf96 Mon Sep 17 00:00:00 2001
+From a01c2a5ac436a00b931a0146cf802f69127c2884 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/35] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/36] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().
@@ -37,5 +37,5 @@ index cf92e18ecdacebad78a6aefc80f727c20c85b63d..9ac8835c794a1dd66afaa081554c8eca
    set_up_specs ();
    putenv_COLLECT_AS_OPTIONS (assembler_options);
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
-From db2bf9f2fe7a80e61d5f0edc50b1ae256d1b40a4 Mon Sep 17 00:00:00 2001
+From 6c249f64bd2d0ebf30f51531484ea1742962ee12 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/35] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/36] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---
@@ -81,5 +81,5 @@ index eb8af567cd525b163017d2aea9923744b4b53e86..8c979f07b0a84af4e0f4ea7214554ff4
  {
    if (__gthread_active_p ())
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,603 +1,395 @@
-From b9a10356ac1f4913c5aa81bf5d47ed5ce1575c62 Mon Sep 17 00:00:00 2001
+From b5b5a3209f4fc3c59198b392b728576612a85f78 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/35] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/36] Added libstc++ support for AmigaOS.
 
 ---
- libstdc++-v3/config/os/amigaos/ctype_base.h   |  59 ++++++
- .../config/os/amigaos/ctype_configure_char.cc |  99 ++++++++++
- libstdc++-v3/config/os/amigaos/ctype_inline.h | 173 +++++++++++++++++
- .../config/os/amigaos/error_constants.h       | 178 ++++++++++++++++++
- libstdc++-v3/config/os/amigaos/os_defines.h   |  43 +++++
- libstdc++-v3/configure.host                   |   3 +
- 6 files changed, 555 insertions(+)
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_base.h
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_inline.h
- create mode 100644 libstdc++-v3/config/os/amigaos/error_constants.h
- create mode 100644 libstdc++-v3/config/os/amigaos/os_defines.h
+ .../os/{generic => amigaos}/ctype_base.h      |  2 +-
+ .../ctype_configure_char.cc                   | 24 ++++++-------
+ .../os/{generic => amigaos}/ctype_inline.h    | 16 ++++-----
+ .../os/{generic => amigaos}/error_constants.h | 34 +++++++++----------
+ .../config/os/{djgpp => amigaos}/os_defines.h | 11 +++---
+ libstdc++-v3/configure.host                   |  3 ++
+ 6 files changed, 48 insertions(+), 42 deletions(-)
+ copy libstdc++-v3/config/os/{generic => amigaos}/ctype_base.h (97%)
+ copy libstdc++-v3/config/os/{bsd/darwin => amigaos}/ctype_configure_char.cc (87%)
+ copy libstdc++-v3/config/os/{generic => amigaos}/ctype_inline.h (96%)
+ copy libstdc++-v3/config/os/{generic => amigaos}/error_constants.h (89%)
+ copy libstdc++-v3/config/os/{djgpp => amigaos}/os_defines.h (85%)
 
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_base.h b/libstdc++-v3/config/os/amigaos/ctype_base.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..260b6142b6fc6a11a1e5f0bf7820b592d09f285e
---- /dev/null
+diff --git a/libstdc++-v3/config/os/generic/ctype_base.h b/libstdc++-v3/config/os/amigaos/ctype_base.h
+similarity index 97%
+copy from libstdc++-v3/config/os/generic/ctype_base.h
+copy to libstdc++-v3/config/os/amigaos/ctype_base.h
+index 62fce6080d16e87d4ad57074b550aaeccb6be62e..260b6142b6fc6a11a1e5f0bf7820b592d09f285e 100644
+--- a/libstdc++-v3/config/os/generic/ctype_base.h
 +++ b/libstdc++-v3/config/os/amigaos/ctype_base.h
-@@ -0,0 +1,59 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 1997-2021 Free Software Foundation, Inc.
 +// Copyright (C) 1997-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
-+
-+// Default information, may not be appropriate for specific host.
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  /// @brief  Base class for ctype.
-+  struct ctype_base
-+  {
-+    // Non-standard typedefs.
-+    typedef const int* 		__to_type;
-+
-+    // NB: Offsets into ctype<char>::_M_table force a particular size
-+    // on the mask type. Because of this, we don't use an enum.
-+    typedef unsigned int 	mask;
-+    static const mask upper    	= 1 << 0;
-+    static const mask lower 	= 1 << 1;
-+    static const mask alpha 	= 1 << 2;
-+    static const mask digit 	= 1 << 3;
-+    static const mask xdigit 	= 1 << 4;
-+    static const mask space 	= 1 << 5;
-+    static const mask print 	= 1 << 6;
-+    static const mask graph 	= (1 << 2) | (1 << 3) | (1 << 9); // alnum|punct
-+    static const mask cntrl 	= 1 << 8;
-+    static const mask punct 	= 1 << 9;
-+    static const mask alnum 	= (1 << 2) | (1 << 3);  // alpha|digit
-+    static const mask blank	= 1 << 10;
-+  };
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
-new file mode 100644
-index 0000000000000000000000000000000000000000..e6f4895aee78da54bc6b1e01df00816206361c41
---- /dev/null
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+diff --git a/libstdc++-v3/config/os/bsd/darwin/ctype_configure_char.cc b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+similarity index 87%
+copy from libstdc++-v3/config/os/bsd/darwin/ctype_configure_char.cc
+copy to libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+index b12c0bd435ca013496f95c0ed9dad9c884b20001..e6f4895aee78da54bc6b1e01df00816206361c41 100644
+--- a/libstdc++-v3/config/os/bsd/darwin/ctype_configure_char.cc
 +++ b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
-@@ -0,0 +1,99 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 2011-2021 Free Software Foundation, Inc.
 +// Copyright (C) 2011-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file ctype_configure_char.cc */
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
-+
-+#include <locale>
-+#include <cstdlib>
-+#include <cstring>
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+// Information as gleaned from /usr/include/ctype.h
-+
-+  const ctype_base::mask*
-+  ctype<char>::classic_table() throw()
-+  { return 0; }
-+
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -39,29 +39,29 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ // Information as gleaned from /usr/include/ctype.h
+ 
+   const ctype_base::mask*
+   ctype<char>::classic_table() throw()
+   { return 0; }
+ 
+-  ctype<char>::ctype(__c_locale, const mask* __table, bool __del,
+-		     size_t __refs)
+-  : facet(__refs), _M_del(__table != 0 && __del),
+-  _M_toupper(NULL), _M_tolower(NULL),
+-  _M_table(__table ? __table : classic_table())
+-  {
 +  ctype<char>::ctype(__c_locale, const mask* __table, bool __del, 
 +		     size_t __refs) 
 +  : facet(__refs), _M_del(__table != 0 && __del), 
 +  _M_toupper(NULL), _M_tolower(NULL), 
 +  _M_table(__table ? __table : classic_table()) 
 +  { 
-+    memset(_M_widen, 0, sizeof(_M_widen));
-+    _M_widen_ok = 0;
-+    memset(_M_narrow, 0, sizeof(_M_narrow));
-+    _M_narrow_ok = 0;
-+  }
-+
+     memset(_M_widen, 0, sizeof(_M_widen));
+     _M_widen_ok = 0;
+     memset(_M_narrow, 0, sizeof(_M_narrow));
+     _M_narrow_ok = 0;
+   }
+ 
+-  ctype<char>::ctype(const mask* __table, bool __del, size_t __refs)
+-  : facet(__refs), _M_del(__table != 0 && __del),
+-  _M_toupper(NULL), _M_tolower(NULL),
 +  ctype<char>::ctype(const mask* __table, bool __del, size_t __refs) 
 +  : facet(__refs), _M_del(__table != 0 && __del), 
 +  _M_toupper(NULL), _M_tolower(NULL), 
-+  _M_table(__table ? __table : classic_table())
+   _M_table(__table ? __table : classic_table())
+-  {
 +  { 
-+    memset(_M_widen, 0, sizeof(_M_widen));
-+    _M_widen_ok = 0;
-+    memset(_M_narrow, 0, sizeof(_M_narrow));
-+    _M_narrow_ok = 0;
-+  }
-+
-+  char
-+  ctype<char>::do_toupper(char __c) const
-+  { return ::toupper((int) __c); }
-+
-+  const char*
-+  ctype<char>::do_toupper(char* __low, const char* __high) const
-+  {
-+    while (__low < __high)
-+      {
-+	*__low = ::toupper((int) *__low);
-+	++__low;
-+      }
-+    return __high;
-+  }
-+
-+  char
-+  ctype<char>::do_tolower(char __c) const
-+  { return ::tolower((int) __c); }
-+
+     memset(_M_widen, 0, sizeof(_M_widen));
+     _M_widen_ok = 0;
+     memset(_M_narrow, 0, sizeof(_M_narrow));
+     _M_narrow_ok = 0;
+   }
+ 
+@@ -81,13 +81,13 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+   }
+ 
+   char
+   ctype<char>::do_tolower(char __c) const
+   { return ::tolower((int) __c); }
+ 
+-  const char*
 +  const char* 
-+  ctype<char>::do_tolower(char* __low, const char* __high) const
-+  {
-+    while (__low < __high)
-+      {
-+	*__low = ::tolower((int) *__low);
-+	++__low;
-+      }
-+    return __high;
-+  }
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_inline.h b/libstdc++-v3/config/os/amigaos/ctype_inline.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..cfa0146ae6b70623c2fe63b864ceef7bce0d5fe0
---- /dev/null
+   ctype<char>::do_tolower(char* __low, const char* __high) const
+   {
+     while (__low < __high)
+       {
+ 	*__low = ::tolower((int) *__low);
+ 	++__low;
+diff --git a/libstdc++-v3/config/os/generic/ctype_inline.h b/libstdc++-v3/config/os/amigaos/ctype_inline.h
+similarity index 96%
+copy from libstdc++-v3/config/os/generic/ctype_inline.h
+copy to libstdc++-v3/config/os/amigaos/ctype_inline.h
+index b6ad988d82edd8a0a12b262103d66d23c812b3f7..cfa0146ae6b70623c2fe63b864ceef7bce0d5fe0 100644
+--- a/libstdc++-v3/config/os/generic/ctype_inline.h
 +++ b/libstdc++-v3/config/os/amigaos/ctype_inline.h
-@@ -0,0 +1,173 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 2000-2021 Free Software Foundation, Inc.
 +// Copyright (C) 2000-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/ctype_inline.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{locale}
-+ */
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -27,16 +27,16 @@
+  *  Do not attempt to use it directly. @headername{locale}
+  */
+ 
+ //
+ // ISO C++ 14882: 22.1  Locales
+ //
+-
 +  
-+// ctype bits to be inlined go here. Non-inlinable (ie virtual do_*)
-+// functions go in ctype.cc
+ // ctype bits to be inlined go here. Non-inlinable (ie virtual do_*)
+ // functions go in ctype.cc
+-
 +  
-+// The following definitions are portable, but insanely slow. If one
-+// cares at all about performance, then specialized ctype
-+// functionality should be added for the native os in question: see
-+// the config/os/bits/ctype_*.h files.
-+
-+// Constructing a synthetic "C" table should be seriously considered...
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  bool
-+  ctype<char>::
-+  is(mask __m, char __c) const
+ // The following definitions are portable, but insanely slow. If one
+ // cares at all about performance, then specialized ctype
+ // functionality should be added for the native os in question: see
+ // the config/os/bits/ctype_*.h files.
+ 
+ // Constructing a synthetic "C" table should be seriously considered...
+@@ -45,19 +45,19 @@ namespace std _GLIBCXX_VISIBILITY(default)
+ {
+ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 
+   bool
+   ctype<char>::
+   is(mask __m, char __c) const
+-  {
 +  { 
-+    if (_M_table)
-+      return _M_table[static_cast<unsigned char>(__c)] & __m;
-+    else
-+      {
-+	bool __ret = false;
+     if (_M_table)
+       return _M_table[static_cast<unsigned char>(__c)] & __m;
+     else
+       {
+ 	bool __ret = false;
+-	const size_t __bitmasksize = 15;
 +	const size_t __bitmasksize = 15; 
-+	size_t __bitcur = 0; // Lowest bitmask in ctype_base == 0
-+	for (; __bitcur <= __bitmasksize; ++__bitcur)
-+	  {
-+	    const mask __bit = static_cast<mask>(1 << __bitcur);
-+	    if (__m & __bit)
-+	      {
-+		bool __testis;
-+		switch (__bit)
-+		  {
-+		  case space:
-+		    __testis = isspace(__c);
-+		    break;
-+		  case print:
-+		    __testis = isprint(__c);
-+		    break;
-+		  case cntrl:
-+		    __testis = iscntrl(__c);
-+		    break;
-+		  case upper:
-+		    __testis = isupper(__c);
-+		    break;
-+		  case lower:
-+		    __testis = islower(__c);
-+		    break;
-+		  case alpha:
-+		    __testis = isalpha(__c);
-+		    break;
-+		  case digit:
-+		    __testis = isdigit(__c);
-+		    break;
-+		  case punct:
-+		    __testis = ispunct(__c);
-+		    break;
-+		  case xdigit:
-+		    __testis = isxdigit(__c);
-+		    break;
-+		  case alnum:
-+		    __testis = isalnum(__c);
-+		    break;
-+		  case graph:
-+		    __testis = isgraph(__c);
-+		    break;
-+#ifdef _GLIBCXX_USE_C99_CTYPE_TR1
-+		  case blank:
-+		    __testis = isblank(__c);
-+		    break;
-+#endif
-+		  default:
-+		    __testis = false;
-+		    break;
-+		  }
-+		__ret |= __testis;
-+	      }
-+	  }
-+	return __ret;
-+      }
-+  }
+ 	size_t __bitcur = 0; // Lowest bitmask in ctype_base == 0
+ 	for (; __bitcur <= __bitmasksize; ++__bitcur)
+ 	  {
+ 	    const mask __bit = static_cast<mask>(1 << __bitcur);
+ 	    if (__m & __bit)
+ 	      {
+@@ -109,29 +109,29 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 		__ret |= __testis;
+ 	      }
+ 	  }
+ 	return __ret;
+       }
+   }
+-
 +   
-+  const char*
-+  ctype<char>::
-+  is(const char* __low, const char* __high, mask* __vec) const
-+  {
-+    if (_M_table)
-+      while (__low < __high)
-+	*__vec++ = _M_table[static_cast<unsigned char>(*__low++)];
-+    else
-+      {
-+	// Highest bitmask in ctype_base == 11.
+   const char*
+   ctype<char>::
+   is(const char* __low, const char* __high, mask* __vec) const
+   {
+     if (_M_table)
+       while (__low < __high)
+ 	*__vec++ = _M_table[static_cast<unsigned char>(*__low++)];
+     else
+       {
+ 	// Highest bitmask in ctype_base == 11.
+-	const size_t __bitmasksize = 15;
 +	const size_t __bitmasksize = 15; 
-+	for (;__low < __high; ++__vec, ++__low)
-+	  {
-+	    mask __m = 0;
-+	    // Lowest bitmask in ctype_base == 0
+ 	for (;__low < __high; ++__vec, ++__low)
+ 	  {
+ 	    mask __m = 0;
+ 	    // Lowest bitmask in ctype_base == 0
+-	    size_t __i = 0;
 +	    size_t __i = 0; 
-+	    for (;__i <= __bitmasksize; ++__i)
-+	      {
-+		const mask __bit = static_cast<mask>(1 << __i);
-+		if (this->is(__bit, *__low))
-+		  __m |= __bit;
-+	      }
-+	    *__vec = __m;
-+	  }
-+      }
-+    return __high;
-+  }
-+
-+  const char*
-+  ctype<char>::
-+  scan_is(mask __m, const char* __low, const char* __high) const
-+  {
-+    if (_M_table)
-+      while (__low < __high
-+	     && !(_M_table[static_cast<unsigned char>(*__low)] & __m))
-+	++__low;
-+    else
-+      while (__low < __high && !this->is(__m, *__low))
-+	++__low;
-+    return __low;
-+  }
-+
-+  const char*
-+  ctype<char>::
-+  scan_not(mask __m, const char* __low, const char* __high) const
-+  {
-+    if (_M_table)
-+      while (__low < __high
-+	     && (_M_table[static_cast<unsigned char>(*__low)] & __m) != 0)
-+	++__low;
-+    else
-+      while (__low < __high && this->is(__m, *__low) != 0)
-+	++__low;
-+    return __low;
-+  }
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/error_constants.h b/libstdc++-v3/config/os/amigaos/error_constants.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..74492cf61c875eac28cb8a86d5bfdb3b8807aa16
---- /dev/null
+ 	    for (;__i <= __bitmasksize; ++__i)
+ 	      {
+ 		const mask __bit = static_cast<mask>(1 << __i);
+ 		if (this->is(__bit, *__low))
+ 		  __m |= __bit;
+ 	      }
+diff --git a/libstdc++-v3/config/os/generic/error_constants.h b/libstdc++-v3/config/os/amigaos/error_constants.h
+similarity index 89%
+copy from libstdc++-v3/config/os/generic/error_constants.h
+copy to libstdc++-v3/config/os/amigaos/error_constants.h
+index 9d01c16ee2711daa822df00a7e8683a7baf22b52..74492cf61c875eac28cb8a86d5bfdb3b8807aa16 100644
+--- a/libstdc++-v3/config/os/generic/error_constants.h
 +++ b/libstdc++-v3/config/os/amigaos/error_constants.h
-@@ -0,0 +1,178 @@
-+// Specific definitions for generic platforms  -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Specific definitions for generic platforms  -*- C++ -*-
+ 
+-// Copyright (C) 2007-2021 Free Software Foundation, Inc.
 +// Copyright (C) 2007-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/error_constants.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{system_error}
-+ */
-+
-+#ifndef _GLIBCXX_ERROR_CONSTANTS
-+#define _GLIBCXX_ERROR_CONSTANTS 1
-+
-+#include <bits/c++config.h>
-+#include <cerrno>
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  enum class errc
-+    {
-+      address_family_not_supported = 		EAFNOSUPPORT,
-+      address_in_use = 				EADDRINUSE,
-+      address_not_available = 			EADDRNOTAVAIL,
-+      already_connected = 			EISCONN,
-+      argument_list_too_long = 			E2BIG,
-+      argument_out_of_domain = 			EDOM,
-+      bad_address = 				EFAULT,
-+      bad_file_descriptor = 			EBADF,
-+
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -45,13 +45,13 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       already_connected = 			EISCONN,
+       argument_list_too_long = 			E2BIG,
+       argument_out_of_domain = 			EDOM,
+       bad_address = 				EFAULT,
+       bad_file_descriptor = 			EBADF,
+ 
+-#ifdef EBADMSG
 +#ifdef _GLIBCXX_HAVE_EBADMSG
-+      bad_message = 				EBADMSG,
-+#endif
-+
-+      broken_pipe = 				EPIPE,
-+      connection_aborted = 			ECONNABORTED,
-+      connection_already_in_progress = 		EALREADY,
-+      connection_refused = 			ECONNREFUSED,
-+      connection_reset = 			ECONNRESET,
-+      cross_device_link = 			EXDEV,
-+      destination_address_required = 		EDESTADDRREQ,
-+      device_or_resource_busy = 		EBUSY,
-+      directory_not_empty = 			ENOTEMPTY,
-+      executable_format_error = 		ENOEXEC,
-+      file_exists = 	       			EEXIST,
-+      file_too_large = 				EFBIG,
-+      filename_too_long = 			ENAMETOOLONG,
-+      function_not_supported = 			ENOSYS,
-+      host_unreachable = 			EHOSTUNREACH,
-+
+       bad_message = 				EBADMSG,
+ #endif
+ 
+       broken_pipe = 				EPIPE,
+       connection_aborted = 			ECONNABORTED,
+       connection_already_in_progress = 		EALREADY,
+@@ -65,13 +65,13 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       file_exists = 	       			EEXIST,
+       file_too_large = 				EFBIG,
+       filename_too_long = 			ENAMETOOLONG,
+       function_not_supported = 			ENOSYS,
+       host_unreachable = 			EHOSTUNREACH,
+ 
+-#ifdef EIDRM
 +#ifdef _GLIBCXX_HAVE_EIDRM
-+      identifier_removed = 			EIDRM,
-+#endif
-+
-+      illegal_byte_sequence = 			EILSEQ,
-+      inappropriate_io_control_operation = 	ENOTTY,
-+      interrupted = 				EINTR,
-+      invalid_argument = 			EINVAL,
-+      invalid_seek = 				ESPIPE,
-+      io_error = 				EIO,
-+      is_a_directory = 				EISDIR,
-+      message_size = 				EMSGSIZE,
-+      network_down = 				ENETDOWN,
-+      network_reset = 				ENETRESET,
-+      network_unreachable = 			ENETUNREACH,
-+      no_buffer_space = 			ENOBUFS,
-+      no_child_process = 			ECHILD,
-+
+       identifier_removed = 			EIDRM,
+ #endif
+ 
+       illegal_byte_sequence = 			EILSEQ,
+       inappropriate_io_control_operation = 	ENOTTY,
+       interrupted = 				EINTR,
+@@ -83,92 +83,92 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       network_down = 				ENETDOWN,
+       network_reset = 				ENETRESET,
+       network_unreachable = 			ENETUNREACH,
+       no_buffer_space = 			ENOBUFS,
+       no_child_process = 			ECHILD,
+ 
+-#ifdef ENOLINK
 +#ifdef _GLIBCXX_HAVE_ENOLINK
-+      no_link = 				ENOLINK,
-+#endif
-+
-+      no_lock_available = 			ENOLCK,
-+
+       no_link = 				ENOLINK,
+ #endif
+ 
+       no_lock_available = 			ENOLCK,
+ 
+-#ifdef ENODATA
+-      no_message_available = 			ENODATA,
 +#ifdef _GLIBCXX_HAVE_ENODATA
 +      no_message_available = 			ENODATA, 
-+#endif
-+
+ #endif
+ 
+-      no_message = 				ENOMSG,
 +      no_message = 				ENOMSG, 
-+      no_protocol_option = 			ENOPROTOOPT,
-+      no_space_on_device = 			ENOSPC,
-+
+       no_protocol_option = 			ENOPROTOOPT,
+       no_space_on_device = 			ENOSPC,
+ 
+-#ifdef ENOSR
 +#ifdef _GLIBCXX_HAVE_ENOSR
-+      no_stream_resources = 			ENOSR,
-+#endif
-+
-+      no_such_device_or_address = 		ENXIO,
-+      no_such_device = 				ENODEV,
-+      no_such_file_or_directory = 		ENOENT,
-+      no_such_process = 			ESRCH,
-+      not_a_directory = 			ENOTDIR,
-+      not_a_socket = 				ENOTSOCK,
-+
+       no_stream_resources = 			ENOSR,
+ #endif
+ 
+       no_such_device_or_address = 		ENXIO,
+       no_such_device = 				ENODEV,
+       no_such_file_or_directory = 		ENOENT,
+       no_such_process = 			ESRCH,
+       not_a_directory = 			ENOTDIR,
+       not_a_socket = 				ENOTSOCK,
+ 
+-#ifdef ENOSTR
 +#ifdef _GLIBCXX_HAVE_ENOSTR
-+      not_a_stream = 				ENOSTR,
-+#endif
-+
-+      not_connected = 				ENOTCONN,
-+      not_enough_memory = 			ENOMEM,
-+
+       not_a_stream = 				ENOSTR,
+ #endif
+ 
+       not_connected = 				ENOTCONN,
+       not_enough_memory = 			ENOMEM,
+ 
+-#ifdef ENOTSUP
 +#ifdef _GLIBCXX_HAVE_ENOTSUP
-+      not_supported = 				ENOTSUP,
-+#endif
-+
+       not_supported = 				ENOTSUP,
+ #endif
+ 
+-#ifdef ECANCELED
 +#ifdef _GLIBCXX_HAVE_ECANCELED
-+      operation_canceled = 			ECANCELED,
-+#endif
-+
-+      operation_in_progress = 			EINPROGRESS,
-+      operation_not_permitted = 		EPERM,
-+      operation_not_supported = 		EOPNOTSUPP,
-+      operation_would_block = 			EWOULDBLOCK,
-+
+       operation_canceled = 			ECANCELED,
+ #endif
+ 
+       operation_in_progress = 			EINPROGRESS,
+       operation_not_permitted = 		EPERM,
+       operation_not_supported = 		EOPNOTSUPP,
+       operation_would_block = 			EWOULDBLOCK,
+ 
+-#ifdef EOWNERDEAD
 +#ifdef _GLIBCXX_HAVE_EOWNERDEAD
-+      owner_dead = 				EOWNERDEAD,
-+#endif
-+
-+      permission_denied = 			EACCES,
-+
+       owner_dead = 				EOWNERDEAD,
+ #endif
+ 
+       permission_denied = 			EACCES,
+ 
+-#ifdef EPROTO
 +#ifdef _GLIBCXX_HAVE_EPROTO
-+      protocol_error = 				EPROTO,
-+#endif
-+
-+      protocol_not_supported = 			EPROTONOSUPPORT,
-+      read_only_file_system = 			EROFS,
-+      resource_deadlock_would_occur = 		EDEADLK,
-+      resource_unavailable_try_again = 		EAGAIN,
-+      result_out_of_range = 			ERANGE,
-+
+       protocol_error = 				EPROTO,
+ #endif
+ 
+       protocol_not_supported = 			EPROTONOSUPPORT,
+       read_only_file_system = 			EROFS,
+       resource_deadlock_would_occur = 		EDEADLK,
+       resource_unavailable_try_again = 		EAGAIN,
+       result_out_of_range = 			ERANGE,
+ 
+-#ifdef ENOTRECOVERABLE
 +#ifdef _GLIBCXX_HAVE_ENOTRECOVERABLE
-+      state_not_recoverable = 			ENOTRECOVERABLE,
-+#endif
-+
+       state_not_recoverable = 			ENOTRECOVERABLE,
+ #endif
+ 
+-#ifdef ETIME
 +#ifdef _GLIBCXX_HAVE_ETIME
-+      stream_timeout = 				ETIME,
-+#endif
-+
+       stream_timeout = 				ETIME,
+ #endif
+ 
+-#ifdef ETXTBSY
 +#ifdef _GLIBCXX_HAVE_ETXTBSY
-+      text_file_busy = 				ETXTBSY,
-+#endif
-+
-+      timed_out = 				ETIMEDOUT,
-+      too_many_files_open_in_system = 		ENFILE,
-+      too_many_files_open = 			EMFILE,
-+      too_many_links = 				EMLINK,
-+      too_many_symbolic_link_levels = 		ELOOP,
-+
+       text_file_busy = 				ETXTBSY,
+ #endif
+ 
+       timed_out = 				ETIMEDOUT,
+       too_many_files_open_in_system = 		ENFILE,
+       too_many_files_open = 			EMFILE,
+       too_many_links = 				EMLINK,
+       too_many_symbolic_link_levels = 		ELOOP,
+ 
+-#ifdef EOVERFLOW
 +#ifdef _GLIBCXX_HAVE_EOVERFLOW
-+      value_too_large = 			EOVERFLOW,
-+#endif
-+
-+      wrong_protocol_type = 			EPROTOTYPE
-+    };
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-+
-+#endif
-diff --git a/libstdc++-v3/config/os/amigaos/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..346f063958cd7e80ebf97be4acee0bdf391cb811
---- /dev/null
+       value_too_large = 			EOVERFLOW,
+ #endif
+ 
+       wrong_protocol_type = 			EPROTOTYPE
+     };
+ 
+diff --git a/libstdc++-v3/config/os/djgpp/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
+similarity index 85%
+copy from libstdc++-v3/config/os/djgpp/os_defines.h
+copy to libstdc++-v3/config/os/amigaos/os_defines.h
+index 11c783871accd6e8f9bcbb076654e9c49e27b2cc..346f063958cd7e80ebf97be4acee0bdf391cb811 100644
+--- a/libstdc++-v3/config/os/djgpp/os_defines.h
 +++ b/libstdc++-v3/config/os/amigaos/os_defines.h
-@@ -0,0 +1,43 @@
+@@ -1,9 +1,9 @@
+-// Specific definitions for DJGPP  -*- C++ -*-
 +// Specific definitions for AmigaOS -*- C++ -*-
-+
+ 
+-// Copyright (C) 2001-2021 Free Software Foundation, Inc.
 +// Copyright (C) 2000-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/os_defines.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{iosfwd}
-+ */
-+
-+#ifndef _GLIBCXX_OS_DEFINES
-+#define _GLIBCXX_OS_DEFINES 1
-+
-+// System-specific #define, typedefs, corrections, etc, go here.  This
-+// file will come before all others.
-+
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -30,11 +30,14 @@
+ #ifndef _GLIBCXX_OS_DEFINES
+ #define _GLIBCXX_OS_DEFINES 1
+ 
+ // System-specific #define, typedefs, corrections, etc, go here.  This
+ // file will come before all others.
+ 
+-// FIXME: should there be '#undef POSIX_SOURCE'?
 +// No ioctl() on AmigaOS
 +#define _GLIBCXX_NO_IOCTL 1
-+
+ 
 +#ifdef __NEWLIB__
 +#define _GLIBCXX_USE_C99_STDINT_TR1 1
-+#endif
-+
+ #endif
+ 
+-
 +#endif
 diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
 index ec32980aa0db898623804980af65dad588e4d9f5..e9789a4981c6fc36c6b660ab768427bb42eb6509 100644
@@ -620,5 +412,5 @@ index ec32980aa0db898623804980af65dad588e4d9f5..e9789a4981c6fc36c6b660ab768427bb
    cygwin*)
      os_include_dir="os/newlib"
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,154 +1,100 @@
-From a1c843d1830e526435bc1a8bace78f6523a98d1b Mon Sep 17 00:00:00 2001
+From c9fb3357d886c3e9561e008b9087c9b75caef37d Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 09/35] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 09/36] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---
- libatomic/config/amigaos/host-config.h |  55 +++++++++++++
- libatomic/config/amigaos/lock.c        | 102 +++++++++++++++++++++++++
- libatomic/configure.tgt                |   4 +
- 3 files changed, 161 insertions(+)
- create mode 100644 libatomic/config/amigaos/host-config.h
- create mode 100644 libatomic/config/amigaos/lock.c
+ .../config/{posix => amigaos}/host-config.h   |  2 +-
+ libatomic/config/{posix => amigaos}/lock.c    | 64 ++++++++-----------
+ libatomic/configure.tgt                       |  4 ++
+ 3 files changed, 30 insertions(+), 40 deletions(-)
+ copy libatomic/config/{posix => amigaos}/host-config.h (96%)
+ copy libatomic/config/{posix => amigaos}/lock.c (68%)
 
-diff --git a/libatomic/config/amigaos/host-config.h b/libatomic/config/amigaos/host-config.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..879758e4eb5594a79b8ee2d25564b19a6f51cd31
---- /dev/null
+diff --git a/libatomic/config/posix/host-config.h b/libatomic/config/amigaos/host-config.h
+similarity index 96%
+copy from libatomic/config/posix/host-config.h
+copy to libatomic/config/amigaos/host-config.h
+index 62be4cb0c52e489bef2a2cd71d1bc47d2980784c..879758e4eb5594a79b8ee2d25564b19a6f51cd31 100644
+--- a/libatomic/config/posix/host-config.h
 +++ b/libatomic/config/amigaos/host-config.h
-@@ -0,0 +1,55 @@
+@@ -1,7 +1,7 @@
+-/* Copyright (C) 2012-2021 Free Software Foundation, Inc.
 +/* Copyright (C) 2012-2015 Free Software Foundation, Inc.
-+   Contributed by Richard Henderson <rth@redhat.com>.
-+
-+   This file is part of the GNU Atomic Library (libatomic).
-+
-+   Libatomic is free software; you can redistribute it and/or modify it
-+   under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   Libatomic is distributed in the hope that it will be useful, but WITHOUT ANY
-+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-+   FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+   more details.
-+
-+   Under Section 7 of GPL version 3, you are granted additional
-+   permissions described in the GCC Runtime Library Exception, version
-+   3.1, as published by the Free Software Foundation.
-+
-+   You should have received a copy of the GNU General Public License and
-+   a copy of the GCC Runtime Library Exception along with this program;
-+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+/* Included after all more target-specific host-config.h.  */
-+
-+
-+#ifndef protect_start_end
-+# ifdef HAVE_ATTRIBUTE_VISIBILITY
-+#  pragma GCC visibility push(hidden)
-+# endif
-+
-+void libat_lock_1 (void *ptr);
-+void libat_unlock_1 (void *ptr);
-+
-+static inline UWORD
-+protect_start (void *ptr)
-+{
-+  libat_lock_1 (ptr);
-+  return 0;
-+}
-+
-+static inline void
-+protect_end (void *ptr, UWORD dummy UNUSED)
-+{
-+  libat_unlock_1 (ptr);
-+}
-+
-+# define protect_start_end 1
-+# ifdef HAVE_ATTRIBUTE_VISIBILITY
-+#  pragma GCC visibility pop
-+# endif
-+#endif /* protect_start_end */
-+
-+#include_next <host-config.h>
-diff --git a/libatomic/config/amigaos/lock.c b/libatomic/config/amigaos/lock.c
-new file mode 100644
-index 0000000000000000000000000000000000000000..ffd09f50095429f844bfe6bf7bec8741f56f1a28
---- /dev/null
+    Contributed by Richard Henderson <rth@redhat.com>.
+ 
+    This file is part of the GNU Atomic Library (libatomic).
+ 
+    Libatomic is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+diff --git a/libatomic/config/posix/lock.c b/libatomic/config/amigaos/lock.c
+similarity index 68%
+copy from libatomic/config/posix/lock.c
+copy to libatomic/config/amigaos/lock.c
+index 54766dfd9911ee293f597275ff1d7189d8e55345..ffd09f50095429f844bfe6bf7bec8741f56f1a28 100644
+--- a/libatomic/config/posix/lock.c
 +++ b/libatomic/config/amigaos/lock.c
-@@ -0,0 +1,102 @@
+@@ -1,7 +1,7 @@
+-/* Copyright (C) 2012-2021 Free Software Foundation, Inc.
 +/* Copyright (C) 2012-2015 Free Software Foundation, Inc.
-+   Contributed by Richard Henderson <rth@redhat.com>.
-+
-+   This file is part of the GNU Atomic Library (libatomic).
-+
-+   Libatomic is free software; you can redistribute it and/or modify it
-+   under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   Libatomic is distributed in the hope that it will be useful, but WITHOUT ANY
-+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-+   FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+   more details.
-+
-+   Under Section 7 of GPL version 3, you are granted additional
-+   permissions described in the GCC Runtime Library Exception, version
-+   3.1, as published by the Free Software Foundation.
-+
-+   You should have received a copy of the GNU General Public License and
-+   a copy of the GCC Runtime Library Exception along with this program;
-+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+#include "libatomic_i.h"
-+
+    Contributed by Richard Henderson <rth@redhat.com>.
+ 
+    This file is part of the GNU Atomic Library (libatomic).
+ 
+    Libatomic is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+@@ -20,14 +20,15 @@
+    You should have received a copy of the GNU General Public License and
+    a copy of the GCC Runtime Library Exception along with this program;
+    see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+    <http://www.gnu.org/licenses/>.  */
+ 
+ #include "libatomic_i.h"
+-#include <pthread.h>
+ 
 +#define UWORD UWORD_
 +#include <proto/exec.h>
-+
-+/* The target page size.  Must be no larger than the runtime page size,
-+   lest locking fail with virtual address aliasing (i.e. a page mmaped
-+   at two locations).  */
-+#ifndef PAGE_SIZE
-+#define PAGE_SIZE	4096
-+#endif
-+
-+/* The target cacheline size.  This is an optimization; the padding that
-+   should be applied to the locks to keep them from interfering.  */
-+#ifndef CACHLINE_SIZE
-+#define CACHLINE_SIZE	64
-+#endif
-+
-+/* The granularity at which locks are applied.  Almost certainly the
-+   cachline size is the right thing to use here.  */
-+#ifndef WATCH_SIZE
-+#define WATCH_SIZE	CACHLINE_SIZE
-+#endif
-+
-+struct lock
-+{
+ 
+ /* The target page size.  Must be no larger than the runtime page size,
+    lest locking fail with virtual address aliasing (i.e. a page mmaped
+    at two locations).  */
+ #ifndef PAGE_SIZE
+ #define PAGE_SIZE	4096
+@@ -44,73 +45,58 @@
+ #ifndef WATCH_SIZE
+ #define WATCH_SIZE	CACHLINE_SIZE
+ #endif
+ 
+ struct lock
+ {
+-  pthread_mutex_t mutex;
+-  char pad[sizeof(pthread_mutex_t) < CACHLINE_SIZE
+-	   ? CACHLINE_SIZE - sizeof(pthread_mutex_t)
 +  struct SignalSemaphore sem;
 +  char initialized;
 +  char pad[sizeof(struct SignalSemaphore) + 1 < CACHLINE_SIZE
 +	   ? CACHLINE_SIZE - sizeof(struct SignalSemaphore) - 1
-+	   : 0];
-+};
-+
+ 	   : 0];
+ };
+ 
 +/* TODO: Use a constructor to initialize the semaphore */
-+#define NLOCKS		(PAGE_SIZE / WATCH_SIZE)
+ #define NLOCKS		(PAGE_SIZE / WATCH_SIZE)
+-static struct lock locks[NLOCKS] = {
+-  [0 ... NLOCKS-1].mutex = PTHREAD_MUTEX_INITIALIZER
+-};
 +static struct lock locks[NLOCKS];
-+
-+static inline uintptr_t 
-+addr_hash (void *ptr)
-+{
-+  return ((uintptr_t)ptr / WATCH_SIZE) % NLOCKS;
-+}
-+
-+void
-+libat_lock_1 (void *ptr)
-+{
+ 
+ static inline uintptr_t 
+ addr_hash (void *ptr)
+ {
+   return ((uintptr_t)ptr / WATCH_SIZE) % NLOCKS;
+ }
+ 
+ void
+ libat_lock_1 (void *ptr)
+ {
+-  pthread_mutex_lock (&locks[addr_hash (ptr)].mutex);
 +  struct lock *l = &locks[addr_hash (ptr)];
 +  IExec->Forbid();
 +  if (!l->initialized)
@@ -158,27 +104,57 @@ index 0000000000000000000000000000000000000000..ffd09f50095429f844bfe6bf7bec8741
 +  }
 +  IExec->Permit();
 +  IExec->ObtainSemaphore(&l->sem);
-+}
-+
-+void
-+libat_unlock_1 (void *ptr)
-+{
+ }
+ 
+ void
+ libat_unlock_1 (void *ptr)
+ {
+-  pthread_mutex_unlock (&locks[addr_hash (ptr)].mutex);
 +  struct lock *l = &locks[addr_hash (ptr)];
 +  IExec->ReleaseSemaphore(&l->sem);
-+}
-+
+ }
+ 
 +#if 0
 +
 +/* TODO: Implement me when needed */
-+void
-+libat_lock_n (void *ptr, size_t n)
-+{
-+}
-+
-+void
-+libat_unlock_n (void *ptr, size_t n)
-+{
-+}
+ void
+ libat_lock_n (void *ptr, size_t n)
+ {
+-  uintptr_t h = addr_hash (ptr);
+-  size_t i = 0;
+-
+-  /* Don't lock more than all the locks we have.  */
+-  if (n > PAGE_SIZE)
+-    n = PAGE_SIZE;
+-
+-  do
+-    {
+-      pthread_mutex_lock (&locks[h].mutex);
+-      if (++h == NLOCKS)
+-	h = 0;
+-      i += WATCH_SIZE;
+-    }
+-  while (i < n);
+ }
+ 
+ void
+ libat_unlock_n (void *ptr, size_t n)
+ {
+-  uintptr_t h = addr_hash (ptr);
+-  size_t i = 0;
+-
+-  if (n > PAGE_SIZE)
+-    n = PAGE_SIZE;
+-
+-  do
+-    {
+-      pthread_mutex_unlock (&locks[h].mutex);
+-      if (++h == NLOCKS)
+-	h = 0;
+-      i += WATCH_SIZE;
+-    }
+-  while (i < n);
+ }
 +
 +#endif
 diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
@@ -203,5 +179,5 @@ index 670b0d72cfec2027a02347eb5b62521054f264c4..f78d93afba8849adac23d24b152cf400
  	# If the target supports disabling interrupts, we can work in
  	# kernel-mode, given the system is not multi-processor.
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,7 +1,7 @@
-From 9b4a7f8eae34ff3b28083374576bc0d5c88543bf Mon Sep 17 00:00:00 2001
+From 33102a20e983d901be1859333d922cb32459d2b2 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
-Subject: [PATCH 10/35] Implement libat_lock_n() and libat_unlock_n().
+Subject: [PATCH 10/36] Implement libat_lock_n() and libat_unlock_n().
 
 ---
  libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++-------
@@ -100,5 +100,5 @@ index ffd09f50095429f844bfe6bf7bec8741f56f1a28..82dd696f78cc4afa5592c5fb83f33e91
 -
 -#endif
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/11/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
-From fc020e27aa263cd291810d3913923f40e9862558 Mon Sep 17 00:00:00 2001
+From 60505eb8b49c04957f3e1122484b5e2297f19c8e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/35] Pretend C99 compatibility.
+Subject: [PATCH 11/36] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses
@@ -107,5 +107,5 @@ index 47b954cf2faca25ffbac6d5b5e81857ad22cad90..99325ad0682f2f88bc04ca38a50cc97a
  } // extern "C++"
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
-From fc6fb6e51a900502b00dd7ea1288867ff28e273a Mon Sep 17 00:00:00 2001
+From 75d527aeab41195aa6161eb90ab1c75fb39692ac Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/35] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/36] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-
@@ -50,5 +50,5 @@ index cf771b4f614a98d09190c19fad90624c04e5c69d..854009ca098f9dff59be936425a565dd
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
-From aca719e2ae84f5c6a58b56bfb98e290f3c543b0c Mon Sep 17 00:00:00 2001
+From f5d04240570843fd4419cd0d9ce6f9aa50609145 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/35] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/36] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------
@@ -161,5 +161,5 @@ index 4bacf36d4eb8a597e44dc907591dd30854adebbe..8f7a5e14cb6e8b59a5a53ecde2f75933
  	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/xmalloc.c -o noasan/$@; \
  	else true; fi
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
-From 6384023c2f32dc65ede8868ba6c712b2595e75ad Mon Sep 17 00:00:00 2001
+From 6a98220e936165ce6238e071fcfda1277ef80392 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/35] Add custom implementation of various env-related
+Subject: [PATCH 14/36] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.
@@ -17,7 +17,7 @@ part of the clib like putenv().
  create mode 100644 libiberty/setenv-amigaos.c
 
 diff --git a/libiberty/Makefile.in b/libiberty/Makefile.in
-index 8f7a5e14cb6e8b59a5a53ecde2f7593329c20fa4..4a2c78ce1234a35ecb645e90ba15266ccce727e4 100644
+index 8f7a5e14cb6e8b59a5a53ecde2f7593329c20fa4..f8aed54a79d8a2d16ce79cfe73a0648bb03cd7cc 100644
 --- a/libiberty/Makefile.in
 +++ b/libiberty/Makefile.in
 @@ -144,13 +144,13 @@ CFILES = alloca.c argv.c asprintf.c atexit.c				\
@@ -56,7 +56,7 @@ index 8f7a5e14cb6e8b59a5a53ecde2f7593329c20fa4..4a2c78ce1234a35ecb645e90ba15266c
  	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/safe-ctype.c -o noasan/$@; \
  	else true; fi
  	$(COMPILE.c) $(srcdir)/safe-ctype.c $(OUTPUT_OPTION)
-
+ 
 +./setenv-amigaos.$(objext): $(srcdir)/setenv-amigaos.c
 +	if [ x"$(PICFLAG)" != x ]; then \
 +	  $(COMPILE.c) $(PICFLAG) $(srcdir)/setenv-amigaos.c -o pic/$@; \
@@ -82,7 +82,7 @@ index 9e43c9ae0d66795f2dafb4b6d192579261c1a9ab..99b1a3e12d69c105edb9b1de260275b2
      # function, which AC_CHECK_FUNCS does not handle properly.
      ac_cv_func_getpagesize=yes
      ;;
-
+ 
 +   *-*-amigaos*)
 +     # current newlib lacks unsetenv(), so we custom versions
 +     # of setenv() and unsetenv().
@@ -110,7 +110,7 @@ index 0f9b97cb457b68249dfe1e5424ce312bab705949..d57c6fb4682e21b0bc2094173eab0991
      # function, which AC_CHECK_FUNCS does not handle properly.
      ac_cv_func_getpagesize=yes
      ;;
-
+ 
 +  *-*-amigaos*)
 +    # current newlib lacks unsetenv(), so we custom versions
 +    # of setenv() and unsetenv().
@@ -122,10 +122,10 @@ index 0f9b97cb457b68249dfe1e5424ce312bab705949..d57c6fb4682e21b0bc2094173eab0991
      AC_LIBOBJ([snprintf])
      AC_LIBOBJ([vsnprintf])
      ;;
-
+ 
 diff --git a/libiberty/setenv-amigaos.c b/libiberty/setenv-amigaos.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..59c41e3a47d203cadd03ec834d8d0cff7bbe2168
+index 0000000000000000000000000000000000000000..6ec12b89c740874d0b7a83f322f80d5cd6f7a05e
 --- /dev/null
 +++ b/libiberty/setenv-amigaos.c
 @@ -0,0 +1,74 @@
@@ -203,6 +203,6 @@ index 0000000000000000000000000000000000000000..59c41e3a47d203cadd03ec834d8d0cff
 +   }
 +   return lvar->lv_Value;
 +}
---
-2.30.2
+-- 
+2.34.1
 

--- a/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
-From 5bc937a4934878f1a9e736f9b61ba78ee2f54c00 Mon Sep 17 00:00:00 2001
+From 8982a14a86f101333989f8b8959d031209e2401a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/35] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/36] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.
@@ -41,5 +41,5 @@ index 7b6c63237dd81117f5e0e92860a7b266b903f7d9..7127b05e44ac34d31b17125bce4e6e43
     have no conflict with that.  */
  #ifndef _VA_LIST_
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
-From 9305060083159b762090b2e195e927bfdbab6e93 Mon Sep 17 00:00:00 2001
+From a5b8eb192677e48f84822bc15c20ba8975b5fad5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/35] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/36] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---
@@ -28,5 +28,5 @@ index e1097afdbeea232fb9746a4d872482b54fb412bf..3bfe4699728a6cc25726dc8a193e8b8e
        emit_move_insn (reg, mem);
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
-From a2680a524748c1b61bf80b3d643486e10d3a2c1c Mon Sep 17 00:00:00 2001
+From dd595e5c58180a1ad9e8572bf17dd5cfbfabf789 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/35] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/36] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +
@@ -77,5 +77,5 @@ index 1153ece337930f7bbf5f9978bf6f3faf2138bda6..d339c4280b67d863ec9c60dd38230d7b
  
  #undef INIT_CUMULATIVE_INCOMING_ARGS
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
-From c2fe5e37e23a7161f8aa52de3bcbf254794879e6 Mon Sep 17 00:00:00 2001
+From c64cc31006520260c4a23cc23799442e28402415 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/35] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/36] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---
@@ -29,5 +29,5 @@ index d339c4280b67d863ec9c60dd38230d7bb2549345..f88bfe5f879cb4ca09f067d907ec36ef
  #define LINK_SPEC "\
  --defsym __amigaos4__=1 \
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0019-Add-_Static_warning.patch
+++ b/gcc/11/patches/0019-Add-_Static_warning.patch
@@ -1,7 +1,7 @@
-From 44dc483b3468fc41b12505aba134a9da67664a7a Mon Sep 17 00:00:00 2001
+From 7e5ea9debe2babeb92ebd4e6d081599ea8441004 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
-Subject: [PATCH 19/35] Add _Static_warning().
+Subject: [PATCH 19/36] Add _Static_warning().
 
 This acts very similar to _Static_assert() but produces a warning
 rather than an compiler error.
@@ -137,5 +137,5 @@ index 90d119eaa28025deabc21ef519f9f608a6317c4c..aa7099de9e8822a466f3f459ae10dcb1
  				  /*maybe_range_for_decl*/NULL);
  }
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
+++ b/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
@@ -1,7 +1,7 @@
-From aa7626af9823e4e4a36d250eaf6084f90a3aba06 Mon Sep 17 00:00:00 2001
+From c0a70959ea598b7004bb62e22b42443e090788b4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
-Subject: [PATCH 20/35] Rename lineartags to checktags.
+Subject: [PATCH 20/36] Rename lineartags to checktags.
 
 The name lineartags would imply linearvarargs but this is not implemented
 or necessary.
@@ -110,5 +110,5 @@ index f88bfe5f879cb4ca09f067d907ec36ef0b4c2da3..d4812d8f618c2758bf95ec998f6aa53e
  /* Overrides */
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,7 +1,7 @@
-From 7719077d8b23261bec91aa85be07cc443ad43b73 Mon Sep 17 00:00:00 2001
+From 4257f6d9961b0a9e583bf71f8cabcceb92ca44d3 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
-Subject: [PATCH 21/35] Fix order of AmigaOS PPC sections in the documentation.
+Subject: [PATCH 21/36] Fix order of AmigaOS PPC sections in the documentation.
 
 ---
  gcc/doc/extend.texi |  4 ++--
@@ -84,5 +84,5 @@ index 7c39fc25397cc82a7c42672fdb4f320ffa4930bb..f38461ee463a15f3406df3bb45113686
  @opindex mcrt
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,7 +1,7 @@
-From 1823d28a62b671641da8a6ddcf8a7942afa4226c Mon Sep 17 00:00:00 2001
+From 4cb533514851a1840dea1ce9d8e20884b45f53e1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
-Subject: [PATCH 22/35] Provide a documentation for checktags and tagtype
+Subject: [PATCH 22/36] Provide a documentation for checktags and tagtype
  attributes.
 
 ---
@@ -67,5 +67,5 @@ index 1cd6f26fd93e06e9c2ba4176c64daa6cdaf0048a..11b9555628735dccb8db88e5a4ee3c41
  @cindex Statement Attributes
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 6fff5cadc0f220325ad43df49a941e3dca950258 Mon Sep 17 00:00:00 2001
+From ab20508a3cdea818bb37195cea6d2e960b32e8d7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
-Subject: [PATCH 23/35] Adapt libssp for AmigaOS.
+Subject: [PATCH 23/36] Adapt libssp for AmigaOS.
 
 ---
  libssp/ssp.c | 8 +++++---
@@ -64,5 +64,5 @@ index 6e911f087f1e6dc32fd5a6a54a54d49fed481e99..e036b6fbb32963387a07a6ff791e6afe
       is dead.  */
    {
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0024-Add-amigaos-thread-model.patch
+++ b/gcc/11/patches/0024-Add-amigaos-thread-model.patch
@@ -1,33 +1,33 @@
-From d38dbc52a42486f14cd57ecde6eb9b769a1cb75b Mon Sep 17 00:00:00 2001
+From 1a726f2c22094261ab929462bc51bd250f82e3c4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
-Subject: [PATCH 24/35] Add amigaos thread model.
+Subject: [PATCH 24/36] Add amigaos thread model.
 
 It is work in progress.
 ---
- config/gthr.m4                 |    1 +
- gcc/config.host                |    1 +
- gcc/config/rs6000/amigaos.h    |    8 +-
- gcc/config/rs6000/amigaos.opt  |   18 +
- gcc/config/rs6000/x-amigaos    |   16 +
- gcc/configure                  |    2 +-
- gcc/configure.ac               |    2 +-
- gcc/doc/invoke.texi            |    9 +-
- libgcc/config/rs6000/t-amigaos |    5 +
- libgcc/configure               |    1 +
- libgcc/gthr-amigaos-asserts.h  |    8 +
- libgcc/gthr-amigaos-native.c   | 1017 ++++++++++++++++++++++++++++++++
- libgcc/gthr-amigaos-posix.c    |  233 ++++++++
- libgcc/gthr-amigaos-single.c   |  141 +++++
- libgcc/gthr-amigaos.h          |  347 +++++++++++
- libstdc++-v3/configure         |    1 +
- 16 files changed, 1805 insertions(+), 5 deletions(-)
+ config/gthr.m4                           |    1 +
+ gcc/config.host                          |    1 +
+ gcc/config/rs6000/amigaos.h              |    8 +-
+ gcc/config/rs6000/amigaos.opt            |   18 +
+ gcc/config/rs6000/x-amigaos              |   16 +
+ gcc/configure                            |    2 +-
+ gcc/configure.ac                         |    2 +-
+ gcc/doc/invoke.texi                      |    9 +-
+ libgcc/config/rs6000/t-amigaos           |    5 +
+ libgcc/configure                         |    1 +
+ libgcc/gthr-amigaos-asserts.h            |    8 +
+ libgcc/gthr-amigaos-native.c             | 1017 ++++++++++++++++++++++
+ libgcc/gthr-amigaos-posix.c              |  233 +++++
+ libgcc/gthr-amigaos-single.c             |  141 +++
+ libgcc/{gthr-single.h => gthr-amigaos.h} |  219 +++--
+ libstdc++-v3/configure                   |    1 +
+ 16 files changed, 1592 insertions(+), 90 deletions(-)
  create mode 100644 gcc/config/rs6000/x-amigaos
  create mode 100644 libgcc/gthr-amigaos-asserts.h
  create mode 100644 libgcc/gthr-amigaos-native.c
  create mode 100644 libgcc/gthr-amigaos-posix.c
  create mode 100644 libgcc/gthr-amigaos-single.c
- create mode 100644 libgcc/gthr-amigaos.h
+ copy libgcc/{gthr-single.h => gthr-amigaos.h} (59%)
 
 diff --git a/config/gthr.m4 b/config/gthr.m4
 index 4b937306ad0802c013aa4862eafeefaa597bd590..84d29116c9a06ce37b8ed0bd46cf46eed6a252d6 100644
@@ -1702,47 +1702,53 @@ index 0000000000000000000000000000000000000000..d68a3e019fbac94a93a420fcf59476d2
 +#ifdef __cplusplus
 +}
 +#endif
-diff --git a/libgcc/gthr-amigaos.h b/libgcc/gthr-amigaos.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..123d3512abed0a43a8c019bbce0d83f0128a89ec
---- /dev/null
+diff --git a/libgcc/gthr-single.h b/libgcc/gthr-amigaos.h
+similarity index 59%
+copy from libgcc/gthr-single.h
+copy to libgcc/gthr-amigaos.h
+index 4d5cd39a967fdc2f1c3231e60ce08ec603b354b2..123d3512abed0a43a8c019bbce0d83f0128a89ec 100644
+--- a/libgcc/gthr-single.h
 +++ b/libgcc/gthr-amigaos.h
-@@ -0,0 +1,347 @@
-+/* Threads compatibility routines for libgcc2 and libobjc.  */
-+/* Compile this one with gcc.  */
+@@ -1,9 +1,9 @@
+ /* Threads compatibility routines for libgcc2 and libobjc.  */
+ /* Compile this one with gcc.  */
+-/* Copyright (C) 1997-2021 Free Software Foundation, Inc.
 +/* Copyright (C) 1997-2018 Free Software Foundation, Inc.
-+
-+This file is part of GCC.
-+
-+GCC is free software; you can redistribute it and/or modify it under
-+the terms of the GNU General Public License as published by the Free
-+Software Foundation; either version 3, or (at your option) any later
-+version.
-+
-+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
-+WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-+for more details.
-+
-+Under Section 7 of GPL version 3, you are granted additional
-+permissions described in the GCC Runtime Library Exception, version
-+3.1, as published by the Free Software Foundation.
-+
-+You should have received a copy of the GNU General Public License and
-+a copy of the GCC Runtime Library Exception along with this program;
-+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+<http://www.gnu.org/licenses/>.  */
-+
+ 
+ This file is part of GCC.
+ 
+ GCC is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free
+ Software Foundation; either version 3, or (at your option) any later
+@@ -20,31 +20,57 @@ permissions described in the GCC Runtime Library Exception, version
+ 
+ You should have received a copy of the GNU General Public License and
+ a copy of the GCC Runtime Library Exception along with this program;
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-#ifndef GCC_GTHR_SINGLE_H
+-#define GCC_GTHR_SINGLE_H
 +#ifndef GCC_GTHR_AMIGAOS_H
 +#define GCC_GTHR_AMIGAOS_H
-+
+ 
+-/* Just provide compatibility for mutex handling.  */
 +#include <stdlib.h>
 +#include <stdint.h>
-+
+ 
+-typedef int __gthread_key_t;
+-typedef int __gthread_once_t;
+-typedef int __gthread_mutex_t;
+-typedef int __gthread_recursive_mutex_t;
 +typedef struct { int data1, data2; } __gthread_once_t;
-+
+ 
+-#define __GTHREAD_ONCE_INIT 0
+-#define __GTHREAD_MUTEX_INIT 0
+-#define __GTHREAD_MUTEX_INIT_FUNCTION(mx) do {} while (0)
+-#define __GTHREAD_RECURSIVE_MUTEX_INIT 0
 +typedef struct { long unsigned int id; } __gthread_key_t;
-+
+ 
+-#define UNUSED __attribute__((__unused__))
 +/* Should cover at least as much data as the maximum of sizeof(struct SignalSemaphore)
 + * and sizeof(pthread_mutex_t)
 + */
@@ -1770,222 +1776,142 @@ index 0000000000000000000000000000000000000000..123d3512abed0a43a8c019bbce0d83f0
 +extern "C"
 +{
 +#endif
-+
-+#ifdef _LIBOBJC
-+
+ 
+ #ifdef _LIBOBJC
+ 
 +#ifndef UNUSED
 +#define UNUSED __attribute__((__unused__))
 +#define UNUSED_DEFINED
 +#endif
 +
-+/* Thread local storage for a single thread */
-+static void *thread_local_storage = NULL;
-+
-+/* Backend initialization functions */
-+
-+/* Initialize the threads subsystem.  */
-+static inline int
-+__gthread_objc_init_thread_system (void)
-+{
-+  /* No thread support available */
-+  return -1;
-+}
-+
-+/* Close the threads subsystem.  */
-+static inline int
-+__gthread_objc_close_thread_system (void)
-+{
-+  /* No thread support available */
-+  return -1;
-+}
-+
-+/* Backend thread functions */
-+
-+/* Create a new thread of execution.  */
-+static inline objc_thread_t
-+__gthread_objc_thread_detach (void (* func)(void *), void * arg UNUSED)
-+{
-+  /* No thread support available */
-+  return NULL;
-+}
-+
-+/* Set the current thread's priority.  */
-+static inline int
-+__gthread_objc_thread_set_priority (int priority UNUSED)
-+{
-+  /* No thread support available */
-+  return -1;
-+}
-+
-+/* Return the current thread's priority.  */
-+static inline int
-+__gthread_objc_thread_get_priority (void)
-+{
-+  return OBJC_THREAD_INTERACTIVE_PRIORITY;
-+}
-+
-+/* Yield our process time to another thread.  */
-+static inline void
-+__gthread_objc_thread_yield (void)
-+{
-+  return;
-+}
-+
-+/* Terminate the current thread.  */
-+static inline int
-+__gthread_objc_thread_exit (void)
-+{
-+  /* No thread support available */
-+  /* Should we really exit the program */
-+  /* exit (&__objc_thread_exit_status); */
-+  return -1;
-+}
-+
-+/* Returns an integer value which uniquely describes a thread.  */
-+static inline objc_thread_t
-+__gthread_objc_thread_id (void)
-+{
-+  /* No thread support, use 1.  */
-+  return (objc_thread_t) 1;
-+}
-+
-+/* Sets the thread's local storage pointer.  */
-+static inline int
-+__gthread_objc_thread_set_data (void *value)
-+{
-+  thread_local_storage = value;
-+  return 0;
-+}
-+
-+/* Returns the thread's local storage pointer.  */
-+static inline void *
-+__gthread_objc_thread_get_data (void)
-+{
-+  return thread_local_storage;
-+}
-+
-+/* Backend mutex functions */
-+
-+/* Allocate a mutex.  */
-+static inline int
-+__gthread_objc_mutex_allocate (objc_mutex_t mutex UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Deallocate a mutex.  */
-+static inline int
-+__gthread_objc_mutex_deallocate (objc_mutex_t mutex UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Grab a lock on a mutex.  */
-+static inline int
-+__gthread_objc_mutex_lock (objc_mutex_t mutex UNUSED)
-+{
-+  /* There can only be one thread, so we always get the lock */
-+  return 0;
-+}
-+
-+/* Try to grab a lock on a mutex.  */
-+static inline int
-+__gthread_objc_mutex_trylock (objc_mutex_t mutex UNUSED)
-+{
-+  /* There can only be one thread, so we always get the lock */
-+  return 0;
-+}
-+
-+/* Unlock the mutex */
-+static inline int
-+__gthread_objc_mutex_unlock (objc_mutex_t mutex UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Backend condition mutex functions */
-+
-+/* Allocate a condition.  */
-+static inline int
-+__gthread_objc_condition_allocate (objc_condition_t condition UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Deallocate a condition.  */
-+static inline int
-+__gthread_objc_condition_deallocate (objc_condition_t condition UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Wait on the condition */
-+static inline int
-+__gthread_objc_condition_wait (objc_condition_t condition UNUSED,
-+			       objc_mutex_t mutex UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Wake up all threads waiting on this condition.  */
-+static inline int
-+__gthread_objc_condition_broadcast (objc_condition_t condition UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Wake up one thread waiting on this condition.  */
-+static inline int
-+__gthread_objc_condition_signal (objc_condition_t condition UNUSED)
-+{
-+  return 0;
-+}
-+
+ /* Thread local storage for a single thread */
+ static void *thread_local_storage = NULL;
+ 
+ /* Backend initialization functions */
+ 
+ /* Initialize the threads subsystem.  */
+@@ -202,97 +228,120 @@ __gthread_objc_condition_broadcast (objc_condition_t condition UNUSED)
+ static inline int
+ __gthread_objc_condition_signal (objc_condition_t condition UNUSED)
+ {
+   return 0;
+ }
+ 
 +#ifndef UNUSED_DEFINED
 +#undef UNUSED
 +#endif
 +
-+#else /* _LIBOBJC */
-+
+ #else /* _LIBOBJC */
+ 
+-static inline int
+-__gthread_active_p (void)
+-{
+-  return 0;
+-}
 +int
 +__gthread_active_p (void);
-+
+ 
+-static inline int
+-__gthread_once (__gthread_once_t *__once UNUSED, void (*__func) (void) UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_once (__gthread_once_t *__once, void (*__func) (void));
-+
+ 
+-static inline int UNUSED
+-__gthread_key_create (__gthread_key_t *__key UNUSED, void (*__func) (void *) UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_key_create (__gthread_key_t *__key, void (*destroy) (void *));
-+
+ 
+-static int UNUSED
+-__gthread_key_delete (__gthread_key_t __key UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_key_delete (__gthread_key_t __key);
-+
+ 
+-static inline void *
+-__gthread_getspecific (__gthread_key_t __key UNUSED)
+-{
+-  return 0;
+-}
 +void *
 +__gthread_getspecific (__gthread_key_t __key);
-+
+ 
+-static inline int
+-__gthread_setspecific (__gthread_key_t __key UNUSED, const void *__v UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_setspecific (__gthread_key_t __key, const void *__v);
-+
+ 
+-static inline int
+-__gthread_mutex_destroy (__gthread_mutex_t *__mutex UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_mutex_init (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_mutex_lock (__gthread_mutex_t *__mutex UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_mutex_destroy (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_mutex_trylock (__gthread_mutex_t *__mutex UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_mutex_lock (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_mutex_unlock (__gthread_mutex_t *__mutex UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_mutex_trylock (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex)
+-{
+-  return __gthread_mutex_lock (__mutex);
+-}
 +int
 +__gthread_mutex_unlock (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex)
+-{
+-  return __gthread_mutex_trylock (__mutex);
+-}
 +int
 +__gthread_recursive_mutex_init (__gthread_recursive_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_recursive_mutex_unlock (__gthread_recursive_mutex_t *__mutex)
+-{
+-  return __gthread_mutex_unlock (__mutex);
+-}
 +int
 +__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_recursive_mutex_destroy (__gthread_recursive_mutex_t *__mutex)
+-{
+-  return __gthread_mutex_destroy (__mutex);
+-}
 +int
 +__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex);
 +
@@ -2047,13 +1973,15 @@ index 0000000000000000000000000000000000000000..123d3512abed0a43a8c019bbce0d83f0
 +int
 +__gthread_recursive_mutex_timedlock (__gthread_recursive_mutex_t *m,
 +                                    const __gthread_time_t *abs_time);
-+
-+#endif /* _LIBOBJC */
-+
+ 
+ #endif /* _LIBOBJC */
+ 
+-#undef UNUSED
 +#ifdef __cplusplus
 +}
 +#endif
-+
+ 
+-#endif /* ! GCC_GTHR_SINGLE_H */
 +#endif /* ! GCC_GTHR_AMIGAOS_H */
 diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
 index af5d1ad365ef3113c61c8ce05993077635061ac1..6f771d0b1bc3a62bb68bd0657bb295b11c005ba6 100755
@@ -2074,5 +2002,5 @@ index af5d1ad365ef3113c61c8ce05993077635061ac1..6f771d0b1bc3a62bb68bd0657bb295b1
      posix)	thread_header=gthr-posix.h ;;
      rtems)	thread_header=config/gthr-rtems.h ;;
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,7 +1,7 @@
-From 2fd862b50904191d117c76e5f634220442049079 Mon Sep 17 00:00:00 2001
+From 32df36c00d3b7244a206c14d8318d67065a75e26 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
-Subject: [PATCH 25/35] Add aregparam attribute for functions for the m68k
+Subject: [PATCH 25/36] Add aregparam attribute for functions for the m68k
  backend.
 
 These can be used to pass arguments to directly named registers.
@@ -260,5 +260,5 @@ index 8dfa3a9bb4c8f9ba8eca411bdc46580f0f511ea1..863cc7e967f13256fd3fdeffbd1a9ebd
  #define EXIT_IGNORE_STACK 1
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
+++ b/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
@@ -1,7 +1,7 @@
-From 1cc5f4646e1a58bc5ae89df72b0e8b732bde7423 Mon Sep 17 00:00:00 2001
+From 28c0ba8817d98c02e3eaeb4e1f9f0186ff221efe Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:22:55 +0100
-Subject: [PATCH 26/35] gcc10: Don't use poisoned define.
+Subject: [PATCH 26/36] gcc10: Don't use poisoned define.
 
 ---
  gcc/config/rs6000/amigaos.h | 3 ---
@@ -28,5 +28,5 @@ index ec0146c4b8c05eb300f8928e475641123c3f5632..19dacdc885e71ef81186b3f990173dad
  #undef PROCESSOR_DEFAULT
  #define PROCESSOR_DEFAULT PROCESSOR_PPC604e
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
+++ b/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
@@ -1,7 +1,7 @@
-From af2a70bd67b7f047f151261dcb63a589478fb32c Mon Sep 17 00:00:00 2001
+From afab86a678caaa9ac9a9c3c3c20f403d751acebf Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:25:51 +0100
-Subject: [PATCH 27/35] gcc10: Remove unused variable.
+Subject: [PATCH 27/36] gcc10: Remove unused variable.
 
 ---
  gcc/c/c-parser.c | 3 ---
@@ -41,5 +41,5 @@ index 7e644cf341991336d9a11369f9910c0acd8550ab..f284811b59c3574509aa2dbc5edd123f
      bool old_flag_plugin_added = flag_plugin_added;
      register_callback ("amigaos-tagtype", PLUGIN_FINISH_DECL,
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
+++ b/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
@@ -1,7 +1,7 @@
-From a42738d6aeb69823c194665c5fc107a30dd7410d Mon Sep 17 00:00:00 2001
+From 20b1fd8b7d74b36d7da722bcef98356fea03ec1f Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:05:59 +0100
-Subject: [PATCH 28/35] gcc10: Remove tagtype attribute.
+Subject: [PATCH 28/36] gcc10: Remove tagtype attribute.
 
 The 'Add tagtype attribute that can be passed to enum' patch needs
 to be adapted. Temporarily disable the patch since adaptation requires
@@ -29,5 +29,5 @@ index 19dacdc885e71ef81186b3f990173dade2bd517a..1731d3263ced055f39eb150e375392d0
  /* Overrides */
  
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
+++ b/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
@@ -1,7 +1,7 @@
-From d55f30bfa893be40a2ae8ad451a75aab3a91cda8 Mon Sep 17 00:00:00 2001
+From 266f38251b6aa1c7fd3b8429d2d2b95d0c577f5c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:07:45 +0100
-Subject: [PATCH 29/35] gcc10: Define CC1_SPEC.
+Subject: [PATCH 29/36] gcc10: Define CC1_SPEC.
 
 ---
  gcc/config/rs6000/amigaos.h | 13 +++++++++++++
@@ -38,5 +38,5 @@ index 1731d3263ced055f39eb150e375392d055acd125..eacc455e168c4bf46522151148bc72c0
  #undef TARGET_OS_CPP_BUILTINS
  #define TARGET_OS_CPP_BUILTINS()                \
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
+++ b/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
@@ -1,7 +1,7 @@
-From 246e81be3562e1c764b89e4ed52ba5e51952b077 Mon Sep 17 00:00:00 2001
+From 0fe8d761ed5446ed3c7ca431659958b2498ee613 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 01:02:33 +0100
-Subject: [PATCH 30/35] gcc10: Link lto-dump with -athread=native.
+Subject: [PATCH 30/36] gcc10: Link lto-dump with -athread=native.
 
 ---
  gcc/config/rs6000/x-amigaos | 3 ++-
@@ -30,5 +30,5 @@ index a3dd2195809c2ce1fbab8be854f3c987dccc039b..6d9efb985ff5619c741e44edaf5431b9
 \ No newline at end of file
 +$(ALL_EXECUTABLES) : override LDFLAGS += -athread=native -Wl,--gc-sections
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
+++ b/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
@@ -1,7 +1,7 @@
-From 98a7171e7f90c70ea910b98dc4b29791c3d3d2fd Mon Sep 17 00:00:00 2001
+From f55c00ae21292b68738143bbf275ef30e94b7efe Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 14:03:50 +0100
-Subject: [PATCH 31/35] gcc10: Expose max_align_t when using clib2.
+Subject: [PATCH 31/36] gcc10: Expose max_align_t when using clib2.
 
 ---
  libstdc++-v3/include/c_global/cstddef | 3 ---
@@ -51,5 +51,5 @@ index 16fa6bf68690127c7a735979108b1addbd562d2b..6568adfca2089c116ae2cbdfa8c933aa
  
  #endif // _GLIBCXX_CSTDDEF
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
+++ b/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
@@ -1,7 +1,7 @@
-From d6a71f22cba30ad7810cf6c71e27e8d681b5e65d Mon Sep 17 00:00:00 2001
+From 0c74121b54a3b0c55ede757302dd13f6728d560d Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sun, 7 Feb 2021 19:38:47 +0100
-Subject: [PATCH 32/35] gcc10: Don't define __STRICT_ANSI__.
+Subject: [PATCH 32/36] gcc10: Don't define __STRICT_ANSI__.
 
 Doing so hides C99 features when configuring libstdc++.
 ---
@@ -34,5 +34,5 @@ index 6b67630b7be7102a9dfb7c104deac6293a13c017..3f2d894b6c28e493e38c114da8d4f852
 +
  #endif
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
+++ b/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
@@ -1,7 +1,7 @@
-From 50d80a7e56c2f5fbbb6fe05d3f4d3fcc0e9da2db Mon Sep 17 00:00:00 2001
+From c3443778d66979c2734bb02baf24c14b979e7326 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Mon, 15 Mar 2021 15:55:11 +0100
-Subject: [PATCH 33/35] gcc10: Fix libstdc++v3 paths.
+Subject: [PATCH 33/36] gcc10: Fix libstdc++v3 paths.
 
 ---
  libstdc++-v3/src/c++17/fs_ops.cc  |  17 ++++-
@@ -340,5 +340,5 @@ index 506ff25f9a6db19ad8062a224c07c61e19f31f22..c557c7d055108771a3a4f74f5e425489
  
    _Parser parser(_M_pathname);
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
+++ b/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
@@ -1,7 +1,7 @@
-From d57c5741f8aa7cd331ad1889671e585358f85c08 Mon Sep 17 00:00:00 2001
+From 0b5fd31f94a96acd4b83b34be52e2915982494fc Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:21:55 +0200
-Subject: [PATCH 34/35] gcc11: Include stdint.h when sys/mman.h is missing.
+Subject: [PATCH 34/36] gcc11: Include stdint.h when sys/mman.h is missing.
 
 Since sys/mman.h indirectly includes stdint.h, we need to explicitly
 include stdint.h when sys/mman.h is missing.
@@ -29,5 +29,5 @@ index 7b0d367ec52693dec4ea2a798635b3e32fa8f300..fc2a00eb4efb3539f2a4252ad39547ac
  typedef unsigned gcov_position_t __attribute__ ((mode (SI)));
  #if LONG_LONG_TYPE_SIZE > 32
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
+++ b/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
@@ -1,7 +1,7 @@
-From 1e3f0293998795f22c94709d934bb53f891db46f Mon Sep 17 00:00:00 2001
+From 57cdd99bfe45740a2021212005227a089eb5921c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:27:59 +0200
-Subject: [PATCH 35/35] gcc11: Use include_next to circumvent fenv.h include
+Subject: [PATCH 35/36] gcc11: Use include_next to circumvent fenv.h include
  guard.
 
 Include guards will prevent the correct fenv.h to be included
@@ -30,5 +30,5 @@ index 0b0ec35a8377d8af928e97dbffd7e52a6ef9e3b3..3a6381577e0b3e34842759dba06e3ee8
  #undef feclearexcept
  #undef fegetexceptflag
 -- 
-2.30.2
+2.34.1
 

--- a/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
+++ b/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
@@ -1,0 +1,131 @@
+From c99b141102f736198f6c013f5e58946ccc6d3b95 Mon Sep 17 00:00:00 2001
+From: rjd <3246251196ryan@gmail.com>
+Date: Wed, 5 Oct 2022 11:36:32 +0100
+Subject: [PATCH 36/36] gcc11: Fix to exception raised by Callable in call_once
+ implementation.
+
+In the case the Callable raises an exception, the shared resources between
+potentially multiple concurrent threads is not reset causing thread(s)
+(Amiga Tasks) to become stuck in an infinite loop.
+---
+ libgcc/gthr-amigaos-native.c   | 25 +++++++++++++++----------
+ libgcc/gthr-amigaos.h          |  3 +++
+ libstdc++-v3/include/std/mutex | 20 ++++++++++++++++++--
+ 3 files changed, 36 insertions(+), 12 deletions(-)
+
+diff --git a/libgcc/gthr-amigaos-native.c b/libgcc/gthr-amigaos-native.c
+index 3806359eed9a80027a7b37e79d148cded12ce7b9..683d7f497d08f749f188be915b3f9231bdf9a747 100644
+--- a/libgcc/gthr-amigaos-native.c
++++ b/libgcc/gthr-amigaos-native.c
+@@ -167,36 +167,41 @@ __gthread_once (__gthread_once_t *__once, void (*__func) (void))
+   if (__once == NULL || __func == NULL)
+     return EINVAL;
+ 
+   if (__atomic_load_1(&once->u.i.done, __ATOMIC_SEQ_CST))
+     return 0;
+ 
++  while (!__atomic_load_1(&once->u.i.done, __ATOMIC_SEQ_CST) && __atomic_load_1(&once->u.i.started, __ATOMIC_SEQ_CST))
++    {
++      /* Allow the other thread to progress quickly but iexec may be not available */
++      struct ExecBase *SysBase = *(struct ExecBase **)4;
++      struct ExecIFace *ie = (struct ExecIFace *)SysBase->MainInterface;
++      ie->Reschedule();
++    }
++
+   if (!__atomic_test_and_set(&once->u.i.started, __ATOMIC_SEQ_CST))
+     {
+       /* Started flag was not set so call func now */
+       __func();
+ 
+       /* Remember that we are done now. And make all effects prior to this
+        * store visible to all the other clients that will read that we are
+        * actually done.
+        */
+       __atomic_store_1(&once->u.i.done, 1, __ATOMIC_SEQ_CST);
+     }
+-  else
+-    {
+-      while (!__atomic_load_1(&once->u.i.done, __ATOMIC_SEQ_CST))
+-        {
+-          /* Allow the other thread to progress quickly but iexec may be not available */
+-          struct ExecBase *SysBase = *(struct ExecBase **)4;
+-          struct ExecIFace *ie = (struct ExecIFace *)SysBase->MainInterface;
+-          ie->Reschedule();
+-        }
+-    }
++
+   return 0;
+ }
+ 
++void __gthread_once_unlock(__gthread_once_t *__once)
++{
++  __internal_gthread_once_t *once = (__internal_gthread_once_t *)__once;
++  __atomic_store_1(&once->u.i.started, 0, __ATOMIC_SEQ_CST);
++}
++
+ /******************************************************************************/
+ 
+ /* We keep the entries of each key organized as a single linked list */
+ struct keyentry
+ {
+   struct keyentry *next;
+diff --git a/libgcc/gthr-amigaos.h b/libgcc/gthr-amigaos.h
+index 123d3512abed0a43a8c019bbce0d83f0128a89ec..62190bcc0578c33eb79da512648513db0df8a825 100644
+--- a/libgcc/gthr-amigaos.h
++++ b/libgcc/gthr-amigaos.h
+@@ -240,12 +240,15 @@ __gthread_objc_condition_signal (objc_condition_t condition UNUSED)
+ int
+ __gthread_active_p (void);
+ 
+ int
+ __gthread_once (__gthread_once_t *__once, void (*__func) (void));
+ 
++void
++__gthread_once_unlock (__gthread_once_t *__once);
++
+ int
+ __gthread_key_create (__gthread_key_t *__key, void (*destroy) (void *));
+ 
+ int
+ __gthread_key_delete (__gthread_key_t __key);
+ 
+diff --git a/libstdc++-v3/include/std/mutex b/libstdc++-v3/include/std/mutex
+index d4c5d13f65407aca5ce8aa938ea7131dc6b28662..17242119de191b34af5bf35b4a7842b5c7bfad20 100644
+--- a/libstdc++-v3/include/std/mutex
++++ b/libstdc++-v3/include/std/mutex
+@@ -777,14 +777,30 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 			std::forward<_Args>(__args)...);
+       };
+ 
+       once_flag::_Prepare_execution __exec(__callable);
+ 
+       // XXX pthread_once does not reset the flag if an exception is thrown.
+-      if (int __e = __gthread_once(&__once._M_once, &__once_proxy))
+-	__throw_system_error(__e);
++      // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66146
++      // https://github.com/sba1/adtools/issues/82
++      int __e = 0;
++#if defined(__amigaos4__) && defined(__EXCEPTIONS)
++      try
++      {
++#endif
++        __e = __gthread_once(&__once._M_once, &__once_proxy);
++#if defined(__amigaos4__) && defined(__EXCEPTIONS)
++      }
++      catch (...)
++      {
++        __gthread_once_unlock(&__once._M_once);
++        throw;
++      }
++#endif
++      if (__e)
++        __throw_system_error(__e);
+     }
+ 
+ #else // _GLIBCXX_HAS_GTHREADS
+ 
+   /// Flag type used by std::call_once
+   struct once_flag
+-- 
+2.34.1
+

--- a/tests/makefile
+++ b/tests/makefile
@@ -45,6 +45,11 @@ test-tls: test-tls.cpp
 test-checktags.o: test-checktags.c
 	$(XGCC) $< -c
 
+test-call-once: test-call-once.cpp
+	# This is only expected to work for gcc11+ since patch 0036
+	# only applies to the gcc11 patches!
+	$(CPP) -std=c++11 -athread=native -g $< -o $@
+
 ################################################################################
 
 .PHONY: run-all
@@ -54,7 +59,8 @@ run-all: \
 	run-test-aos4-extensions-simple-o3 \
 	run-test-baserel \
 	run-test-baserel-o1 \
-	run-test-baserel-o3
+	run-test-baserel-o3 \
+	run-test-call-once
 
 #
 # Macro to insert a recipe for compiling plain tests that run on a qemu target.

--- a/tests/test-call-once.cpp
+++ b/tests/test-call-once.cpp
@@ -1,0 +1,67 @@
+/* A simple test from https://en.cppreference.com/w/cpp/thread/call_once
+ * that tests c++ call_once in simple form: many threads attempting to execute
+ * the same Callable - concurrently; in which case we expect 1 call
+ * and,
+ * the same again, only where the Callable raises an exception.
+ *
+ * It shall produce following output (most of the time! since the excecution
+ * of the threads is not deterministic)
+ *
+ * ```stdout
+ * Simple example: called once
+ * throw: call_once will retry
+ * throw: call_once will retry
+ * Didn't throw, call_once will not attempt again
+ * ```
+ *
+ */
+
+#include <iostream>
+#include <thread>
+#include <mutex>
+ 
+std::once_flag flag1, flag2;
+ 
+void simple_do_once()
+{
+    std::call_once(flag1, [](){ std::cout << "Simple example: called once\n"; });
+}
+ 
+void may_throw_function(bool do_throw)
+{
+  if (do_throw) {
+    std::cout << "throw: call_once will retry\n"; // this may appear more than once
+    throw std::exception();
+  }
+  std::cout << "Didn't throw, call_once will not attempt again\n"; // guaranteed once
+}
+ 
+void do_once(bool do_throw)
+{
+  try {
+    std::call_once(flag2, may_throw_function, do_throw);
+  }
+  catch (...) {
+  }
+}
+ 
+int main()
+{
+    std::thread st1(simple_do_once);
+    std::thread st2(simple_do_once);
+    std::thread st3(simple_do_once);
+    std::thread st4(simple_do_once);
+    st1.join();
+    st2.join();
+    st3.join();
+    st4.join();
+ 
+    std::thread t1(do_once, true);
+    std::thread t2(do_once, true);
+    std::thread t3(do_once, false);
+    std::thread t4(do_once, true);
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
+}


### PR DESCRIPTION
Based on MorphOS implementation: catch the potential exception in Callable, and when doing so, reset the flag allowing other threads calling the same callable to complete Callable.

Not extensive testing, only the code/test in https://en.cppreference.com/w/cpp/thread/call_once which was previously causing thread (Amiga Task) to become stuck waiting for the release of the shared  resource (call_once flag).

== PS: Just updated this initial comment because a lot of detail was there explaining how you have to patch gthr-amiga-native.cpp which we no longer need to do since we have updated to 54.16 SDK.