### PR TITLE
Provide clib4 as an additional C runtime library.

### DIFF
--- a/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
 From a065f15c8bb17b6717633ef513e4c2f12f152499 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/37] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/38] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |   1 +

--- a/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
 From 5901f8aec0e2f6a0f826903cd483cc1b10f63aeb Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/37] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/38] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions

--- a/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
 From 07718db105d776cff50b4cd8102132c88ea7c002 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/37] Disable .machine directive generation.
+Subject: [PATCH 03/38] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.

--- a/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From f7398a949dd5201e983c7d8188d497e548112123 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/37] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/38] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---

--- a/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
 From e6ec2d752903863da6dcf190e18c73e346b6b253 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/37] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/38] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---

--- a/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
 From a01c2a5ac436a00b931a0146cf802f69127c2884 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/37] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/38] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().

--- a/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
 From 6c249f64bd2d0ebf30f51531484ea1742962ee12 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/37] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/38] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---

--- a/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From b5b5a3209f4fc3c59198b392b728576612a85f78 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/37] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/38] Added libstc++ support for AmigaOS.
 
 ---
  .../os/{generic => amigaos}/ctype_base.h      |  2 +-

--- a/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,7 +1,7 @@
 From c9fb3357d886c3e9561e008b9087c9b75caef37d Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 09/37] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 09/38] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---

--- a/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,7 +1,7 @@
 From 33102a20e983d901be1859333d922cb32459d2b2 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
-Subject: [PATCH 10/37] Implement libat_lock_n() and libat_unlock_n().
+Subject: [PATCH 10/38] Implement libat_lock_n() and libat_unlock_n().
 
 ---
  libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++-------

--- a/gcc/11/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/11/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
 From 60505eb8b49c04957f3e1122484b5e2297f19c8e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/37] Pretend C99 compatibility.
+Subject: [PATCH 11/38] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses

--- a/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
 From 75d527aeab41195aa6161eb90ab1c75fb39692ac Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/37] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/38] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-

--- a/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
 From f5d04240570843fd4419cd0d9ce6f9aa50609145 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/37] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/38] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------

--- a/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
 From 6a98220e936165ce6238e071fcfda1277ef80392 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/37] Add custom implementation of various env-related
+Subject: [PATCH 14/38] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.

--- a/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
 From 8982a14a86f101333989f8b8959d031209e2401a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/37] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/38] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.

--- a/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
 From a5b8eb192677e48f84822bc15c20ba8975b5fad5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/37] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/38] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---

--- a/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
 From dd595e5c58180a1ad9e8572bf17dd5cfbfabf789 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/37] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/38] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +

--- a/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
 From c64cc31006520260c4a23cc23799442e28402415 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/37] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/38] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---

--- a/gcc/11/patches/0019-Add-_Static_warning.patch
+++ b/gcc/11/patches/0019-Add-_Static_warning.patch
@@ -1,7 +1,7 @@
 From 7e5ea9debe2babeb92ebd4e6d081599ea8441004 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
-Subject: [PATCH 19/37] Add _Static_warning().
+Subject: [PATCH 19/38] Add _Static_warning().
 
 This acts very similar to _Static_assert() but produces a warning
 rather than an compiler error.

--- a/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
+++ b/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
@@ -1,7 +1,7 @@
 From c0a70959ea598b7004bb62e22b42443e090788b4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
-Subject: [PATCH 20/37] Rename lineartags to checktags.
+Subject: [PATCH 20/38] Rename lineartags to checktags.
 
 The name lineartags would imply linearvarargs but this is not implemented
 or necessary.

--- a/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,7 +1,7 @@
 From 4257f6d9961b0a9e583bf71f8cabcceb92ca44d3 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
-Subject: [PATCH 21/37] Fix order of AmigaOS PPC sections in the documentation.
+Subject: [PATCH 21/38] Fix order of AmigaOS PPC sections in the documentation.
 
 ---
  gcc/doc/extend.texi |  4 ++--

--- a/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,7 +1,7 @@
 From 4cb533514851a1840dea1ce9d8e20884b45f53e1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
-Subject: [PATCH 22/37] Provide a documentation for checktags and tagtype
+Subject: [PATCH 22/38] Provide a documentation for checktags and tagtype
  attributes.
 
 ---

--- a/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From ab20508a3cdea818bb37195cea6d2e960b32e8d7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
-Subject: [PATCH 23/37] Adapt libssp for AmigaOS.
+Subject: [PATCH 23/38] Adapt libssp for AmigaOS.
 
 ---
  libssp/ssp.c | 8 +++++---

--- a/gcc/11/patches/0024-Add-amigaos-thread-model.patch
+++ b/gcc/11/patches/0024-Add-amigaos-thread-model.patch
@@ -1,7 +1,7 @@
 From 1a726f2c22094261ab929462bc51bd250f82e3c4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
-Subject: [PATCH 24/37] Add amigaos thread model.
+Subject: [PATCH 24/38] Add amigaos thread model.
 
 It is work in progress.
 ---

--- a/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,7 +1,7 @@
 From 32df36c00d3b7244a206c14d8318d67065a75e26 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
-Subject: [PATCH 25/37] Add aregparam attribute for functions for the m68k
+Subject: [PATCH 25/38] Add aregparam attribute for functions for the m68k
  backend.
 
 These can be used to pass arguments to directly named registers.

--- a/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
+++ b/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
@@ -1,7 +1,7 @@
 From 28c0ba8817d98c02e3eaeb4e1f9f0186ff221efe Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:22:55 +0100
-Subject: [PATCH 26/37] gcc10: Don't use poisoned define.
+Subject: [PATCH 26/38] gcc10: Don't use poisoned define.
 
 ---
  gcc/config/rs6000/amigaos.h | 3 ---

--- a/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
+++ b/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
@@ -1,7 +1,7 @@
 From afab86a678caaa9ac9a9c3c3c20f403d751acebf Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:25:51 +0100
-Subject: [PATCH 27/37] gcc10: Remove unused variable.
+Subject: [PATCH 27/38] gcc10: Remove unused variable.
 
 ---
  gcc/c/c-parser.c | 3 ---

--- a/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
+++ b/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
@@ -1,7 +1,7 @@
 From 20b1fd8b7d74b36d7da722bcef98356fea03ec1f Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:05:59 +0100
-Subject: [PATCH 28/37] gcc10: Remove tagtype attribute.
+Subject: [PATCH 28/38] gcc10: Remove tagtype attribute.
 
 The 'Add tagtype attribute that can be passed to enum' patch needs
 to be adapted. Temporarily disable the patch since adaptation requires

--- a/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
+++ b/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
@@ -1,7 +1,7 @@
 From 266f38251b6aa1c7fd3b8429d2d2b95d0c577f5c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:07:45 +0100
-Subject: [PATCH 29/37] gcc10: Define CC1_SPEC.
+Subject: [PATCH 29/38] gcc10: Define CC1_SPEC.
 
 ---
  gcc/config/rs6000/amigaos.h | 13 +++++++++++++

--- a/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
+++ b/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
@@ -1,7 +1,7 @@
 From 0fe8d761ed5446ed3c7ca431659958b2498ee613 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 01:02:33 +0100
-Subject: [PATCH 30/37] gcc10: Link lto-dump with -athread=native.
+Subject: [PATCH 30/38] gcc10: Link lto-dump with -athread=native.
 
 ---
  gcc/config/rs6000/x-amigaos | 3 ++-

--- a/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
+++ b/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
@@ -1,7 +1,7 @@
 From f55c00ae21292b68738143bbf275ef30e94b7efe Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 14:03:50 +0100
-Subject: [PATCH 31/37] gcc10: Expose max_align_t when using clib2.
+Subject: [PATCH 31/38] gcc10: Expose max_align_t when using clib2.
 
 ---
  libstdc++-v3/include/c_global/cstddef | 3 ---

--- a/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
+++ b/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
@@ -1,7 +1,7 @@
 From 0c74121b54a3b0c55ede757302dd13f6728d560d Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sun, 7 Feb 2021 19:38:47 +0100
-Subject: [PATCH 32/37] gcc10: Don't define __STRICT_ANSI__.
+Subject: [PATCH 32/38] gcc10: Don't define __STRICT_ANSI__.
 
 Doing so hides C99 features when configuring libstdc++.
 ---

--- a/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
+++ b/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
@@ -1,7 +1,7 @@
 From c3443778d66979c2734bb02baf24c14b979e7326 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Mon, 15 Mar 2021 15:55:11 +0100
-Subject: [PATCH 33/37] gcc10: Fix libstdc++v3 paths.
+Subject: [PATCH 33/38] gcc10: Fix libstdc++v3 paths.
 
 ---
  libstdc++-v3/src/c++17/fs_ops.cc  |  17 ++++-

--- a/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
+++ b/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
@@ -1,7 +1,7 @@
 From 0b5fd31f94a96acd4b83b34be52e2915982494fc Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:21:55 +0200
-Subject: [PATCH 34/37] gcc11: Include stdint.h when sys/mman.h is missing.
+Subject: [PATCH 34/38] gcc11: Include stdint.h when sys/mman.h is missing.
 
 Since sys/mman.h indirectly includes stdint.h, we need to explicitly
 include stdint.h when sys/mman.h is missing.

--- a/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
+++ b/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
@@ -1,7 +1,7 @@
 From 57cdd99bfe45740a2021212005227a089eb5921c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:27:59 +0200
-Subject: [PATCH 35/37] gcc11: Use include_next to circumvent fenv.h include
+Subject: [PATCH 35/38] gcc11: Use include_next to circumvent fenv.h include
  guard.
 
 Include guards will prevent the correct fenv.h to be included

--- a/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
+++ b/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
@@ -1,7 +1,7 @@
 From c99b141102f736198f6c013f5e58946ccc6d3b95 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 5 Oct 2022 11:36:32 +0100
-Subject: [PATCH 36/37] gcc11: Fix to exception raised by Callable in call_once
+Subject: [PATCH 36/38] gcc11: Fix to exception raised by Callable in call_once
  implementation.
 
 In the case the Callable raises an exception, the shared resources between

--- a/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
+++ b/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
@@ -1,7 +1,7 @@
-From 59202d8341b6a02e4ccc3c97063c95ab28f0ba43 Mon Sep 17 00:00:00 2001
-From: Ola Söder <rolfkopman@gmail.com>
+From 80cd06ee17ebac85775c82d8b884de7ead35f169 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ola=20S=C3=B6der?= <rolfkopman@gmail.com>
 Date: Sun, 9 Apr 2023 22:34:16 +0200
-Subject: [PATCH 37/37] gcc11: Add builtin _AMIGA define.
+Subject: [PATCH 37/38] gcc11: Add builtin _AMIGA define.
 
 Define _AMIGA like on AROS, MorphOS and OS3 (SAS/C).
 ---

--- a/gcc/11/patches/0038-gcc11-Provide-clib4-as-an-alternative-C-runtime-libr.patch
+++ b/gcc/11/patches/0038-gcc11-Provide-clib4-as-an-alternative-C-runtime-libr.patch
@@ -1,0 +1,207 @@
+From 89d22be348dd26a4d82b12f8c79ae8fe0db46ecb Mon Sep 17 00:00:00 2001
+From: rjd <3246251196ryan@gmail.com>
+Date: Mon, 2 Oct 2023 12:28:43 +0100
+Subject: [PATCH 38/38] gcc11: Provide clib4 as an alternative C runtime
+ library.
+
+The mcrt option will now accept clib4 (--mcrt=clib4) in addition to
+newlib and clib2.
+---
+ gcc/config/rs6000/amigaos.h           | 43 ++++++++++++++++++++-------
+ gcc/config/rs6000/t-amigaos           |  4 +--
+ libstdc++-v3/include/c_global/cstdlib |  4 +--
+ 3 files changed, 37 insertions(+), 14 deletions(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index 8a549ed05ca4358e30e2bdef6a2b6d2d177fdd14..a8040a84d958d84815193959f07a47684d8dae18 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -122,12 +122,17 @@
+       else if (IS_MCRT("clib2") || IS_MCRT("clib2-ts")) \
+         {					\
+           builtin_define_std ("CLIB2");		\
+           if (IS_MCRT("clib2-ts"))		\
+             builtin_define ("__THREAD_SAFE");	\
+         }					\
++      else if (IS_MCRT("clib4"))		\
++        {					\
++          builtin_define_std ("CLIB4");		\
++          builtin_define ("CLIB4");		\
++        }					\
+       else if (IS_MCRT("ixemul"))		\
+         {					\
+           builtin_define_std ("ixemul");	\
+           builtin_define_std ("IXEMUL");	\
+         }					\
+       else if (IS_MCRT("libnix"))		\
+@@ -166,28 +171,18 @@
+ #undef REAL_LIBGCC_SPEC
+ #define REAL_LIBGCC_SPEC "\
+ %{static|static-libgcc: %{!use-dynld: -lgcc -lgcc_eh} %{use-dynld: -lgcc} }%{!static:%{!static-libgcc:%{!shared:%{!shared-libgcc: %{!use-dynld: -lgcc -lgcc_eh} %{use-dynld: -lgcc}}%{shared-libgcc:-lgcc}}%{shared:%{shared-libgcc:-lgcc}%{!shared-libgcc:-lgcc}}}}"
+ 
+ 
+ /* make newlib the default */
+-#if 1
+ #define CPP_AMIGA_DEFAULT_SPEC "%{mcrt=default|!mcrt=*:%<mcrt=default -mcrt=newlib} %(cpp_newlib)"
+ #define LINK_AMIGA_DEFAULT_SPEC "%(link_newlib)"
+ #define STARTFILE_AMIGA_DEFAULT_SPEC "%(startfile_newlib)"
+ #define ENDFILE_AMIGA_DEFAULT_SPEC "%(endfile_newlib)"
+ #undef MULTILIB_DEFAULTS
+ #define MULTILIB_DEFAULTS {"mcrt=newlib"}
+-#else
+-/* make clib2 the default */
+-#define CPP_AMIGA_DEFAULT_SPEC "%{mcrt=default|!mcrt=*:%<mcrt=default -mcrt=clib2} %(cpp_clib2)"
+-#define LINK_AMIGA_DEFAULT_SPEC "%(link_clib2)"
+-#define STARTFILE_AMIGA_DEFAULT_SPEC "%(startfile_clib2)"
+-#define ENDFILE_AMIGA_DEFAULT_SPEC "%(endfile_clib2)"
+-#undef MULTILIB_DEFAULTS
+-#define MULTILIB_DEFAULTS {"mcrt=clib2"}
+-#endif
+ 
+ 
+ /* For specifying the include system paths, we generally use -idirafter so the include
+  * paths are added at the end of the gcc default include paths. This is required for
+  * fixincludes and libstdc++ to work properly
+  */
+@@ -212,12 +207,30 @@
+                  "%{!msoft-float:%(lib_subdir_type)}/crt0.o"
+ 
+ #define ENDFILE_CLIB2_SPEC "\
+ %(base_sdk)clib2/%{mcrt=clib2-ts:lib.threadsafe; :lib}" \
+                  "%{!msoft-float:%(lib_subdir_type)}/crtend.o"
+ 
++/* clib4 */
++
++#define CPP_CLIB4_SPEC "\
++-idirafter %(base_sdk)clib4/include -idirafter %(base_sdk)local/clib4/include"
++
++#define LIB_SUBDIR_CLIB4_SPEC "lib%(lib_subdir_type)"
++
++#define LINK_CLIB4_SPEC "\
++-L%(base_sdk)clib4/%(lib_subdir_clib4) \
++-L%(base_gcc)lib/gcc/ppc-amigaos/%(version)/clib4/lib%(lib_subdir_clib4) \
++-L%(base_sdk)local/clib4/%(lib_subdir_clib4)"
++
++#define STARTFILE_CLIB4_SPEC "\
++%{shared: %(base_sdk)clib4/%(lib_subdir_clib4)/shcrtbegin.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crtbegin.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crt0.o}"
++
++#define ENDFILE_CLIB4_SPEC "\
++%{shared: %(base_sdk)clib4/%(lib_subdir_clib4)/shcrtend.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crtend.o}"
++
+ /* ixemul */
+ 
+ #define CPP_IXEMUL_SPEC "\
+ -idirafter %(base_sdk)ixemul/include -idirafter %(base_sdk)local/ixemul/include"
+ 
+ #define LIB_SUBDIR_IXEMUL_SPEC "lib%(lib_subdir_type)"
+@@ -267,12 +280,13 @@
+ 
+ /* End clib specific */
+ 
+ #undef CPP_OS_DEFAULT_SPEC
+ #define CPP_OS_DEFAULT_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(cpp_clib2); \
++mcrt=clib4: %(cpp_clib4); \
+ mcrt=ixemul: %(cpp_ixemul); \
+ mcrt=libnix: %(cpp_libnix); \
+ mcrt=newlib: %(cpp_newlib); \
+ mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
+ : %eInvalid C runtime library} \
+ %{!nostdinc: -idirafter %(base_sdk)include/include_h -idirafter %(base_sdk)include/netinclude -idirafter %(base_sdk)local/common/include} \
+@@ -286,12 +300,13 @@ mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
+ -q -d %{h*} %{v:-V} %{G*} \
+ %{Wl,*:%*} %{YP,*} %{R*} \
+ %{Qy:} %{!Qn:-Qy} \
+ %(link_thread) %(link_shlib) %(link_text) \
+ %{mbaserel: %{msdata|msdata=default|msdata=sysv: %e-mbaserel and -msdata options are incompatible}} \
+ %{mcrt=clib2|mcrt=clib2-ts: %(link_clib2); \
++mcrt=clib4: %(link_clib4); \
+ mcrt=ixemul: %(link_ixemul); \
+ mcrt=libnix: %(link_libnix); \
+ mcrt=newlib: %(link_newlib); \
+ mcrt=default|!mcrt=*: %(link_amiga_default); \
+ : %eInvalid C runtime library} \
+ -L%(base_sdk)local/common/lib%(lib_subdir_type) \
+@@ -311,21 +326,23 @@ mcrt=default|!mcrt=*: %(link_amiga_default); \
+ #define LINK_THREAD "\
+ %s%{athread=native:gthr-amigaos-native.o;athread=single:gthr-amigaos-single.o;athread=pthread:gthr-amigaos-pthread.o}"
+ 
+ #undef STARTFILE_SPEC
+ #define STARTFILE_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(startfile_clib2); \
++mcrt=clib4: %(startfile_clib4); \
+ mcrt=ixemul: %(startfile_ixemul); \
+ mcrt=libnix: %(startfile_libnix); \
+ mcrt=newlib: %(startfile_newlib); \
+ mcrt=default|!mcrt=*: %(startfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+ #undef ENDFILE_SPEC
+ #define ENDFILE_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(endfile_clib2); \
++mcrt=clib4: %(endfile_clib4); \
+ mcrt=ixemul: %(endfile_ixemul); \
+ mcrt=libnix: %(endfile_libnix); \
+ mcrt=newlib: %(endfile_newlib); \
+ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+@@ -350,12 +367,18 @@ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+   /* clib2 */ \
+   {"cpp_clib2", CPP_CLIB2_SPEC}, \
+   {"lib_subdir_clib2", LIB_SUBDIR_CLIB2_SPEC}, \
+   {"link_clib2", LINK_CLIB2_SPEC}, \
+   {"startfile_clib2", STARTFILE_CLIB2_SPEC}, \
+   {"endfile_clib2", ENDFILE_CLIB2_SPEC}, \
++  /* clib4 */ \
++  {"cpp_clib4", CPP_CLIB4_SPEC}, \
++  {"lib_subdir_clib4", LIB_SUBDIR_CLIB4_SPEC}, \
++  {"link_clib4", LINK_CLIB4_SPEC}, \
++  {"startfile_clib4", STARTFILE_CLIB4_SPEC}, \
++  {"endfile_clib4", ENDFILE_CLIB4_SPEC}, \
+   /* ixemul */ \
+   {"cpp_ixemul", CPP_IXEMUL_SPEC}, \
+   {"lib_subdir_ixemul", LIB_SUBDIR_IXEMUL_SPEC}, \
+   {"link_ixemul", LINK_IXEMUL_SPEC}, \
+   {"startfile_ixemul", STARTFILE_IXEMUL_SPEC}, \
+   {"endfile_ixemul", ENDFILE_IXEMUL_SPEC}, \
+diff --git a/gcc/config/rs6000/t-amigaos b/gcc/config/rs6000/t-amigaos
+index 15d9d3fd5a5f0c8109cd158242745fa52b19257e..0d8049f400ca7f0937330ffec4f01546d9d61cc2 100644
+--- a/gcc/config/rs6000/t-amigaos
++++ b/gcc/config/rs6000/t-amigaos
+@@ -12,9 +12,9 @@ LIMITS_H_TEST = true
+ NATIVE_SYSTEM_HEADER_DIR=/gcc/include
+ #OTHER_FIXINCLUDES_DIRS=${gcc_tooldir}/include
+ 
+ # Build the libraries for both newlib and clib2
+ # We do not build soft float flavours as none of the
+ # libs support soft floats
+-MULTILIB_OPTIONS = mcrt=newlib/mcrt=clib2
+-MULTILIB_DIRNAMES = newlib clib2
++MULTILIB_OPTIONS = mcrt=newlib/mcrt=clib2/mcrt=clib4
++MULTILIB_DIRNAMES = newlib clib2 clib4
+ #MULTILIB_REUSE = =mcrt=newlib
+diff --git a/libstdc++-v3/include/c_global/cstdlib b/libstdc++-v3/include/c_global/cstdlib
+index 99325ad0682f2f88bc04ca38a50cc97a2bcea4d5..deae1df7fd4657b48ee9ccd4f0d1781f2d09237e 100644
+--- a/libstdc++-v3/include/c_global/cstdlib
++++ b/libstdc++-v3/include/c_global/cstdlib
+@@ -188,14 +188,14 @@ _GLIBCXX_END_NAMESPACE_VERSION
+ #undef lldiv
+ #undef atoll
+ #undef strtoll
+ #undef strtoull
+ #undef strtof
+ 
+-/* Neigther clib2 nor newlib offers strtoud() */
+-#ifndef __amigaos4__
++/* clib2 and newlib do not provide an implementation of strtold */
++#if !defined (__amigaos4__) || defined(__CLIB4__)
+ #undef strtold
+ #endif
+ 
+ namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
+ {
+ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+-- 
+2.34.1
+

--- a/native-build/ReadMe.mak
+++ b/native-build/ReadMe.mak
@@ -48,6 +48,9 @@ accompanying clib2 release archive ${CLIB2_RELEASE_ARCHIVE_NAME} and install its
 contents into the SDK: folder. You can find this (unofficial) archive at
 https://dl.bintray.com/sba1/adtools-native/.
 
+Alternatively to clib2, there is clib4, which is a fork from the original
+clib2. The release archive is ${CLIB4_RELEASE_ARCHIVE_NAME}.
+
 Also for C++, it is recommended not to use the shared objects feature (aka
 dynload) for now. The reason is that the C++-ABI may change in the future.
 Lastly, you should link the final executable using the --athread=native

--- a/native-build/makefile
+++ b/native-build/makefile
@@ -7,6 +7,7 @@
 # The user running this script must have write access to /gcc
 #
 # ===
+CROSS_IS_PRESENT?=0
 # Optional (DEFAULT=0):
 # Define CROSS_IS_PRESENT=1 if a suitable cross compiler is already
 # present, in which case the cross compiler build is skipped, e.g.:
@@ -14,16 +15,18 @@
 #  make CROSS_IS_PRESENT=1
 #
 # ===
-# Optional (DEFAULT=0):
-# Define EXP_CLIB2=1 if the later experimental version of clib2 is desired
-# In case EXP_CLIB2=1, optionally define CLIB2_SHA1=X, where X is the commit id
-# or branch to be used within the experimental version; defaults to HEAD e.g.:
-#
-#  make EXP_CLIB2=1 CLIB2_SHA1=beta8
-#
-# See https://github.com/afxgroup/clib2.
-#
+CLIB2_SHA1?=1a42c693e03881f6f969c43ab36ce20d2569751d
+# Optional (DEFAULT 1a42c693e03881f6f969c43ab36ce20d2569751d)
+# Define CLIB2_SHA1 to be the value of the branch or commit to use for clib2
 # ===
+CLIB4_SHA1?=HEAD
+# Optional (DEFAULT HEAD)
+# Define CLIB4_SHA1 to be the value of the branch or commit to use for clib4
+#
+# Note that CLIB4 is only supported for certain version of GCC, see
+# the variable named "CLIB4_SUPPORT" below
+# ===
+SDK_VERSION?=54.16
 # Optional (DEFAULT=54.16):
 # Define SDK_VERSION to specify which version of the Amiga SDK is desired
 
@@ -51,8 +54,10 @@ endif
 
 GCC_BRANCH_NAME:=$(word 1, $(subst ., , $(GCC_VERSION)))
 
-SDK_VERSION?=54.16
+# Handle SDK version and mapping to necessary file URL
+ifeq (54.16,$(SDK_VERSION))
 SDK_URL_FILE=127
+else
 ifeq (53.34,$(SDK_VERSION))
 SDK_URL_FILE=125
 else
@@ -68,7 +73,7 @@ endif
 endif
 endif
 endif
-
+endif
 SDK_URL=http://www.hyperion-entertainment.biz/index.php?option=com_registration&amp;view=download&amp;format=raw&amp;file=$(SDK_URL_FILE)
 
 # Native tools
@@ -78,13 +83,14 @@ COREUTILS_VERSION=5.2.1
 # Distribution version, used as middle part of a distribution archive
 DIST_VERSION=$(shell date +%Y%m%d)-$(shell git rev-list --count HEAD)
 
-ifeq (1,$(EXP_CLIB2))
-CLIB2_URL=https://github.com/afxgroup/clib2.git
-CLIB2_SHA1?=HEAD
-else
+# Set up the necessary variables for the CLIBs
+CLIB4_SUPPORT=$(filter 11,$(GCC_BRANCH_NAME))
+CLIB4_URL=https://github.com/afxgroup/clib2.git
+CLIB4_DIR=downloads/clib4/
+CLIB4_RELEASE_ARCHIVE_NAME=adtools-os4-clib4-$(DIST_VERSION).lha
+
 CLIB2_URL=https://github.com/sodero/clib2
-CLIB2_SHA1=1a42c693e03881f6f969c43ab36ce20d2569751d
-endif
+CLIB2_DIR=downloads/clib2/library/
 CLIB2_RELEASE_ARCHIVE_NAME=adtools-os4-clib2-$(DIST_VERSION).lha
 
 CROSS_PREFIX?=$(ROOT_DIR)/root-cross
@@ -109,16 +115,33 @@ print-dist-version:
 #
 downloads-done-clib2:
 	mkdir -p downloads
-	cd downloads && (git clone $(CLIB2_URL) clib2 || true) && cd clib2 && git checkout $(CLIB2_SHA1)
-ifeq (1,$(EXP_CLIB2))
-	touch EXP_CLIB2
-endif
+	cd downloads && \
+		(git clone $(CLIB2_URL) clib2 || true) && \
+		cd clib2 && \
+		git checkout $(CLIB2_SHA1)
 	touch $@
+
+#
+# Downloads clib4
+#
+ifneq ($(CLIB4_SUPPORT),)
+downloads-done-clib4:
+	mkdir -p downloads
+	cd downloads && \
+		(git clone $(CLIB4_URL) clib4 || true) && \
+		cd clib4 && \
+		git checkout $(CLIB4_SHA1)
+	touch $@
+endif
 
 #
 # Downloads the SDK and libraries necesseary to build the cross compiler
 #
-downloads-done: downloads-done-clib2
+DOWNLOADS_DONE_DEPENDENCY=downloads-done-clib2
+ifneq ($(CLIB4_SUPPORT),)
+DOWNLOADS_DONE_DEPENDENCY+=downloads-done-clib4
+endif
+downloads-done: $(DOWNLOADS_DONE_DEPENDENCY)
 	wget "$(SDK_URL)" -O downloads/SDK_$(SDK_VERSION).lha
 	cd downloads && wget -N http://ftp.gnu.org/gnu/gmp/$(GMP_ARCHIVE)
 	cd downloads && wget -N http://ftp.gnu.org/gnu/mpfr/$(MPFR_ARCHIVE)
@@ -151,8 +174,6 @@ binutils-install: binutils-cross-done-$(BINUTILS_VERSION)
 includes-done: downloads-done
 	mkdir -p $(CROSS_PREFIX)/ppc-amigaos/SDK/include
 	cd downloads && lha x SDK_$(SDK_VERSION).lha
-# We built clib2 inplace
-#	cd downloads/SDK_Install && lha xf clib2*.lha
 	cd downloads/SDK_Install && lha xf newlib*.lha
 	cd downloads/SDK_Install && lha xf base.lha
 ifneq (53.30,$(SDK_VERSION))
@@ -162,7 +183,6 @@ endif
 endif
 	cd downloads/SDK_Install && rm -Rf *.lha
 	cd downloads/SDK_Install && mv newlib* $(CROSS_PREFIX)/ppc-amigaos/SDK
-#	cd downloads/SDK_Install && mv clib2* $(CROSS_PREFIX)/ppc-amigaos/SDK
 	cd downloads/SDK_Install && mv Include/* $(CROSS_PREFIX)/ppc-amigaos/SDK/include
 	rm -Rf downloads/SDK_Install downloads/SDK_Install.info
 	touch $@
@@ -179,7 +199,10 @@ XGCC_CC=ppc-amigaos-gcc
 XAR=ppc-amigaos-ar -q
 XRANLIB=ppc-amigaos-ranlib
 
-CLIB2_CROSS_DONE_DEPENDENCY=downloads-done-clib2
+CLIB_CROSS_DONE_DEPENDENCY=downloads-done-clib2
+ifneq ($(CLIB4_SUPPORT),)
+CLIB_CROSS_DONE_DEPENDENCY+=downloads-done-clib4
+endif
 
 else
 
@@ -189,16 +212,8 @@ XGCC_CC=$(XGCC) -B $(XGCC_DIR)
 XAR=$(CROSS_PREFIX)/bin/ppc-amigaos-ar -q
 XRANLIB=$(CROSS_PREFIX)/bin/ppc-amigaos-ranlib
 
-CLIB2_CROSS_DONE_DEPENDENCY=xgcc-done-$(GCC_VERSION)
+CLIB_CROSS_DONE_DEPENDENCY=xgcc-done-$(GCC_VERSION)
 
-endif
-
-EXP_CLIB2_DIR=downloads/clib2/
-STABLE_CLIB2_DIR=downloads/clib2/library/
-ifeq (1,$(EXP_CLIB2))
-CLIB2_DIR=$(EXP_CLIB2_DIR)
-else
-CLIB2_DIR=$(STABLE_CLIB2_DIR)
 endif
 
 #
@@ -222,40 +237,48 @@ xgcc-done-$(GCC_VERSION): includes-done binutils-cross-done-$(BINUTILS_VERSION)
 	touch $@
 
 #
-# Build clib2 via xgcc
+# Build clib via xgcc
 #
-clib2-cross-done-$(GCC_VERSION): $(CLIB2_CROSS_DONE_DEPENDENCY)
-# Build clib2 using xgcc that have just been built
-ifeq (1,$(EXP_CLIB2))
-	$(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 \
+ifneq ($(CLIB4_SUPPORT),)
+clib4-cross-done-$(GCC_VERSION): $(CLIB_CROSS_DONE_DEPENDENCY)
+# Build clib using xgcc that have just been built
+	$(MAKE) -C $(CLIB4_DIR) -f GNUmakefile.os4 \
 		CC="$(XGCC_CC)" \
 		AR="$(XAR)" \
 		RANLIB="$(XRANLIB)" \
-		SHARED=no \
-		INSTALL_PREFIX=$(CROSS_PREFIX)/ppc-amigaos/SDK/clib2 \
+		STRIP=$(STRIP) \
+		INSTALL_PREFIX=$(CROSS_PREFIX)/ppc-amigaos/SDK/clib4 \
 		SDK_INCLUDE=$(CROSS_PREFIX)/ppc-amigaos/SDK/include
-else
-	$(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 CC="$(XGCC_CC)" AR="$(XAR)" RANLIB="$(XRANLIB)"
+# Copy clib libs and includes
+	$(MAKE) -C $(CLIB4_DIR) -f GNUmakefile.os4 install \
+		INSTALL_PREFIX=$(CROSS_PREFIX)/ppc-amigaos/SDK/clib4
+	cp $(CLIB4_DIR)/LICENSE* $(CROSS_PREFIX)/ppc-amigaos/SDK/clib4
+	touch $@
 endif
-# Copy clib2 libs and includes
-ifeq (1,$(EXP_CLIB2))
-	$(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 install \
-		INSTALL_PREFIX=$(CROSS_PREFIX)/ppc-amigaos/SDK/clib2
-	cp $(CLIB2_DIR)/LICENSE* $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2
-else
+
+clib2-cross-done-$(GCC_VERSION): $(CLIB_CROSS_DONE_DEPENDENCY)
+# Build clib using xgcc that have just been built
+	$(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 \
+		CC="$(XGCC_CC)" \
+		AR="$(XAR)" \
+		RANLIB="$(XRANLIB)"
+# Copy clib libs and includes
 	rm -Rf $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/lib $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/include
 	mkdir -p $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/lib
 	mkdir -p $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/include
 	cp -Rp $(CLIB2_DIR)/include/* $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/include
 	cp -Rp $(CLIB2_DIR)/lib/* $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2/lib
 	cp $(CLIB2_DIR)/../LICENSE $(CROSS_PREFIX)/ppc-amigaos/SDK/clib2
-endif
 	touch $@
 
 #
 # Build the cross compiler
 #
-gcc-cross-done-$(GCC_VERSION): clib2-cross-done-$(GCC_VERSION)
+GCC_CROSS_DONE_DEPENDENCY=clib2-cross-done-$(GCC_VERSION)
+ifneq ($(CLIB4_SUPPORT),)
+GCC_CROSS_DONE_DEPENDENCY+=clib4-cross-done-$(GCC_VERSION)
+endif
+gcc-cross-done-$(GCC_VERSION): $(GCC_CROSS_DONE_DEPENDENCY)
 # Compile remaining
 	$(MAKE) -C $(ROOT_DIR)/gcc-cross-build-$(GCC_VERSION)
 	$(MAKE) -C $(ROOT_DIR)/gcc-cross-build-$(GCC_VERSION) install
@@ -323,19 +346,19 @@ gcc-native-done-$(GCC_VERSION): binutils-native-done-$(BINUTILS_VERSION)
 ifeq ($(CROSS_IS_PRESENT),1)
 coreutils-native-done:
 else
+
 coreutils-native-done: gcc-cross-done-$(GCC_VERSION)
 endif
 	mkdir -p coreutils-native-build
 	@if [ ! -f $(COREUTILS_SRC_DIR)/configure ]; then echo "Please checkout coreutils first!"; false; fi
 # Pretend few files to be uptodate
 	touch $(realpath $(COREUTILS_SRC_DIR))/configure $(realpath $(COREUTILS_SRC_DIR))/config.hin
-#	cd coreutils-native-build ; PATH="$(CROSS_PREFIX)/bin:$(PATH)" LIBS="-lunix" $(realpath $(COREUTILS_SRC_DIR))/configure --prefix=/gcc --host=ppc-amigaos
-ifeq (0, $(shell test -f EXP_CLIB2 ; echo $$?))
-# We do not need libunix / lnet for EXP CLIB2
-	cd coreutils-native-build ; PATH="$(CROSS_PREFIX)/bin:$(PATH)" CPPFLAGS="-mcrt=clib2" LDFLAGS="-mcrt=clib2" $(realpath $(COREUTILS_SRC_DIR))/configure --prefix=/gcc --host=ppc-amigaos --disable-maintainer-mode
-else
-	cd coreutils-native-build ; PATH="$(CROSS_PREFIX)/bin:$(PATH)" CPPFLAGS="-mcrt=clib2" LDFLAGS="-mcrt=clib2" LIBS="-lunix -lnet" $(realpath $(COREUTILS_SRC_DIR))/configure --prefix=/gcc --host=ppc-amigaos --disable-maintainer-mode
-endif
+	cd coreutils-native-build ; \
+		$(realpath $(COREUTILS_SRC_DIR))/configure --prefix=/gcc --host=ppc-amigaos --disable-maintainer-mode \
+		PATH="$(CROSS_PREFIX)/bin:$(PATH)" \
+		CPPFLAGS="-mcrt=clib2" \
+		LDFLAGS="-mcrt=clib2" \
+		LIBS="-lunix -lnet"
 	PATH="$(CROSS_PREFIX)/bin:$(PATH)" $(MAKE) -C coreutils-native-build
 	touch $@
 
@@ -375,6 +398,11 @@ doc:
 #
 # Target for generating the ReadMe used for Aminet
 #
+ifneq ($(CLIB4_SUPPORT),)
+CLIB4_ENTRY=CLIB4_RELEASE_ARCHIVE_NAME='$(CLIB4_RELEASE_ARCHIVE_NAME)'
+else
+CLIB4_ENTRY=CLIB4_RELEASE_ARCHIVE_NAME=<NOT GENERATED>
+endif
 ReadMe: ReadMe.mak
 	python -c "\
 	from mako.template import Template;\
@@ -390,7 +418,8 @@ ReadMe: ReadMe.mak
 			GCC_VERSION='$(GCC_VERSION)',\
 			GCC_DEV_PHASE='$(GCC_DEV_PHASE)',\
 			COREUTILS_VERSION='$(COREUTILS_VERSION)',\
-			CLIB2_RELEASE_ARCHIVE_NAME='$(CLIB2_RELEASE_ARCHIVE_NAME)'\
+			CLIB2_RELEASE_ARCHIVE_NAME='$(CLIB2_RELEASE_ARCHIVE_NAME)',\
+			$(CLIB4_ENTRY)\
 		))\
 	" >$@.utf8
 	iconv --from-code=UTF8 --to-code=ISO-8859-15 $@.utf8 >$@
@@ -514,10 +543,14 @@ native-dist: native-strip-really
 	cd /tmp && lha ao5 $(realpath .)/$(DIST_FOLDER).lha $(DIST_FOLDER)/*
 
 #
-# Clib2 distribution
+# Clib distribution
 #
 clib2-dist: clib2-cross-done-$(GCC_VERSION)
 	cd root-cross/ppc-amigaos/SDK && lha ao5 $(realpath .)/$(CLIB2_RELEASE_ARCHIVE_NAME) clib2
+ifneq ($(CLIB4_SUPPORT),)
+clib4-dist: clib4-cross-done-$(GCC_VERSION)
+	cd root-cross/ppc-amigaos/SDK && lha ao5 $(realpath .)/$(CLIB4_RELEASE_ARCHIVE_NAME) clib4
+endif
 
 #
 # Upload the binary archive to the main Aminet server
@@ -528,16 +561,14 @@ upload-release: native-dist
 	lftp -e "put adtools-$(GCC_BRANCH_NAME)-os4.lha && put ReadMe -o adtools-$(GCC_BRANCH_NAME)-os4.readme && quit" ftp://main.aminet.net/new
 
 #
-# Cleanup clib2
+# Cleanup clib
 #
 
 .PHONY: clean-clib2
 clean-clib2:
-ifeq (0, $(shell test -f EXP_CLIB2 ; echo $$?))
-	test ! -d $(EXP_CLIB2_DIR) || $(MAKE) -C $(EXP_CLIB2_DIR) -f GNUmakefile.os4 clean
-else
-	test ! -d $(STABLE_CLIB2_DIR) || $(MAKE) -C $(STABLE_CLIB2_DIR) -f GNUmakefile.os4 clean
-endif
+	test ! -d $(CLIB2_DIR) || $(MAKE) -C $(CLIB2_DIR) -f GNUmakefile.os4 clean
+clean-clib4:
+	test ! -d $(CLIB4_DIR) || $(MAKE) -C $(CLIB4_DIR) -f GNUmakefile.os4 clean
 
 #
 # Cleanup gcc only
@@ -556,7 +587,7 @@ clean-gcc:
 # Cleanup everything
 #
 .PHONY: clean
-clean: clean-clib2 clean-gcc
+clean: clean-clib2 clean-clib4 clean-gcc
 	rm -Rf	\
 		binutils-cross-build-$(BINUTILS_VERSION) \
 		binutils-native-build-$(BINUTILS_VERSION) \
@@ -566,6 +597,7 @@ clean: clean-clib2 clean-gcc
 		binutils-cross-done-$(BINUTILS_VERSION) \
 		binutils-native-done-$(BINUTILS_VERSION) \
 		clib2-cross-done-$(GCC_VERSION) \
+		clib4-cross-done-$(GCC_VERSION) \
 		includes-done \
 		libraries-done \
 		root-native \
@@ -577,7 +609,4 @@ clean: clean-clib2 clean-gcc
 #
 .PNONY: clean-all
 clean-all: clean
-	rm -Rf downloads-done downloads-done-clib2 downloads
-ifeq (0, $(shell test -f EXP_CLIB2 ; echo $$?))
-	rm -f EXP_CLIB2
-endif
+	rm -Rf downloads-done downloads-done-clib2 downloads-done-clib4 downloads


### PR DESCRIPTION
As well as the existing newlib and clib2 as C runtime library choices, clib4 is now introduced. Support for clib4 is currently restricted to GCC version 11.