### PR TITLE
Provide clib4 as an additional C runtime library.

### DIFF
--- a/gcc/6/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/6/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
-From 0d8660c728facae5297abc8b10a15cf28b2f022e Mon Sep 17 00:00:00 2001
+From fb1fbc56ecf4c107fb138577d8aa135ed2ed80f6 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/18] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/19] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |    1 +
@@ -12,11 +12,11 @@ Subject: [PATCH 01/18] Changes for AmigaOS version of gcc.
  gcc/config.gcc                        |    8 +
  gcc/config.host                       |    6 +
  gcc/config/rs6000/amigaos-protos.h    |   41 +
- gcc/config/rs6000/amigaos.c           |  463 +++++++++
- gcc/config/rs6000/amigaos.h           |  433 ++++++++
+ gcc/config/rs6000/amigaos.c           |  463 +++++++
+ gcc/config/rs6000/amigaos.h           |  433 ++++++
  gcc/config/rs6000/amigaos.opt         |   37 +
  gcc/config/rs6000/rs6000-builtin.def  |    7 +
- gcc/config/rs6000/rs6000.c            |  176 +++-
+ gcc/config/rs6000/rs6000.c            |  176 ++-
  gcc/config/rs6000/rs6000.h            |    3 +
  gcc/config/rs6000/rs6000.md           |   27 +-
  gcc/config/rs6000/t-amigaos           |   20 +
@@ -37,8 +37,8 @@ Subject: [PATCH 01/18] Changes for AmigaOS version of gcc.
  libiberty/lrealpath.c                 |    3 +-
  libiberty/make-relative-prefix.c      |   37 +-
  libiberty/make-temp-file.c            |   27 +-
- libiberty/pex-amigaos.c               |  325 ++++++
- libstdc++-v3/configure                | 1852 ++++++++++++++++++++++++++++++++-
+ libiberty/pex-amigaos.c               |  325 +++++
+ libstdc++-v3/configure                | 1852 ++++++++++++++++++++++++-
  libstdc++-v3/configure.ac             |    3 +
  libstdc++-v3/crossconfig.m4           |    8 +
  libstdc++-v3/include/c_global/cstddef |    3 +
@@ -5187,5 +5187,5 @@ index 58d4f4bb060de34ea2284d1b3ce908e360268a8a..21a77fcc3af4e3f05f2a79274dfa89c7
  
  #endif // _GLIBCXX_CSTDDEF
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/6/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
-From bc0cb63bb0208881df98bd560e13aa4fff6608fa Mon Sep 17 00:00:00 2001
+From 091ebe485044d027b393b067505e9dfc35c12267 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/18] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/19] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions
@@ -28,10 +28,10 @@ For instance, no check is done that the attribute is applied to varargs
 functions.
 ---
  gcc/c-family/c-pragma.c            |  10 +++
- gcc/c/c-parser.c                   | 129 +++++++++++++++++++++++++++++++++++++
- gcc/c/c-typeck.c                   |  26 ++++++++
+ gcc/c/c-parser.c                   | 129 +++++++++++++++++++++++++++++
+ gcc/c/c-typeck.c                   |  26 ++++++
  gcc/config/rs6000/amigaos-protos.h |   1 +
- gcc/config/rs6000/amigaos.c        |  33 ++++++++++
+ gcc/config/rs6000/amigaos.c        |  33 ++++++++
  5 files changed, 199 insertions(+)
 
 diff --git a/gcc/c-family/c-pragma.c b/gcc/c-family/c-pragma.c
@@ -397,5 +397,5 @@ index a6da7d543241e2fc8cf51a952633c62e19d7d875..0749b33bab279bebf7146a7592c4fc02
  amigaos_legitimize_baserel_address (rtx addr)
  {
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/6/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
-From 1e7be0884b71ce4bbb9ce24c643953baec4a5e30 Mon Sep 17 00:00:00 2001
+From 3bfa44553e3aa11ca27cc5a6fa2f1f5270c01a89 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/18] Disable .machine directive generation.
+Subject: [PATCH 03/19] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.
@@ -45,5 +45,5 @@ index 86b12340bd060bf8c3482b0d869eefa96c670c47..16c96acdb619e5de889b2fe42f95ec54
      fprintf (file, "\t.abiversion 2\n");
  }
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/6/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From ae3b1fdfc70971f2cae735621081aa2e6ebb710d Mon Sep 17 00:00:00 2001
+From 8032a07ba466421f9376f7e0bca8c692464063ae Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/18] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/19] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---
@@ -47,5 +47,5 @@ index 03cbde090cb361f7f6244c97a91c8ad567d9a092..c8dec4b7a0ad1d95811dd9a50a7916e3
  	case OPT_static_libstdc__:
  	  library = library >= 0 ? 2 : library;
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/6/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
-From be8d850c6f68837487ba2f36bc52db3aef06ecdf Mon Sep 17 00:00:00 2001
+From 170b394977e6ae18a504573e299ac290a0c58441 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/18] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/19] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---
@@ -69,5 +69,5 @@ index 3d4137b7c7b91490e63c3e0620058bd6f65b47c9..8a1ffe877f0e7d0166781cb7b5cc2f1f
  
  	gettimeofday (&tv, NULL);
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/6/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
-From d59b2766ff564a8a166f2fc3bb7b14cab7214aa5 Mon Sep 17 00:00:00 2001
+From a008069e551d9658ebd5d166a1569f102dadea4a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/18] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/19] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().
@@ -37,5 +37,5 @@ index f189a4ff9cb6f7cc26141a7740cfcc5cfcf1ccc4..3598a24408784bf564f64aaa94ff81e3
    set_up_specs ();
    putenv_COLLECT_GCC (argv[0]);
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/6/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
-From 2b1f83c9cf01a117d441cce137df6fd554a53a26 Mon Sep 17 00:00:00 2001
+From 35669b2c7f84f356af24dfbab6040214e22497c0 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/18] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/19] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---
@@ -81,5 +81,5 @@ index 555c0fe2458fa3e0e96d769d3f36ae35db47e1bb..daee24052b68cea2159d68abd6cf6817
  {
    if (__gthread_active_p ())
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/6/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,604 +1,132 @@
-From 63c981b11f7e732611b268975ea896979385cf42 Mon Sep 17 00:00:00 2001
+From 8e344c7495f38559c4ab23692f86fc7a78ee551a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/18] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/19] Added libstc++ support for AmigaOS.
 
 ---
- libstdc++-v3/config/os/amigaos/ctype_base.h        |  59 +++++++
- .../config/os/amigaos/ctype_configure_char.cc      |  99 ++++++++++++
- libstdc++-v3/config/os/amigaos/ctype_inline.h      | 173 ++++++++++++++++++++
- libstdc++-v3/config/os/amigaos/error_constants.h   | 178 +++++++++++++++++++++
- libstdc++-v3/config/os/amigaos/os_defines.h        |  43 +++++
- libstdc++-v3/configure.host                        |   3 +
- 6 files changed, 555 insertions(+)
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_base.h
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_inline.h
- create mode 100644 libstdc++-v3/config/os/amigaos/error_constants.h
- create mode 100644 libstdc++-v3/config/os/amigaos/os_defines.h
+ .../config/os/{generic => amigaos}/ctype_base.h     |  2 +-
+ .../os/{generic => amigaos}/ctype_configure_char.cc |  2 +-
+ .../config/os/{generic => amigaos}/ctype_inline.h   |  2 +-
+ .../os/{generic => amigaos}/error_constants.h       |  2 +-
+ .../config/os/{vxworks => amigaos}/os_defines.h     | 13 +++++++------
+ libstdc++-v3/configure.host                         |  3 +++
+ 6 files changed, 14 insertions(+), 10 deletions(-)
+ copy libstdc++-v3/config/os/{generic => amigaos}/ctype_base.h (97%)
+ copy libstdc++-v3/config/os/{generic => amigaos}/ctype_configure_char.cc (97%)
+ copy libstdc++-v3/config/os/{generic => amigaos}/ctype_inline.h (98%)
+ copy libstdc++-v3/config/os/{generic => amigaos}/error_constants.h (98%)
+ copy libstdc++-v3/config/os/{vxworks => amigaos}/os_defines.h (86%)
 
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_base.h b/libstdc++-v3/config/os/amigaos/ctype_base.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..260b6142b6fc6a11a1e5f0bf7820b592d09f285e
---- /dev/null
+diff --git a/libstdc++-v3/config/os/generic/ctype_base.h b/libstdc++-v3/config/os/amigaos/ctype_base.h
+similarity index 97%
+copy from libstdc++-v3/config/os/generic/ctype_base.h
+copy to libstdc++-v3/config/os/amigaos/ctype_base.h
+index 9ac0d6be28dd9d7c58d7a6e803cd61222020979b..260b6142b6fc6a11a1e5f0bf7820b592d09f285e 100644
+--- a/libstdc++-v3/config/os/generic/ctype_base.h
 +++ b/libstdc++-v3/config/os/amigaos/ctype_base.h
-@@ -0,0 +1,59 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 1997-2016 Free Software Foundation, Inc.
 +// Copyright (C) 1997-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
-+
-+// Default information, may not be appropriate for specific host.
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  /// @brief  Base class for ctype.
-+  struct ctype_base
-+  {
-+    // Non-standard typedefs.
-+    typedef const int* 		__to_type;
-+
-+    // NB: Offsets into ctype<char>::_M_table force a particular size
-+    // on the mask type. Because of this, we don't use an enum.
-+    typedef unsigned int 	mask;
-+    static const mask upper    	= 1 << 0;
-+    static const mask lower 	= 1 << 1;
-+    static const mask alpha 	= 1 << 2;
-+    static const mask digit 	= 1 << 3;
-+    static const mask xdigit 	= 1 << 4;
-+    static const mask space 	= 1 << 5;
-+    static const mask print 	= 1 << 6;
-+    static const mask graph 	= (1 << 2) | (1 << 3) | (1 << 9); // alnum|punct
-+    static const mask cntrl 	= 1 << 8;
-+    static const mask punct 	= 1 << 9;
-+    static const mask alnum 	= (1 << 2) | (1 << 3);  // alpha|digit
-+    static const mask blank	= 1 << 10;
-+  };
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
-new file mode 100644
-index 0000000000000000000000000000000000000000..e6f4895aee78da54bc6b1e01df00816206361c41
---- /dev/null
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+diff --git a/libstdc++-v3/config/os/generic/ctype_configure_char.cc b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+similarity index 97%
+copy from libstdc++-v3/config/os/generic/ctype_configure_char.cc
+copy to libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+index af2012e53d9259444c97434323705aa811ba521e..e6f4895aee78da54bc6b1e01df00816206361c41 100644
+--- a/libstdc++-v3/config/os/generic/ctype_configure_char.cc
 +++ b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
-@@ -0,0 +1,99 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 2011-2016 Free Software Foundation, Inc.
 +// Copyright (C) 2011-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file ctype_configure_char.cc */
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
-+
-+#include <locale>
-+#include <cstdlib>
-+#include <cstring>
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+// Information as gleaned from /usr/include/ctype.h
-+
-+  const ctype_base::mask*
-+  ctype<char>::classic_table() throw()
-+  { return 0; }
-+
-+  ctype<char>::ctype(__c_locale, const mask* __table, bool __del, 
-+		     size_t __refs) 
-+  : facet(__refs), _M_del(__table != 0 && __del), 
-+  _M_toupper(NULL), _M_tolower(NULL), 
-+  _M_table(__table ? __table : classic_table()) 
-+  { 
-+    memset(_M_widen, 0, sizeof(_M_widen));
-+    _M_widen_ok = 0;
-+    memset(_M_narrow, 0, sizeof(_M_narrow));
-+    _M_narrow_ok = 0;
-+  }
-+
-+  ctype<char>::ctype(const mask* __table, bool __del, size_t __refs) 
-+  : facet(__refs), _M_del(__table != 0 && __del), 
-+  _M_toupper(NULL), _M_tolower(NULL), 
-+  _M_table(__table ? __table : classic_table())
-+  { 
-+    memset(_M_widen, 0, sizeof(_M_widen));
-+    _M_widen_ok = 0;
-+    memset(_M_narrow, 0, sizeof(_M_narrow));
-+    _M_narrow_ok = 0;
-+  }
-+
-+  char
-+  ctype<char>::do_toupper(char __c) const
-+  { return ::toupper((int) __c); }
-+
-+  const char*
-+  ctype<char>::do_toupper(char* __low, const char* __high) const
-+  {
-+    while (__low < __high)
-+      {
-+	*__low = ::toupper((int) *__low);
-+	++__low;
-+      }
-+    return __high;
-+  }
-+
-+  char
-+  ctype<char>::do_tolower(char __c) const
-+  { return ::tolower((int) __c); }
-+
-+  const char* 
-+  ctype<char>::do_tolower(char* __low, const char* __high) const
-+  {
-+    while (__low < __high)
-+      {
-+	*__low = ::tolower((int) *__low);
-+	++__low;
-+      }
-+    return __high;
-+  }
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_inline.h b/libstdc++-v3/config/os/amigaos/ctype_inline.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..cfa0146ae6b70623c2fe63b864ceef7bce0d5fe0
---- /dev/null
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+diff --git a/libstdc++-v3/config/os/generic/ctype_inline.h b/libstdc++-v3/config/os/amigaos/ctype_inline.h
+similarity index 98%
+copy from libstdc++-v3/config/os/generic/ctype_inline.h
+copy to libstdc++-v3/config/os/amigaos/ctype_inline.h
+index 3347d3324d2cd7de0e1badbf1855023762521d4c..cfa0146ae6b70623c2fe63b864ceef7bce0d5fe0 100644
+--- a/libstdc++-v3/config/os/generic/ctype_inline.h
 +++ b/libstdc++-v3/config/os/amigaos/ctype_inline.h
-@@ -0,0 +1,173 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 2000-2016 Free Software Foundation, Inc.
 +// Copyright (C) 2000-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/ctype_inline.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{locale}
-+ */
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
-+  
-+// ctype bits to be inlined go here. Non-inlinable (ie virtual do_*)
-+// functions go in ctype.cc
-+  
-+// The following definitions are portable, but insanely slow. If one
-+// cares at all about performance, then specialized ctype
-+// functionality should be added for the native os in question: see
-+// the config/os/bits/ctype_*.h files.
-+
-+// Constructing a synthetic "C" table should be seriously considered...
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  bool
-+  ctype<char>::
-+  is(mask __m, char __c) const
-+  { 
-+    if (_M_table)
-+      return _M_table[static_cast<unsigned char>(__c)] & __m;
-+    else
-+      {
-+	bool __ret = false;
-+	const size_t __bitmasksize = 15; 
-+	size_t __bitcur = 0; // Lowest bitmask in ctype_base == 0
-+	for (; __bitcur <= __bitmasksize; ++__bitcur)
-+	  {
-+	    const mask __bit = static_cast<mask>(1 << __bitcur);
-+	    if (__m & __bit)
-+	      {
-+		bool __testis;
-+		switch (__bit)
-+		  {
-+		  case space:
-+		    __testis = isspace(__c);
-+		    break;
-+		  case print:
-+		    __testis = isprint(__c);
-+		    break;
-+		  case cntrl:
-+		    __testis = iscntrl(__c);
-+		    break;
-+		  case upper:
-+		    __testis = isupper(__c);
-+		    break;
-+		  case lower:
-+		    __testis = islower(__c);
-+		    break;
-+		  case alpha:
-+		    __testis = isalpha(__c);
-+		    break;
-+		  case digit:
-+		    __testis = isdigit(__c);
-+		    break;
-+		  case punct:
-+		    __testis = ispunct(__c);
-+		    break;
-+		  case xdigit:
-+		    __testis = isxdigit(__c);
-+		    break;
-+		  case alnum:
-+		    __testis = isalnum(__c);
-+		    break;
-+		  case graph:
-+		    __testis = isgraph(__c);
-+		    break;
-+#ifdef _GLIBCXX_USE_C99_CTYPE_TR1
-+		  case blank:
-+		    __testis = isblank(__c);
-+		    break;
-+#endif
-+		  default:
-+		    __testis = false;
-+		    break;
-+		  }
-+		__ret |= __testis;
-+	      }
-+	  }
-+	return __ret;
-+      }
-+  }
-+   
-+  const char*
-+  ctype<char>::
-+  is(const char* __low, const char* __high, mask* __vec) const
-+  {
-+    if (_M_table)
-+      while (__low < __high)
-+	*__vec++ = _M_table[static_cast<unsigned char>(*__low++)];
-+    else
-+      {
-+	// Highest bitmask in ctype_base == 11.
-+	const size_t __bitmasksize = 15; 
-+	for (;__low < __high; ++__vec, ++__low)
-+	  {
-+	    mask __m = 0;
-+	    // Lowest bitmask in ctype_base == 0
-+	    size_t __i = 0; 
-+	    for (;__i <= __bitmasksize; ++__i)
-+	      {
-+		const mask __bit = static_cast<mask>(1 << __i);
-+		if (this->is(__bit, *__low))
-+		  __m |= __bit;
-+	      }
-+	    *__vec = __m;
-+	  }
-+      }
-+    return __high;
-+  }
-+
-+  const char*
-+  ctype<char>::
-+  scan_is(mask __m, const char* __low, const char* __high) const
-+  {
-+    if (_M_table)
-+      while (__low < __high
-+	     && !(_M_table[static_cast<unsigned char>(*__low)] & __m))
-+	++__low;
-+    else
-+      while (__low < __high && !this->is(__m, *__low))
-+	++__low;
-+    return __low;
-+  }
-+
-+  const char*
-+  ctype<char>::
-+  scan_not(mask __m, const char* __low, const char* __high) const
-+  {
-+    if (_M_table)
-+      while (__low < __high
-+	     && (_M_table[static_cast<unsigned char>(*__low)] & __m) != 0)
-+	++__low;
-+    else
-+      while (__low < __high && this->is(__m, *__low) != 0)
-+	++__low;
-+    return __low;
-+  }
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/error_constants.h b/libstdc++-v3/config/os/amigaos/error_constants.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..74492cf61c875eac28cb8a86d5bfdb3b8807aa16
---- /dev/null
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+diff --git a/libstdc++-v3/config/os/generic/error_constants.h b/libstdc++-v3/config/os/amigaos/error_constants.h
+similarity index 98%
+copy from libstdc++-v3/config/os/generic/error_constants.h
+copy to libstdc++-v3/config/os/amigaos/error_constants.h
+index f5bb12c3b1446d4fb176ed0e641640580f73c7a5..74492cf61c875eac28cb8a86d5bfdb3b8807aa16 100644
+--- a/libstdc++-v3/config/os/generic/error_constants.h
 +++ b/libstdc++-v3/config/os/amigaos/error_constants.h
-@@ -0,0 +1,178 @@
-+// Specific definitions for generic platforms  -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Specific definitions for generic platforms  -*- C++ -*-
+ 
+-// Copyright (C) 2007-2016 Free Software Foundation, Inc.
 +// Copyright (C) 2007-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/error_constants.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{system_error}
-+ */
-+
-+#ifndef _GLIBCXX_ERROR_CONSTANTS
-+#define _GLIBCXX_ERROR_CONSTANTS 1
-+
-+#include <bits/c++config.h>
-+#include <cerrno>
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  enum class errc
-+    {
-+      address_family_not_supported = 		EAFNOSUPPORT,
-+      address_in_use = 				EADDRINUSE,
-+      address_not_available = 			EADDRNOTAVAIL,
-+      already_connected = 			EISCONN,
-+      argument_list_too_long = 			E2BIG,
-+      argument_out_of_domain = 			EDOM,
-+      bad_address = 				EFAULT,
-+      bad_file_descriptor = 			EBADF,
-+
-+#ifdef _GLIBCXX_HAVE_EBADMSG
-+      bad_message = 				EBADMSG,
-+#endif
-+
-+      broken_pipe = 				EPIPE,
-+      connection_aborted = 			ECONNABORTED,
-+      connection_already_in_progress = 		EALREADY,
-+      connection_refused = 			ECONNREFUSED,
-+      connection_reset = 			ECONNRESET,
-+      cross_device_link = 			EXDEV,
-+      destination_address_required = 		EDESTADDRREQ,
-+      device_or_resource_busy = 		EBUSY,
-+      directory_not_empty = 			ENOTEMPTY,
-+      executable_format_error = 		ENOEXEC,
-+      file_exists = 	       			EEXIST,
-+      file_too_large = 				EFBIG,
-+      filename_too_long = 			ENAMETOOLONG,
-+      function_not_supported = 			ENOSYS,
-+      host_unreachable = 			EHOSTUNREACH,
-+
-+#ifdef _GLIBCXX_HAVE_EIDRM
-+      identifier_removed = 			EIDRM,
-+#endif
-+
-+      illegal_byte_sequence = 			EILSEQ,
-+      inappropriate_io_control_operation = 	ENOTTY,
-+      interrupted = 				EINTR,
-+      invalid_argument = 			EINVAL,
-+      invalid_seek = 				ESPIPE,
-+      io_error = 				EIO,
-+      is_a_directory = 				EISDIR,
-+      message_size = 				EMSGSIZE,
-+      network_down = 				ENETDOWN,
-+      network_reset = 				ENETRESET,
-+      network_unreachable = 			ENETUNREACH,
-+      no_buffer_space = 			ENOBUFS,
-+      no_child_process = 			ECHILD,
-+
-+#ifdef _GLIBCXX_HAVE_ENOLINK
-+      no_link = 				ENOLINK,
-+#endif
-+
-+      no_lock_available = 			ENOLCK,
-+
-+#ifdef _GLIBCXX_HAVE_ENODATA
-+      no_message_available = 			ENODATA, 
-+#endif
-+
-+      no_message = 				ENOMSG, 
-+      no_protocol_option = 			ENOPROTOOPT,
-+      no_space_on_device = 			ENOSPC,
-+
-+#ifdef _GLIBCXX_HAVE_ENOSR
-+      no_stream_resources = 			ENOSR,
-+#endif
-+
-+      no_such_device_or_address = 		ENXIO,
-+      no_such_device = 				ENODEV,
-+      no_such_file_or_directory = 		ENOENT,
-+      no_such_process = 			ESRCH,
-+      not_a_directory = 			ENOTDIR,
-+      not_a_socket = 				ENOTSOCK,
-+
-+#ifdef _GLIBCXX_HAVE_ENOSTR
-+      not_a_stream = 				ENOSTR,
-+#endif
-+
-+      not_connected = 				ENOTCONN,
-+      not_enough_memory = 			ENOMEM,
-+
-+#ifdef _GLIBCXX_HAVE_ENOTSUP
-+      not_supported = 				ENOTSUP,
-+#endif
-+
-+#ifdef _GLIBCXX_HAVE_ECANCELED
-+      operation_canceled = 			ECANCELED,
-+#endif
-+
-+      operation_in_progress = 			EINPROGRESS,
-+      operation_not_permitted = 		EPERM,
-+      operation_not_supported = 		EOPNOTSUPP,
-+      operation_would_block = 			EWOULDBLOCK,
-+
-+#ifdef _GLIBCXX_HAVE_EOWNERDEAD
-+      owner_dead = 				EOWNERDEAD,
-+#endif
-+
-+      permission_denied = 			EACCES,
-+
-+#ifdef _GLIBCXX_HAVE_EPROTO
-+      protocol_error = 				EPROTO,
-+#endif
-+
-+      protocol_not_supported = 			EPROTONOSUPPORT,
-+      read_only_file_system = 			EROFS,
-+      resource_deadlock_would_occur = 		EDEADLK,
-+      resource_unavailable_try_again = 		EAGAIN,
-+      result_out_of_range = 			ERANGE,
-+
-+#ifdef _GLIBCXX_HAVE_ENOTRECOVERABLE
-+      state_not_recoverable = 			ENOTRECOVERABLE,
-+#endif
-+
-+#ifdef _GLIBCXX_HAVE_ETIME
-+      stream_timeout = 				ETIME,
-+#endif
-+
-+#ifdef _GLIBCXX_HAVE_ETXTBSY
-+      text_file_busy = 				ETXTBSY,
-+#endif
-+
-+      timed_out = 				ETIMEDOUT,
-+      too_many_files_open_in_system = 		ENFILE,
-+      too_many_files_open = 			EMFILE,
-+      too_many_links = 				EMLINK,
-+      too_many_symbolic_link_levels = 		ELOOP,
-+
-+#ifdef _GLIBCXX_HAVE_EOVERFLOW
-+      value_too_large = 			EOVERFLOW,
-+#endif
-+
-+      wrong_protocol_type = 			EPROTOTYPE
-+    };
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-+
-+#endif
-diff --git a/libstdc++-v3/config/os/amigaos/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..346f063958cd7e80ebf97be4acee0bdf391cb811
---- /dev/null
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+diff --git a/libstdc++-v3/config/os/vxworks/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
+similarity index 86%
+copy from libstdc++-v3/config/os/vxworks/os_defines.h
+copy to libstdc++-v3/config/os/amigaos/os_defines.h
+index 6bbce600cdabe71edad98bf90931c669f058c69a..346f063958cd7e80ebf97be4acee0bdf391cb811 100644
+--- a/libstdc++-v3/config/os/vxworks/os_defines.h
 +++ b/libstdc++-v3/config/os/amigaos/os_defines.h
-@@ -0,0 +1,43 @@
+@@ -1,9 +1,9 @@
+-// Specific definitions for VxWorks  -*- C++ -*-
 +// Specific definitions for AmigaOS -*- C++ -*-
-+
+ 
+-// Copyright (C) 2000-2016 Free Software Foundation, Inc.
 +// Copyright (C) 2000-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/os_defines.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{iosfwd}
-+ */
-+
-+#ifndef _GLIBCXX_OS_DEFINES
-+#define _GLIBCXX_OS_DEFINES 1
-+
-+// System-specific #define, typedefs, corrections, etc, go here.  This
-+// file will come before all others.
-+
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -30,13 +30,14 @@
+ #ifndef _GLIBCXX_OS_DEFINES
+ #define _GLIBCXX_OS_DEFINES 1
+ 
+ // System-specific #define, typedefs, corrections, etc, go here.  This
+ // file will come before all others.
+ 
+-//Keep vxWorks from defining min()/max() as macros
+-#ifdef NOMINMAX
+-#undef NOMINMAX
 +// No ioctl() on AmigaOS
 +#define _GLIBCXX_NO_IOCTL 1
 +
 +#ifdef __NEWLIB__
 +#define _GLIBCXX_USE_C99_STDINT_TR1 1
-+#endif
-+
-+#endif
+ #endif
+-#define NOMINMAX 1
+ 
+ #endif
 diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
 index 304a7f5aff61d13ea4aba80e5b8261c192307579..72438701acdd434a0cb15c278f0dcd46756844e9 100644
 --- a/libstdc++-v3/configure.host
@@ -620,5 +148,5 @@ index 304a7f5aff61d13ea4aba80e5b8261c192307579..72438701acdd434a0cb15c278f0dcd46
    cygwin*)
      os_include_dir="os/newlib"
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0009-Added-e500-support-for-AmigaOS.patch
+++ b/gcc/6/patches/0009-Added-e500-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 7ae9d40a00696477395b1a5b16617f6b2299b21b Mon Sep 17 00:00:00 2001
+From 3fbaae9e66b5a962272be8f453b2e128e67a1a28 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Mon, 30 Jan 2017 20:49:17 +0100
-Subject: [PATCH 09/18] Added e500 support for AmigaOS.
+Subject: [PATCH 09/19] Added e500 support for AmigaOS.
 
 ---
  gcc/config.gcc | 2 +-
@@ -27,5 +27,5 @@ index 568f207eed3c16d4b772b47a7d7273de801977e1..ec2f3ce8eae0f4b16f27e954c1575dc8
  	use_collect2=no
  	;;
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0010-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/6/patches/0010-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,154 +1,100 @@
-From c73d91445fcaa22ccb4ac7e589f62f844dba59c7 Mon Sep 17 00:00:00 2001
+From 9b444e7541cbc72562cee7a8e1795a250d10d613 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 10/18] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 10/19] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---
- libatomic/config/amigaos/host-config.h |  55 ++++++++++++++++++
- libatomic/config/amigaos/lock.c        | 102 +++++++++++++++++++++++++++++++++
- libatomic/configure.tgt                |   4 ++
- 3 files changed, 161 insertions(+)
- create mode 100644 libatomic/config/amigaos/host-config.h
- create mode 100644 libatomic/config/amigaos/lock.c
+ .../config/{posix => amigaos}/host-config.h   |  2 +-
+ libatomic/config/{posix => amigaos}/lock.c    | 64 ++++++++-----------
+ libatomic/configure.tgt                       |  4 ++
+ 3 files changed, 30 insertions(+), 40 deletions(-)
+ copy libatomic/config/{posix => amigaos}/host-config.h (96%)
+ copy libatomic/config/{posix => amigaos}/lock.c (68%)
 
-diff --git a/libatomic/config/amigaos/host-config.h b/libatomic/config/amigaos/host-config.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..879758e4eb5594a79b8ee2d25564b19a6f51cd31
---- /dev/null
+diff --git a/libatomic/config/posix/host-config.h b/libatomic/config/amigaos/host-config.h
+similarity index 96%
+copy from libatomic/config/posix/host-config.h
+copy to libatomic/config/amigaos/host-config.h
+index 00bdde96d5494c9b071fd44880f4197a6e489206..879758e4eb5594a79b8ee2d25564b19a6f51cd31 100644
+--- a/libatomic/config/posix/host-config.h
 +++ b/libatomic/config/amigaos/host-config.h
-@@ -0,0 +1,55 @@
+@@ -1,7 +1,7 @@
+-/* Copyright (C) 2012-2016 Free Software Foundation, Inc.
 +/* Copyright (C) 2012-2015 Free Software Foundation, Inc.
-+   Contributed by Richard Henderson <rth@redhat.com>.
-+
-+   This file is part of the GNU Atomic Library (libatomic).
-+
-+   Libatomic is free software; you can redistribute it and/or modify it
-+   under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   Libatomic is distributed in the hope that it will be useful, but WITHOUT ANY
-+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-+   FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+   more details.
-+
-+   Under Section 7 of GPL version 3, you are granted additional
-+   permissions described in the GCC Runtime Library Exception, version
-+   3.1, as published by the Free Software Foundation.
-+
-+   You should have received a copy of the GNU General Public License and
-+   a copy of the GCC Runtime Library Exception along with this program;
-+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+/* Included after all more target-specific host-config.h.  */
-+
-+
-+#ifndef protect_start_end
-+# ifdef HAVE_ATTRIBUTE_VISIBILITY
-+#  pragma GCC visibility push(hidden)
-+# endif
-+
-+void libat_lock_1 (void *ptr);
-+void libat_unlock_1 (void *ptr);
-+
-+static inline UWORD
-+protect_start (void *ptr)
-+{
-+  libat_lock_1 (ptr);
-+  return 0;
-+}
-+
-+static inline void
-+protect_end (void *ptr, UWORD dummy UNUSED)
-+{
-+  libat_unlock_1 (ptr);
-+}
-+
-+# define protect_start_end 1
-+# ifdef HAVE_ATTRIBUTE_VISIBILITY
-+#  pragma GCC visibility pop
-+# endif
-+#endif /* protect_start_end */
-+
-+#include_next <host-config.h>
-diff --git a/libatomic/config/amigaos/lock.c b/libatomic/config/amigaos/lock.c
-new file mode 100644
-index 0000000000000000000000000000000000000000..ffd09f50095429f844bfe6bf7bec8741f56f1a28
---- /dev/null
+    Contributed by Richard Henderson <rth@redhat.com>.
+ 
+    This file is part of the GNU Atomic Library (libatomic).
+ 
+    Libatomic is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+diff --git a/libatomic/config/posix/lock.c b/libatomic/config/amigaos/lock.c
+similarity index 68%
+copy from libatomic/config/posix/lock.c
+copy to libatomic/config/amigaos/lock.c
+index 854d1a6f475b0807a923c9496f656b6f922e77df..ffd09f50095429f844bfe6bf7bec8741f56f1a28 100644
+--- a/libatomic/config/posix/lock.c
 +++ b/libatomic/config/amigaos/lock.c
-@@ -0,0 +1,102 @@
+@@ -1,7 +1,7 @@
+-/* Copyright (C) 2012-2016 Free Software Foundation, Inc.
 +/* Copyright (C) 2012-2015 Free Software Foundation, Inc.
-+   Contributed by Richard Henderson <rth@redhat.com>.
-+
-+   This file is part of the GNU Atomic Library (libatomic).
-+
-+   Libatomic is free software; you can redistribute it and/or modify it
-+   under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   Libatomic is distributed in the hope that it will be useful, but WITHOUT ANY
-+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-+   FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+   more details.
-+
-+   Under Section 7 of GPL version 3, you are granted additional
-+   permissions described in the GCC Runtime Library Exception, version
-+   3.1, as published by the Free Software Foundation.
-+
-+   You should have received a copy of the GNU General Public License and
-+   a copy of the GCC Runtime Library Exception along with this program;
-+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+#include "libatomic_i.h"
-+
+    Contributed by Richard Henderson <rth@redhat.com>.
+ 
+    This file is part of the GNU Atomic Library (libatomic).
+ 
+    Libatomic is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+@@ -20,14 +20,15 @@
+    You should have received a copy of the GNU General Public License and
+    a copy of the GCC Runtime Library Exception along with this program;
+    see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+    <http://www.gnu.org/licenses/>.  */
+ 
+ #include "libatomic_i.h"
+-#include <pthread.h>
+ 
 +#define UWORD UWORD_
 +#include <proto/exec.h>
-+
-+/* The target page size.  Must be no larger than the runtime page size,
-+   lest locking fail with virtual address aliasing (i.e. a page mmaped
-+   at two locations).  */
-+#ifndef PAGE_SIZE
-+#define PAGE_SIZE	4096
-+#endif
-+
-+/* The target cacheline size.  This is an optimization; the padding that
-+   should be applied to the locks to keep them from interfering.  */
-+#ifndef CACHLINE_SIZE
-+#define CACHLINE_SIZE	64
-+#endif
-+
-+/* The granularity at which locks are applied.  Almost certainly the
-+   cachline size is the right thing to use here.  */
-+#ifndef WATCH_SIZE
-+#define WATCH_SIZE	CACHLINE_SIZE
-+#endif
-+
-+struct lock
-+{
+ 
+ /* The target page size.  Must be no larger than the runtime page size,
+    lest locking fail with virtual address aliasing (i.e. a page mmaped
+    at two locations).  */
+ #ifndef PAGE_SIZE
+ #define PAGE_SIZE	4096
+@@ -44,73 +45,58 @@
+ #ifndef WATCH_SIZE
+ #define WATCH_SIZE	CACHLINE_SIZE
+ #endif
+ 
+ struct lock
+ {
+-  pthread_mutex_t mutex;
+-  char pad[sizeof(pthread_mutex_t) < CACHLINE_SIZE
+-	   ? CACHLINE_SIZE - sizeof(pthread_mutex_t)
 +  struct SignalSemaphore sem;
 +  char initialized;
 +  char pad[sizeof(struct SignalSemaphore) + 1 < CACHLINE_SIZE
 +	   ? CACHLINE_SIZE - sizeof(struct SignalSemaphore) - 1
-+	   : 0];
-+};
-+
+ 	   : 0];
+ };
+ 
 +/* TODO: Use a constructor to initialize the semaphore */
-+#define NLOCKS		(PAGE_SIZE / WATCH_SIZE)
+ #define NLOCKS		(PAGE_SIZE / WATCH_SIZE)
+-static struct lock locks[NLOCKS] = {
+-  [0 ... NLOCKS-1].mutex = PTHREAD_MUTEX_INITIALIZER
+-};
 +static struct lock locks[NLOCKS];
-+
-+static inline uintptr_t 
-+addr_hash (void *ptr)
-+{
-+  return ((uintptr_t)ptr / WATCH_SIZE) % NLOCKS;
-+}
-+
-+void
-+libat_lock_1 (void *ptr)
-+{
+ 
+ static inline uintptr_t 
+ addr_hash (void *ptr)
+ {
+   return ((uintptr_t)ptr / WATCH_SIZE) % NLOCKS;
+ }
+ 
+ void
+ libat_lock_1 (void *ptr)
+ {
+-  pthread_mutex_lock (&locks[addr_hash (ptr)].mutex);
 +  struct lock *l = &locks[addr_hash (ptr)];
 +  IExec->Forbid();
 +  if (!l->initialized)
@@ -158,27 +104,57 @@ index 0000000000000000000000000000000000000000..ffd09f50095429f844bfe6bf7bec8741
 +  }
 +  IExec->Permit();
 +  IExec->ObtainSemaphore(&l->sem);
-+}
-+
-+void
-+libat_unlock_1 (void *ptr)
-+{
+ }
+ 
+ void
+ libat_unlock_1 (void *ptr)
+ {
+-  pthread_mutex_unlock (&locks[addr_hash (ptr)].mutex);
 +  struct lock *l = &locks[addr_hash (ptr)];
 +  IExec->ReleaseSemaphore(&l->sem);
-+}
-+
+ }
+ 
 +#if 0
 +
 +/* TODO: Implement me when needed */
-+void
-+libat_lock_n (void *ptr, size_t n)
-+{
-+}
-+
-+void
-+libat_unlock_n (void *ptr, size_t n)
-+{
-+}
+ void
+ libat_lock_n (void *ptr, size_t n)
+ {
+-  uintptr_t h = addr_hash (ptr);
+-  size_t i = 0;
+-
+-  /* Don't lock more than all the locks we have.  */
+-  if (n > PAGE_SIZE)
+-    n = PAGE_SIZE;
+-
+-  do
+-    {
+-      pthread_mutex_lock (&locks[h].mutex);
+-      if (++h == NLOCKS)
+-	h = 0;
+-      i += WATCH_SIZE;
+-    }
+-  while (i < n);
+ }
+ 
+ void
+ libat_unlock_n (void *ptr, size_t n)
+ {
+-  uintptr_t h = addr_hash (ptr);
+-  size_t i = 0;
+-
+-  if (n > PAGE_SIZE)
+-    n = PAGE_SIZE;
+-
+-  do
+-    {
+-      pthread_mutex_unlock (&locks[h].mutex);
+-      if (++h == NLOCKS)
+-	h = 0;
+-      i += WATCH_SIZE;
+-    }
+-  while (i < n);
+ }
 +
 +#endif
 diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
@@ -203,5 +179,5 @@ index eab2765d7fd2c4a66cece52bb7e005e93029e3ce..ced7a361bafa9e9916e68fcb3710875e
  	# If the target supports disabling interrupts, we can work in
  	# kernel-mode, given the system is not multi-processor.
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/6/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
-From 75c9beff00537616fc193e27bf7088bd9f1eb39d Mon Sep 17 00:00:00 2001
+From 03161dccf14e031ceb5c62241bb62ce232c6e94c Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/18] Pretend C99 compatibility.
+Subject: [PATCH 11/19] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses
@@ -107,5 +107,5 @@ index 1ba5fb7f03ad509d7663ad610c250a72789b02a3..66862e087ee9abee00a6bb06cad058e4
  } // extern "C++"
  
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/6/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
-From 2622f6d00602998782e488604056fb5c568aa61b Mon Sep 17 00:00:00 2001
+From 0cce69f2c07f7cb47daeeaddc02ca2de2afddc25 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/18] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/19] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-
@@ -47,5 +47,5 @@ index 23e94752d3dd84da609e3f5dd9caf8c5008a1d57..7d5248b96c92ee5c66410172ab93488e
  GCC is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/6/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
-From b11f3497a12ae8bd6ad82a9dd9609cd2c070e94c Mon Sep 17 00:00:00 2001
+From a9933b944a4d65e33075614bb35a00ad5328a435 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/18] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/19] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------
@@ -161,5 +161,5 @@ index 7151e59e38eb126f3962cd2370aef45c6be042ea..bc954c353775b59b904dd5a9d8648083
  	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/xmalloc.c -o noasan/$@; \
  	else true; fi
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/6/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
-From b16ee4dd7a186d101fa0592380427ac6a0069350 Mon Sep 17 00:00:00 2001
+From 50341f21238fed7b02599edbcecc0b2b62a20a1a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/18] Add custom implementation of various env-related
+Subject: [PATCH 14/19] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.
@@ -9,10 +9,10 @@ While there are custom implementation of setenv() and unsetenv(), it is
 unclear how their implementation interacts with the other ones that are
 part of the clib like putenv().
 ---
- libiberty/Makefile.in      | 13 ++++++--
- libiberty/configure        | 11 +++++++
+ libiberty/Makefile.in      | 13 +++++--
+ libiberty/configure        | 11 ++++++
  libiberty/configure.ac     |  6 ++++
- libiberty/setenv-amigaos.c | 74 ++++++++++++++++++++++++++++++++++++++++++++++
+ libiberty/setenv-amigaos.c | 74 ++++++++++++++++++++++++++++++++++++++
  4 files changed, 102 insertions(+), 2 deletions(-)
  create mode 100644 libiberty/setenv-amigaos.c
 
@@ -125,7 +125,7 @@ index 4b921054786e0260add9796888b7ffb79f2f5bab..4ae698331038d287abe132b63c0cbeca
      ;;
 diff --git a/libiberty/setenv-amigaos.c b/libiberty/setenv-amigaos.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..dc9a460737538d74558bb43c21c21e61aa5a3305
+index 0000000000000000000000000000000000000000..089d3cbcc6eb7d42d96e8dfb16d1b399cfe856b3
 --- /dev/null
 +++ b/libiberty/setenv-amigaos.c
 @@ -0,0 +1,74 @@
@@ -204,5 +204,5 @@ index 0000000000000000000000000000000000000000..dc9a460737538d74558bb43c21c21e61
 +	return lvar->lv_Value;
 +}
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/6/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
-From 0276442cfc7ed0ebb7800f4f99281a1b62421321 Mon Sep 17 00:00:00 2001
+From 60f42e29046983ae4ffbc9a759e2a871d013dc92 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/18] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/19] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.
@@ -41,5 +41,5 @@ index 65251522ad46df427b043031bedba5b3fdd81543..fd586e16a025870494e68ab3af210b63
     have no conflict with that.  */
  #ifndef _VA_LIST_
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/6/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
-From 84be05f2f4157d19dea6807cd64a778a81cfa800 Mon Sep 17 00:00:00 2001
+From db84bd50e70189be71612ff6baf32371703ce129 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/18] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/19] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---
@@ -28,5 +28,5 @@ index 16c96acdb619e5de889b2fe42f95ec54784f2c6b..84b37268b6bae8529230a22de5bd9024
        emit_move_insn (reg, mem);
  
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/6/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
-From c3ba0f13965006149b244b33067cee8fdb88ed2e Mon Sep 17 00:00:00 2001
+From 3208b1057c63dfebd82fdbe25784742c92888491 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/18] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/19] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +
@@ -77,5 +77,5 @@ index 0d06f2dd48c7d97bbd192b26d530b18bc3029665..547b57d03708bb38904bfdf6fd92f7a0
  
  #undef INIT_CUMULATIVE_INCOMING_ARGS
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/6/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
-From f24414cbb3acf07eaf6328ea3a15b90c03beeb56 Mon Sep 17 00:00:00 2001
+From a8c9e108ae1743f3451691f0506db40a1e5a1360 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/18] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/19] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---
@@ -29,5 +29,5 @@ index 547b57d03708bb38904bfdf6fd92f7a055027564..e8303292ee8cc06a410fb4acc0390f13
  #define LINK_SPEC "\
  --defsym __amigaos4__=1 \
 -- 
-2.14.2
+2.34.1
 

--- a/gcc/6/patches/0019-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/6/patches/0019-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,0 +1,269 @@
+From 74d90b4683ab3248fe2f3ee1154fe552a6d4f4a8 Mon Sep 17 00:00:00 2001
+From: rjd <3246251196ryan@gmail.com>
+Date: Fri, 12 Jan 2024 00:15:23 +0000
+Subject: [PATCH 19/19] Provide clib4 as an additional C runtime library.
+
+As well as the existing newlib and clib2 as C runtime library choices,
+clib4 is now introduced.
+---
+ gcc/config/rs6000/amigaos.h           | 43 ++++++++++++++++++++-------
+ gcc/config/rs6000/t-amigaos           |  4 +--
+ libstdc++-v3/configure                | 15 ++++++++++
+ libstdc++-v3/crossconfig.m4           | 12 ++++++++
+ libstdc++-v3/include/c_global/cstdlib |  4 +--
+ 5 files changed, 64 insertions(+), 14 deletions(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index e8303292ee8cc06a410fb4acc0390f13c96444c9..51ac3583c76b8c0edcd8a2ab606fa0066adcc080 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -111,12 +111,17 @@
+       else if (IS_MCRT("clib2") || IS_MCRT("clib2-ts")) \
+         {					\
+           builtin_define_std ("CLIB2");		\
+           if (IS_MCRT("clib2-ts"))		\
+             builtin_define ("__THREAD_SAFE");	\
+         }					\
++      else if (IS_MCRT("clib4"))		\
++        {					\
++          builtin_define_std ("CLIB4");		\
++          builtin_define ("CLIB4");		\
++        }					\
+       else if (IS_MCRT("ixemul"))		\
+         {					\
+           builtin_define_std ("ixemul");	\
+           builtin_define_std ("IXEMUL");	\
+         }					\
+       else if (IS_MCRT("libnix"))		\
+@@ -155,28 +160,18 @@
+ #undef REAL_LIBGCC_SPEC
+ #define REAL_LIBGCC_SPEC "\
+ %{static|static-libgcc: %{!use-dynld: -lgcc -lgcc_eh} %{use-dynld: -lgcc} }%{!static:%{!static-libgcc:%{!shared:%{!shared-libgcc: %{!use-dynld: -lgcc -lgcc_eh} %{use-dynld: -lgcc}}%{shared-libgcc:-lgcc}}%{shared:%{shared-libgcc:-lgcc}%{!shared-libgcc:-lgcc}}}}"
+ 
+ 
+ /* make newlib the default */
+-#if 1
+ #define CPP_AMIGA_DEFAULT_SPEC "%{mcrt=default|!mcrt=*:%<mcrt=default -mcrt=newlib} %(cpp_newlib)"
+ #define LINK_AMIGA_DEFAULT_SPEC "%(link_newlib)"
+ #define STARTFILE_AMIGA_DEFAULT_SPEC "%(startfile_newlib)"
+ #define ENDFILE_AMIGA_DEFAULT_SPEC "%(endfile_newlib)"
+ #undef MULTILIB_DEFAULTS
+ #define MULTILIB_DEFAULTS {"mcrt=newlib"}
+-#else
+-/* make clib2 the default */
+-#define CPP_AMIGA_DEFAULT_SPEC "%{mcrt=default|!mcrt=*:%<mcrt=default -mcrt=clib2} %(cpp_clib2)"
+-#define LINK_AMIGA_DEFAULT_SPEC "%(link_clib2)"
+-#define STARTFILE_AMIGA_DEFAULT_SPEC "%(startfile_clib2)"
+-#define ENDFILE_AMIGA_DEFAULT_SPEC "%(endfile_clib2)"
+-#undef MULTILIB_DEFAULTS
+-#define MULTILIB_DEFAULTS {"mcrt=clib2"}
+-#endif
+ 
+ 
+ /* For specifying the include system paths, we generally use -idirafter so the include
+  * paths are added at the end of the gcc default include paths. This is required for
+  * fixincludes and libstdc++ to work properly
+  */
+@@ -201,12 +196,30 @@
+                  "%{!msoft-float:%(lib_subdir_type)}/crt0.o"
+ 
+ #define ENDFILE_CLIB2_SPEC "\
+ %(base_sdk)clib2/%{mcrt=clib2-ts:lib.threadsafe; :lib}" \
+                  "%{!msoft-float:%(lib_subdir_type)}/crtend.o"
+ 
++/* clib4 */
++
++#define CPP_CLIB4_SPEC "\
++-idirafter %(base_sdk)clib4/include -idirafter %(base_sdk)local/clib4/include"
++
++#define LIB_SUBDIR_CLIB4_SPEC "lib%(lib_subdir_type)"
++
++#define LINK_CLIB4_SPEC "\
++-L%(base_sdk)clib4/%(lib_subdir_clib4) \
++-L%(base_gcc)lib/gcc/ppc-amigaos/%(version)/clib4/lib%(lib_subdir_type) \
++-L%(base_sdk)local/clib4/%(lib_subdir_clib4)"
++
++#define STARTFILE_CLIB4_SPEC "\
++%{shared: %(base_sdk)clib4/%(lib_subdir_clib4)/shcrtbegin.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crtbegin.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crt0.o}"
++
++#define ENDFILE_CLIB4_SPEC "\
++%{shared: %(base_sdk)clib4/%(lib_subdir_clib4)/shcrtend.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crtend.o}"
++
+ /* ixemul */
+ 
+ #define CPP_IXEMUL_SPEC "\
+ -idirafter %(base_sdk)ixemul/include -idirafter %(base_sdk)local/ixemul/include"
+ 
+ #define LIB_SUBDIR_IXEMUL_SPEC "lib%(lib_subdir_type)"
+@@ -256,12 +269,13 @@
+ 
+ /* End clib specific */
+ 
+ #undef CPP_OS_DEFAULT_SPEC
+ #define CPP_OS_DEFAULT_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(cpp_clib2); \
++mcrt=clib4: %(cpp_clib4); \
+ mcrt=ixemul: %(cpp_ixemul); \
+ mcrt=libnix: %(cpp_libnix); \
+ mcrt=newlib: %(cpp_newlib); \
+ mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
+ : %eInvalid C runtime library} \
+ %{!nostdinc: -idirafter %(base_sdk)include/include_h -idirafter %(base_sdk)include/netinclude -idirafter %(base_sdk)local/common/include} \
+@@ -275,12 +289,13 @@ mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
+ -q -d %{h*} %{v:-V} %{G*} \
+ %{Wl,*:%*} %{YP,*} %{R*} \
+ %{Qy:} %{!Qn:-Qy} \
+ %(link_shlib) %(link_text) \
+ %{mbaserel: %{msdata|msdata=default|msdata=sysv: %e-mbaserel and -msdata options are incompatible}} \
+ %{mcrt=clib2|mcrt=clib2-ts: %(link_clib2); \
++mcrt=clib4: %(link_clib4); \
+ mcrt=ixemul: %(link_ixemul); \
+ mcrt=libnix: %(link_libnix); \
+ mcrt=newlib: %(link_newlib); \
+ mcrt=default|!mcrt=*: %(link_amiga_default); \
+ : %eInvalid C runtime library} \
+ -L%(base_sdk)local/common/lib%(lib_subdir_type) \
+@@ -297,21 +312,23 @@ mcrt=default|!mcrt=*: %(link_amiga_default); \
+ #define LINK_SHLIB "\
+ %{shared:-shared -dy --defsym __dynld_version__=1} %{!shared: %{static:-static}} %{use-dynld: -dy}"
+ 
+ #undef STARTFILE_SPEC
+ #define STARTFILE_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(startfile_clib2); \
++mcrt=clib4: %(startfile_clib4); \
+ mcrt=ixemul: %(startfile_ixemul); \
+ mcrt=libnix: %(startfile_libnix); \
+ mcrt=newlib: %(startfile_newlib); \
+ mcrt=default|!mcrt=*: %(startfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+ #undef ENDFILE_SPEC
+ #define ENDFILE_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(endfile_clib2); \
++mcrt=clib4: %(endfile_clib4); \
+ mcrt=ixemul: %(endfile_ixemul); \
+ mcrt=libnix: %(endfile_libnix); \
+ mcrt=newlib: %(endfile_newlib); \
+ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+@@ -336,12 +353,18 @@ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+   /* clib2 */ \
+   {"cpp_clib2", CPP_CLIB2_SPEC}, \
+   {"lib_subdir_clib2", LIB_SUBDIR_CLIB2_SPEC}, \
+   {"link_clib2", LINK_CLIB2_SPEC}, \
+   {"startfile_clib2", STARTFILE_CLIB2_SPEC}, \
+   {"endfile_clib2", ENDFILE_CLIB2_SPEC}, \
++  /* clib4 */ \
++  {"cpp_clib4", CPP_CLIB4_SPEC}, \
++  {"lib_subdir_clib4", LIB_SUBDIR_CLIB4_SPEC}, \
++  {"link_clib4", LINK_CLIB4_SPEC}, \
++  {"startfile_clib4", STARTFILE_CLIB4_SPEC}, \
++  {"endfile_clib4", ENDFILE_CLIB4_SPEC}, \
+   /* ixemul */ \
+   {"cpp_ixemul", CPP_IXEMUL_SPEC}, \
+   {"lib_subdir_ixemul", LIB_SUBDIR_IXEMUL_SPEC}, \
+   {"link_ixemul", LINK_IXEMUL_SPEC}, \
+   {"startfile_ixemul", STARTFILE_IXEMUL_SPEC}, \
+   {"endfile_ixemul", ENDFILE_IXEMUL_SPEC}, \
+diff --git a/gcc/config/rs6000/t-amigaos b/gcc/config/rs6000/t-amigaos
+index 15d9d3fd5a5f0c8109cd158242745fa52b19257e..0d8049f400ca7f0937330ffec4f01546d9d61cc2 100644
+--- a/gcc/config/rs6000/t-amigaos
++++ b/gcc/config/rs6000/t-amigaos
+@@ -12,9 +12,9 @@ LIMITS_H_TEST = true
+ NATIVE_SYSTEM_HEADER_DIR=/gcc/include
+ #OTHER_FIXINCLUDES_DIRS=${gcc_tooldir}/include
+ 
+ # Build the libraries for both newlib and clib2
+ # We do not build soft float flavours as none of the
+ # libs support soft floats
+-MULTILIB_OPTIONS = mcrt=newlib/mcrt=clib2
+-MULTILIB_DIRNAMES = newlib clib2
++MULTILIB_OPTIONS = mcrt=newlib/mcrt=clib2/mcrt=clib4
++MULTILIB_DIRNAMES = newlib clib2 clib4
+ #MULTILIB_REUSE = =mcrt=newlib
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 1aec69f6af1aa823b38945effc886b4c33cb917c..0d57356933cb71f4c2debf6790b607b5cd3b5296 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -78415,12 +78415,27 @@ $as_echo "$ac_ld_relro" >&6; }
+     OPT_LDFLAGS="-Wl,-O1 $OPT_LDFLAGS"
+   fi
+ 
+ 
+ 
+ 
++
++
++    for ac_func in acosf asinf atan2f atanf ceilf cosf coshf expf fabsf floorf fmodf frexpf sqrtf hypotf ldexpf log10f logf modff powf sinf sinhf tanf tanhf fabsl acosl asinl atanl atan2l ceill cosl coshl expl floorl fmodl frexpl sqrtl hypotl ldexpl logl log10l modfl powl sinl sinhl tanl tanhl
++do :
++  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
++ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
++if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
++  cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
++_ACEOF
++
++fi
++done
++
++
+     ;;
+   *)
+     as_fn_error "No support for this host/target combination." "$LINENO" 5
+    ;;
+ esac
+ 
+diff --git a/libstdc++-v3/crossconfig.m4 b/libstdc++-v3/crossconfig.m4
+index bcb83c81017bfb5496431f8b7f60018cfee93df9..12ee02548bcd4138ca3e6a3e1b291e6240029102 100644
+--- a/libstdc++-v3/crossconfig.m4
++++ b/libstdc++-v3/crossconfig.m4
+@@ -274,12 +274,24 @@ case "${host}" in
+     AC_CHECK_HEADERS([nan.h ieeefp.h endian.h sys/isa_defs.h \
+       machine/endian.h machine/param.h sys/machine.h sys/types.h \
+       fp.h locale.h float.h inttypes.h])
+     SECTION_FLAGS='-ffunction-sections -fdata-sections'
+     AC_SUBST(SECTION_FLAGS)
+     GLIBCXX_CHECK_LINKER_FEATURES
++
++dnl # Although we are cross compiling for Amiga, we already built the
++dnl # first stage compiler: the compiler without any libraries such as
++dnl # libstdc++. This means that we DO have access to AC_CHECK_FUNCS
++dnl # as all the CRTs have been built and installed at the point of
++dnl # running the configure file for libstdc++-v3.
++dnl #
++dnl # Adding checks here:
++
++dnl #
++    AC_CHECK_FUNCS(acosf asinf atan2f atanf ceilf cosf coshf expf fabsf floorf fmodf frexpf sqrtf hypotf ldexpf log10f logf modff powf sinf sinhf tanf tanhf fabsl acosl asinl atanl atan2l ceill cosl coshl expl floorl fmodl frexpl sqrtl hypotl ldexpl logl log10l modfl powl sinl sinhl tanl tanhl)
++
+     ;;
+   *)
+     AC_MSG_ERROR([No support for this host/target combination.])
+    ;;
+ esac
+ ])
+diff --git a/libstdc++-v3/include/c_global/cstdlib b/libstdc++-v3/include/c_global/cstdlib
+index 66862e087ee9abee00a6bb06cad058e489d01cdc..09d99212541ff9d456e5c7f0d11632fe5e1b67c4 100644
+--- a/libstdc++-v3/include/c_global/cstdlib
++++ b/libstdc++-v3/include/c_global/cstdlib
+@@ -208,14 +208,14 @@ _GLIBCXX_END_NAMESPACE_VERSION
+ #undef lldiv
+ #undef atoll
+ #undef strtoll
+ #undef strtoull
+ #undef strtof
+ 
+-/* Neigther clib2 nor newlib offers strtoud() */
+-#ifndef __amigaos4__
++/* clib2 and newlib do not provide an implementation of strtold */
++#if !defined (__amigaos4__) || defined(__CLIB4__)
+ #undef strtold
+ #endif
+ 
+ namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
+ {
+ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+-- 
+2.34.1
+

--- a/native-build/makefile
+++ b/native-build/makefile
@@ -84,7 +84,7 @@ COREUTILS_VERSION=5.2.1
 DIST_VERSION=$(shell date +%Y%m%d)-$(shell git rev-list --count HEAD)
 
 # Set up the necessary variables for the CLIBs
-CLIB4_SUPPORT=$(filter 11,$(GCC_BRANCH_NAME))
+CLIB4_SUPPORT=$(filter 11 6,$(GCC_BRANCH_NAME))
 CLIB4_URL=https://github.com/AmigaLabs/clib4
 CLIB4_DIR=downloads/clib4/
 CLIB4_RELEASE_ARCHIVE_NAME=adtools-os4-clib4-$(DIST_VERSION).lha


### PR DESCRIPTION
As well as the existing newlib and clib2 as C runtime library choices, clib4 is now introduced. Support for clib4 is currently restricted to GCC version 11 and version 6. The version 6 "backport" is useful since this version is still used to build for SPE.