### PR TITLE
Enable experimental clib2 and disable building of COREUTILS optionally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ native-build/root-native-coreutils
 native-build/root-native-gcc
 native-build/ReadMe
 native-build/ReadMe.utf8
+native-build/EXP_CLIB2
+native-build/NO_COREUTILS

--- a/native-build/makefile
+++ b/native-build/makefile
@@ -27,6 +27,10 @@
 # Optional (DEFAULT=54.16):
 # Define SDK_VERSION to specify which version of the Amiga SDK is desired
 #
+# ===
+# Optional (DEFAULT=0):
+# Define NO_COREUTILS=1 if the building of CoreUtils is not desired
+#
 
 ROOT_DIR=$(realpath .)
 
@@ -73,8 +77,13 @@ endif
 SDK_URL=http://www.hyperion-entertainment.biz/index.php?option=com_registration&amp;view=download&amp;format=raw&amp;file=$(SDK_URL_FILE)
 
 # Native tools
+NO_COREUTILS?=0
+ifeq ($(NO_COREUTILS),0)
 COREUTILS_SRC_DIR=../coreutils/repo
 COREUTILS_VERSION=5.2.1
+else
+$(shell touch NO_COREUTILS)
+endif
 
 # Distribution version, used as middle part of a distribution archive
 DIST_VERSION=$(shell date +%Y%m%d)-$(shell git rev-list --count HEAD)
@@ -327,6 +336,7 @@ else
 coreutils-native-done: gcc-cross-done-$(GCC_VERSION)
 endif
 	mkdir -p coreutils-native-build
+ifneq (0, $(shell test -f NO_COREUTILS ; echo $$?))
 	@if [ ! -f $(COREUTILS_SRC_DIR)/configure ]; then echo "Please checkout coreutils first!"; false; fi
 # Pretend few files to be uptodate
 	touch $(realpath $(COREUTILS_SRC_DIR))/configure $(realpath $(COREUTILS_SRC_DIR))/config.hin
@@ -338,6 +348,7 @@ else
 	cd coreutils-native-build ; PATH="$(CROSS_PREFIX)/bin:$(PATH)" CPPFLAGS="-mcrt=clib2" LDFLAGS="-mcrt=clib2" LIBS="-lunix -lnet" $(realpath $(COREUTILS_SRC_DIR))/configure --prefix=/gcc --host=ppc-amigaos --disable-maintainer-mode
 endif
 	PATH="$(CROSS_PREFIX)/bin:$(PATH)" $(MAKE) -C coreutils-native-build
+endif # NO_COREUTILS=0
 	touch $@
 
 
@@ -380,7 +391,7 @@ ReadMe: ReadMe.mak
 	python -c "\
 	from mako.template import Template;\
 	from mako.lookup import TemplateLookup;\
-	print Template(\
+	outStr=Template(\
 		filename='$<',\
 		input_encoding='utf-8',\
 		output_encoding='utf-8',\
@@ -392,7 +403,8 @@ ReadMe: ReadMe.mak
 			GCC_DEV_PHASE='$(GCC_DEV_PHASE)',\
 			COREUTILS_VERSION='$(COREUTILS_VERSION)',\
 			CLIB2_RELEASE_ARCHIVE_NAME='$(CLIB2_RELEASE_ARCHIVE_NAME)'\
-		)\
+		);\
+	print(outStr)\
 	" >$@.utf8
 	iconv --from-code=UTF8 --to-code=ISO-8859-15 $@.utf8 >$@
 
@@ -441,7 +453,9 @@ native-install: coreutils-native-done gcc-native-done-$(GCC_VERSION) ReadMe doc
 # Create copies of few files that usually are also accessible via a filename with the target alias prefix
 	$(foreach EXE, $(BINUTILS_EXES), $(call MAKE_TARGET_ALIAS,$(EXE))$(NL))
 	PATH="$(CROSS_PREFIX)/bin:$(PATH)" $(MAKE) -C gcc-native-build-$(GCC_VERSION) install
+ifneq (0, $(shell test -f NO_COREUTILS ; echo $$? ))
 	PATH="$(CROSS_PREFIX)/bin:$(PATH)" $(MAKE) -C coreutils-native-build install
+endif
 # Disabled SDK as we don't want to distribute it
 #	cp -R $(CROSS_PREFIX)/ppc-amigaos/SDK /gcc
 # Disabled, because we don't want to copy from CROSS_PREFIX here
@@ -464,12 +478,16 @@ native-separate-install:
 	rm -Rf root-native-coreutils
 	PATH="$(CROSS_PREFIX)/bin:$(PATH)" $(MAKE) -C binutils-native-build-$(BINUTILS_VERSION) install DESTDIR=$(ROOT_DIR)/root-native-binutils
 	PATH="$(CROSS_PREFIX)/bin:$(PATH)" $(MAKE) -C gcc-native-build-$(GCC_VERSION) install DESTDIR=$(ROOT_DIR)/root-native-gcc
+ifneq (0, $(shell test -f NO_COREUTILS ; echo $$? ))
 	PATH="$(CROSS_PREFIX)/bin:$(PATH)" $(MAKE) -C coreutils-native-build install DESTDIR=$(ROOT_DIR)/root-native-coreutils
+endif
 	$(MAKE) private-native-separate-dist
 
 # Private target. Unfinished
 private-native-separate-dist:
+ifneq (0, $(shell test -f NO_COREUTILS ; echo $$? ))
 	$(foreach var,$(wildcard $(ROOT_DIR)/root-native-coreutils/gcc/bin/*), $(STRIP) $(STRIPFLAGS) $(var) ; ) true
+endif
 	$(foreach var,$(wildcard $(ROOT_DIR)/root-native-binutils/gcc/bin/*), $(STRIP) $(STRIPFLAGS) $(var) ; ) true
 	$(foreach var,$(wildcard $(ROOT_DIR)/root-native-gcc/gcc/bin/*), $(STRIP) $(STRIPFLAGS) $(var) ; ) true
 	$(STRIP) $(STRIPFLAGS) $(ROOT_DIR)/root-native-gcc/gcc/libexec/gcc/ppc-amigaos/$(GCC_VERSION)/cc1
@@ -578,7 +596,4 @@ clean: clean-clib2 clean-gcc
 #
 .PNONY: clean-all
 clean-all: clean
-	rm -Rf downloads-done downloads-done-clib2 downloads
-ifeq (0, $(shell test -f EXP_CLIB2 ; echo $$?))
-	rm -f EXP_CLIB2
-endif
+	rm -Rf downloads-done downloads-done-clib2 downloads EXP_CLIB2 NO_COREUTILS

--- a/native-build/makefile
+++ b/native-build/makefile
@@ -6,10 +6,26 @@
 #
 # The user running this script must have write access to /gcc
 #
+# ===
+# Optional (DEFAULT=0):
 # Define CROSS_IS_PRESENT=1 if a suitable cross compiler is already
 # present, in which case the cross compiler build is skipped, e.g.:
 #
 #  make CROSS_IS_PRESENT=1
+#
+# ===
+# Optional (DEFAULT=0):
+# Define EXP_CLIB2=1 if the later experimental version of clib2 is desired
+# In case EXP_CLIB2=1, optionally define CLIB2_SHA1=X, where X is the commit id
+# or branch to be used within the experimental version; defaults to HEAD e.g.:
+#
+#  make EXP_CLIB2=1 CLIB2_SHA1=beta8
+#
+# See https://github.com/afxgroup/clib2.
+#
+# ===
+# Optional (DEFAULT=54.16):
+# Define SDK_VERSION to specify which version of the Amiga SDK is desired
 #
 
 ROOT_DIR=$(realpath .)
@@ -36,8 +52,25 @@ endif
 
 GCC_BRANCH_NAME:=$(word 1, $(subst ., , $(GCC_VERSION)))
 
-SDK_URL=http://www.hyperion-entertainment.biz/index.php?option=com_registration&amp;view=download&amp;format=raw&amp;file=127
-SDK_VERSION=54.16
+SDK_VERSION?=54.16
+SDK_URL_FILE=127
+ifeq (53.34,$(SDK_VERSION))
+SDK_URL_FILE=125
+else
+ifeq (53.30,$(SDK_VERSION))
+SDK_URL_FILE=82
+else
+ifeq (53.24,$(SDK_VERSION))
+SDK_URL_FILE=69
+else
+ifneq (54.16,$(SDK_VERSION))
+$(error Unexpected SDK_VERSION supplied)
+endif
+endif
+endif
+endif
+
+SDK_URL=http://www.hyperion-entertainment.biz/index.php?option=com_registration&amp;view=download&amp;format=raw&amp;file=$(SDK_URL_FILE)
 
 # Native tools
 COREUTILS_SRC_DIR=../coreutils/repo
@@ -46,8 +79,13 @@ COREUTILS_VERSION=5.2.1
 # Distribution version, used as middle part of a distribution archive
 DIST_VERSION=$(shell date +%Y%m%d)-$(shell git rev-list --count HEAD)
 
+ifeq (1,$(EXP_CLIB2))
+CLIB2_URL=https://github.com/afxgroup/clib2.git
+CLIB2_SHA1?=HEAD
+else
 CLIB2_URL=https://github.com/sodero/clib2
 CLIB2_SHA1=02ecf7d92448b5486502cd9e95fc838dca4804a7
+endif
 CLIB2_RELEASE_ARCHIVE_NAME=adtools-os4-clib2-$(DIST_VERSION).lha
 
 CROSS_PREFIX?=$(ROOT_DIR)/root-cross
@@ -73,6 +111,9 @@ print-dist-version:
 downloads-done-clib2:
 	mkdir -p downloads
 	cd downloads && (git clone $(CLIB2_URL) clib2 || true) && cd clib2 && git checkout $(CLIB2_SHA1)
+ifeq (1,$(EXP_CLIB2))
+	touch EXP_CLIB2
+endif
 	touch $@
 
 #
@@ -115,7 +156,11 @@ includes-done: downloads-done
 #	cd downloads/SDK_Install && lha xf clib2*.lha
 	cd downloads/SDK_Install && lha xf newlib*.lha
 	cd downloads/SDK_Install && lha xf base.lha
-	cd downloads/SDK_Install && lha xf execsg*.lha
+ifneq (53.30,$(SDK_VERSION))
+ifneq (53.24,$(SDK_VERSION))
+	cd downloads/SDK_Install && lha xf exec*.lha
+endif
+endif
 	cd downloads/SDK_Install && rm -Rf *.lha
 	cd downloads/SDK_Install && mv newlib* $(CROSS_PREFIX)/ppc-amigaos/SDK
 #	cd downloads/SDK_Install && mv clib2* $(CROSS_PREFIX)/ppc-amigaos/SDK
@@ -149,7 +194,13 @@ CLIB2_CROSS_DONE_DEPENDENCY=xgcc-done-$(GCC_VERSION)
 
 endif
 
-CLIB2_DIR=downloads/clib2/library
+EXP_CLIB2_DIR=downloads/clib2/
+STABLE_CLIB2_DIR=downloads/clib2/library/
+ifeq (1,$(EXP_CLIB2))
+CLIB2_DIR=$(EXP_CLIB2_DIR)
+else
+CLIB2_DIR=$(STABLE_CLIB2_DIR)
+endif
 
 #
 # Prints the folder where the basic xg (xgcc or xg++) compilers
@@ -176,14 +227,30 @@ xgcc-done-$(GCC_VERSION): includes-done binutils-cross-done-$(BINUTILS_VERSION)
 #
 clib2-cross-done-$(GCC_VERSION): $(CLIB2_CROSS_DONE_DEPENDENCY)
 # Build clib2 using xgcc that have just been built
+ifeq (1,$(EXP_CLIB2))
+	$(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 \
+		CC="$(XGCC_CC)" \
+		AR="$(XAR)" \
+		RANLIB="$(XRANLIB)" \
+		SHARED=no \
+		INSTALL_PREFIX=$(CROSS_PREFIX)/ppc-amigaos/SDK/clib2 \
+		SDK_INCLUDE=$(CROSS_PREFIX)/ppc-amigaos/SDK/include
+else
 	$(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 CC="$(XGCC_CC)" AR="$(XAR)" RANLIB="$(XRANLIB)"
+endif
 # Copy clib2 libs and includes
+ifeq (1,$(EXP_CLIB2))
+	$(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 install \
+		INSTALL_PREFIX=$(CROSS_PREFIX)/ppc-amigaos/SDK/clib2
+	cp $(CLIB2_DIR)/LICENSE* $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2
+else
 	rm -Rf $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/lib $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/include
 	mkdir -p $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/lib
 	mkdir -p $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/include
 	cp -Rp $(CLIB2_DIR)/include/* $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/include
 	cp -Rp $(CLIB2_DIR)/lib/* $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/lib
 	cp $(CLIB2_DIR)/../LICENSE $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2
+endif
 	touch $@
 
 #
@@ -264,7 +331,12 @@ endif
 # Pretend few files to be uptodate
 	touch $(realpath $(COREUTILS_SRC_DIR))/configure $(realpath $(COREUTILS_SRC_DIR))/config.hin
 #	cd coreutils-native-build ; PATH="$(CROSS_PREFIX)/bin:$(PATH)" LIBS="-lunix" $(realpath $(COREUTILS_SRC_DIR))/configure --prefix=/gcc --host=ppc-amigaos
+ifeq (0, $(shell test -f EXP_CLIB2 ; echo $$?))
+# We do not need libunix / lnet for EXP CLIB2
+	cd coreutils-native-build ; PATH="$(CROSS_PREFIX)/bin:$(PATH)" CPPFLAGS="-mcrt=clib2" LDFLAGS="-mcrt=clib2" $(realpath $(COREUTILS_SRC_DIR))/configure --prefix=/gcc --host=ppc-amigaos --disable-maintainer-mode
+else
 	cd coreutils-native-build ; PATH="$(CROSS_PREFIX)/bin:$(PATH)" CPPFLAGS="-mcrt=clib2" LDFLAGS="-mcrt=clib2" LIBS="-lunix -lnet" $(realpath $(COREUTILS_SRC_DIR))/configure --prefix=/gcc --host=ppc-amigaos --disable-maintainer-mode
+endif
 	PATH="$(CROSS_PREFIX)/bin:$(PATH)" $(MAKE) -C coreutils-native-build
 	touch $@
 
@@ -462,7 +534,11 @@ upload-release: native-dist
 
 .PHONY: clean-clib2
 clean-clib2:
-	test ! -d $(CLIB2_DIR) && true || $(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 clean
+ifeq (0, $(shell test -f EXP_CLIB2 ; echo $$?))
+	test ! -d $(EXP_CLIB2_DIR) || $(MAKE) -C $(EXP_CLIB2_DIR) -f GNUmakefile.os4 clean
+else
+	test ! -d $(STABLE_CLIB2_DIR) || $(MAKE) -C $(STABLE_CLIB2_DIR) -f GNUmakefile.os4 clean
+endif
 
 #
 # Cleanup gcc only
@@ -503,3 +579,6 @@ clean: clean-clib2 clean-gcc
 .PNONY: clean-all
 clean-all: clean
 	rm -Rf downloads-done downloads-done-clib2 downloads
+ifeq (0, $(shell test -f EXP_CLIB2 ; echo $$?))
+	rm -f EXP_CLIB2
+endif


### PR DESCRIPTION
A shot in the dark. Please let me know if you would accept this at all, and if you would but dislike the implementation, then please advise.

The defaults are as they stand today: the "stable" CLIB2 with the same git hash as existing. But, the ability to enable afxgroup clib2. 

Also, the ability not to build coreutils for those who just want the compiler/binutils.