### PR TITLE
Update Makefile to use SDK 54.16 instead of 53.30. Includes extra ext…

### DIFF
--- a/native-build/makefile
+++ b/native-build/makefile
@@ -36,8 +36,8 @@ endif
 
 GCC_BRANCH_NAME:=$(word 1, $(subst ., , $(GCC_VERSION)))
 
-SDK_URL=http://www.hyperion-entertainment.biz/index.php?option=com_registration&amp;view=download&amp;format=raw&amp;file=69&amp;Itemid=82
-SDK_VERSION=53.30
+SDK_URL=http://www.hyperion-entertainment.biz/index.php?option=com_registration&amp;view=download&amp;format=raw&amp;file=127
+SDK_VERSION=54.16
 
 # Native tools
 COREUTILS_SRC_DIR=../coreutils/repo
@@ -115,6 +115,7 @@ includes-done: downloads-done
 #	cd downloads/SDK_Install && lha xf clib2*.lha
 	cd downloads/SDK_Install && lha xf newlib*.lha
 	cd downloads/SDK_Install && lha xf base.lha
+	cd downloads/SDK_Install && lha xf execsg*.lha
 	cd downloads/SDK_Install && rm -Rf *.lha
 	cd downloads/SDK_Install && mv newlib* $(CROSS_PREFIX)/ppc-amigaos/SDK
 #	cd downloads/SDK_Install && mv clib2* $(CROSS_PREFIX)/ppc-amigaos/SDK


### PR DESCRIPTION
…action of execsg lha file since that is now in its own lha inside SDK_Install