### PR TITLE
GCC8: Provide clib4 as an additional C runtime library.

### DIFF
--- a/gcc/8/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/8/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
-From 3381d8ff71670dc71a729196270fa6fdec9c5815 Mon Sep 17 00:00:00 2001
+From 6f3b0c228b2122d1f601ed71a53185476b0cc3bb Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/27] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/28] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |    1 +
@@ -5177,5 +5177,5 @@ index 9ae10100f8d60e900cde415bb7e96baebf35c85d..eb0f1fab6f81ac3f0e56c22ce85532c8
  
  #endif // _GLIBCXX_CSTDDEF
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/8/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
-From 75c8361acf60a8908a1477b486446327d9209650 Mon Sep 17 00:00:00 2001
+From c5f2a43b7ae028a95f5744d76583035fd0171cf1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/27] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/28] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions
@@ -397,5 +397,5 @@ index ad8c0e64c056129afcd8bfa2a656749a2febfaaa..85c03f28e37d64865360692a14fcc8a1
  amigaos_legitimize_baserel_address (rtx addr)
  {
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/8/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
-From d20ca0538e37a67d28bfed22eb6ac23517c4c084 Mon Sep 17 00:00:00 2001
+From d801914b78606622e63d6ed0aedff816f9d67622 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/27] Disable .machine directive generation.
+Subject: [PATCH 03/28] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.
@@ -45,5 +45,5 @@ index 5c62d96fe8523818dacfdc49be4578596149fd4a..fcdbc280a32a84a75def8dd490d913eb
      fprintf (file, "\t.abiversion 2\n");
  }
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/8/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 3e3fd245130fb45a08755b622ade4b0397d374f3 Mon Sep 17 00:00:00 2001
+From 19c459b4d1347b83a56893212fbb6886102df2a5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/27] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/28] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---
@@ -47,5 +47,5 @@ index 443a1746da3791eb3d402fb947afa8d76fe2c049..bdba1ac68a0e4e042bf63ac34129e428
  	case OPT_static_libstdc__:
  	  library = library >= 0 ? 2 : library;
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/8/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
-From 1a8ea2e85103a7ea1adcca88445991d83677a840 Mon Sep 17 00:00:00 2001
+From c28e3674877c0aede0c36e9288a0287d157df936 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/27] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/28] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---
@@ -67,5 +67,5 @@ index bdf021e828a9e4c8737fe5e7fd243262f0a455a6..4eb1e1ee434e1388b08421090782e153
  }
  
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/8/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
-From 51df5cec532625cc0321b15703b2578480f8598b Mon Sep 17 00:00:00 2001
+From 38789b3a6ff9d8a04aa7a27e88bbe6e244c81d2f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/27] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/28] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().
@@ -37,5 +37,5 @@ index 2fe3d2eb7dcb2cb71e24a2fe2e01f637ea2ce727..f1c28df80dd2173d3a98f152e4d9e5d5
    set_up_specs ();
    putenv_COLLECT_GCC (argv[0]);
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/8/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
-From e0915e0d9902a45f360fce8d9839129f1cfcdcd1 Mon Sep 17 00:00:00 2001
+From 6c50d0f39edd65987c4bfb486e54e0f9498e3a3f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/27] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/28] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---
@@ -81,5 +81,5 @@ index e2f952f6c1cdf05237b1d6d6598b780b7f3c0cf4..9b15d7522e91061934693e1bce5bb272
  {
    if (__gthread_active_p ())
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/8/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,604 +1,280 @@
-From 2aac08d334faddce051e4937c7e9609f226fcb49 Mon Sep 17 00:00:00 2001
+From 04b87b3ca37f1a9de987637f5b223c27c5aaa579 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/27] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/28] Added libstc++ support for AmigaOS.
 
 ---
- libstdc++-v3/config/os/amigaos/ctype_base.h   |  59 ++++++
- .../config/os/amigaos/ctype_configure_char.cc |  99 ++++++++++
- libstdc++-v3/config/os/amigaos/ctype_inline.h | 173 +++++++++++++++++
- .../config/os/amigaos/error_constants.h       | 178 ++++++++++++++++++
- libstdc++-v3/config/os/amigaos/os_defines.h   |  43 +++++
- libstdc++-v3/configure.host                   |   3 +
- 6 files changed, 555 insertions(+)
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_base.h
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
- create mode 100644 libstdc++-v3/config/os/amigaos/ctype_inline.h
- create mode 100644 libstdc++-v3/config/os/amigaos/error_constants.h
- create mode 100644 libstdc++-v3/config/os/amigaos/os_defines.h
+ .../os/{generic => amigaos}/ctype_base.h      |  2 +-
+ .../{aix => amigaos}/ctype_configure_char.cc  | 24 +++++++++----------
+ .../os/{generic => amigaos}/ctype_inline.h    | 16 ++++++-------
+ .../os/{generic => amigaos}/error_constants.h |  6 ++---
+ .../os/{vxworks => amigaos}/os_defines.h      | 13 +++++-----
+ libstdc++-v3/configure.host                   |  3 +++
+ 6 files changed, 34 insertions(+), 30 deletions(-)
+ copy libstdc++-v3/config/os/{generic => amigaos}/ctype_base.h (97%)
+ copy libstdc++-v3/config/os/{aix => amigaos}/ctype_configure_char.cc (87%)
+ copy libstdc++-v3/config/os/{generic => amigaos}/ctype_inline.h (96%)
+ copy libstdc++-v3/config/os/{generic => amigaos}/error_constants.h (97%)
+ copy libstdc++-v3/config/os/{vxworks => amigaos}/os_defines.h (86%)
 
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_base.h b/libstdc++-v3/config/os/amigaos/ctype_base.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..260b6142b6fc6a11a1e5f0bf7820b592d09f285e
---- /dev/null
+diff --git a/libstdc++-v3/config/os/generic/ctype_base.h b/libstdc++-v3/config/os/amigaos/ctype_base.h
+similarity index 97%
+copy from libstdc++-v3/config/os/generic/ctype_base.h
+copy to libstdc++-v3/config/os/amigaos/ctype_base.h
+index e73721e57a5a82c47b9375fd8f939d9a798f4c56..260b6142b6fc6a11a1e5f0bf7820b592d09f285e 100644
+--- a/libstdc++-v3/config/os/generic/ctype_base.h
 +++ b/libstdc++-v3/config/os/amigaos/ctype_base.h
-@@ -0,0 +1,59 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 1997-2018 Free Software Foundation, Inc.
 +// Copyright (C) 1997-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
-+
-+// Default information, may not be appropriate for specific host.
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  /// @brief  Base class for ctype.
-+  struct ctype_base
-+  {
-+    // Non-standard typedefs.
-+    typedef const int* 		__to_type;
-+
-+    // NB: Offsets into ctype<char>::_M_table force a particular size
-+    // on the mask type. Because of this, we don't use an enum.
-+    typedef unsigned int 	mask;
-+    static const mask upper    	= 1 << 0;
-+    static const mask lower 	= 1 << 1;
-+    static const mask alpha 	= 1 << 2;
-+    static const mask digit 	= 1 << 3;
-+    static const mask xdigit 	= 1 << 4;
-+    static const mask space 	= 1 << 5;
-+    static const mask print 	= 1 << 6;
-+    static const mask graph 	= (1 << 2) | (1 << 3) | (1 << 9); // alnum|punct
-+    static const mask cntrl 	= 1 << 8;
-+    static const mask punct 	= 1 << 9;
-+    static const mask alnum 	= (1 << 2) | (1 << 3);  // alpha|digit
-+    static const mask blank	= 1 << 10;
-+  };
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
-new file mode 100644
-index 0000000000000000000000000000000000000000..e6f4895aee78da54bc6b1e01df00816206361c41
---- /dev/null
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+diff --git a/libstdc++-v3/config/os/aix/ctype_configure_char.cc b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+similarity index 87%
+copy from libstdc++-v3/config/os/aix/ctype_configure_char.cc
+copy to libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
+index cb80c496e7157c356212a489a99807272f5b6728..e6f4895aee78da54bc6b1e01df00816206361c41 100644
+--- a/libstdc++-v3/config/os/aix/ctype_configure_char.cc
 +++ b/libstdc++-v3/config/os/amigaos/ctype_configure_char.cc
-@@ -0,0 +1,99 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 2011-2018 Free Software Foundation, Inc.
 +// Copyright (C) 2011-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file ctype_configure_char.cc */
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
-+
-+#include <locale>
-+#include <cstdlib>
-+#include <cstring>
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+// Information as gleaned from /usr/include/ctype.h
-+
-+  const ctype_base::mask*
-+  ctype<char>::classic_table() throw()
-+  { return 0; }
-+
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -39,29 +39,29 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ // Information as gleaned from /usr/include/ctype.h
+ 
+   const ctype_base::mask*
+   ctype<char>::classic_table() throw()
+   { return 0; }
+ 
+-  ctype<char>::ctype(__c_locale, const mask* __table, bool __del,
+-		     size_t __refs)
+-  : facet(__refs), _M_del(__table != 0 && __del),
+-  _M_toupper(NULL), _M_tolower(NULL),
+-  _M_table(__table ? __table : classic_table())
+-  {
 +  ctype<char>::ctype(__c_locale, const mask* __table, bool __del, 
 +		     size_t __refs) 
 +  : facet(__refs), _M_del(__table != 0 && __del), 
 +  _M_toupper(NULL), _M_tolower(NULL), 
 +  _M_table(__table ? __table : classic_table()) 
 +  { 
-+    memset(_M_widen, 0, sizeof(_M_widen));
-+    _M_widen_ok = 0;
-+    memset(_M_narrow, 0, sizeof(_M_narrow));
-+    _M_narrow_ok = 0;
-+  }
-+
+     memset(_M_widen, 0, sizeof(_M_widen));
+     _M_widen_ok = 0;
+     memset(_M_narrow, 0, sizeof(_M_narrow));
+     _M_narrow_ok = 0;
+   }
+ 
+-  ctype<char>::ctype(const mask* __table, bool __del, size_t __refs)
+-  : facet(__refs), _M_del(__table != 0 && __del),
+-  _M_toupper(NULL), _M_tolower(NULL),
 +  ctype<char>::ctype(const mask* __table, bool __del, size_t __refs) 
 +  : facet(__refs), _M_del(__table != 0 && __del), 
 +  _M_toupper(NULL), _M_tolower(NULL), 
-+  _M_table(__table ? __table : classic_table())
+   _M_table(__table ? __table : classic_table())
+-  {
 +  { 
-+    memset(_M_widen, 0, sizeof(_M_widen));
-+    _M_widen_ok = 0;
-+    memset(_M_narrow, 0, sizeof(_M_narrow));
-+    _M_narrow_ok = 0;
-+  }
-+
-+  char
-+  ctype<char>::do_toupper(char __c) const
-+  { return ::toupper((int) __c); }
-+
-+  const char*
-+  ctype<char>::do_toupper(char* __low, const char* __high) const
-+  {
-+    while (__low < __high)
-+      {
-+	*__low = ::toupper((int) *__low);
-+	++__low;
-+      }
-+    return __high;
-+  }
-+
-+  char
-+  ctype<char>::do_tolower(char __c) const
-+  { return ::tolower((int) __c); }
-+
+     memset(_M_widen, 0, sizeof(_M_widen));
+     _M_widen_ok = 0;
+     memset(_M_narrow, 0, sizeof(_M_narrow));
+     _M_narrow_ok = 0;
+   }
+ 
+@@ -81,13 +81,13 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+   }
+ 
+   char
+   ctype<char>::do_tolower(char __c) const
+   { return ::tolower((int) __c); }
+ 
+-  const char*
 +  const char* 
-+  ctype<char>::do_tolower(char* __low, const char* __high) const
-+  {
-+    while (__low < __high)
-+      {
-+	*__low = ::tolower((int) *__low);
-+	++__low;
-+      }
-+    return __high;
-+  }
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/ctype_inline.h b/libstdc++-v3/config/os/amigaos/ctype_inline.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..cfa0146ae6b70623c2fe63b864ceef7bce0d5fe0
---- /dev/null
+   ctype<char>::do_tolower(char* __low, const char* __high) const
+   {
+     while (__low < __high)
+       {
+ 	*__low = ::tolower((int) *__low);
+ 	++__low;
+diff --git a/libstdc++-v3/config/os/generic/ctype_inline.h b/libstdc++-v3/config/os/amigaos/ctype_inline.h
+similarity index 96%
+copy from libstdc++-v3/config/os/generic/ctype_inline.h
+copy to libstdc++-v3/config/os/amigaos/ctype_inline.h
+index 3a0ef4f9921c572f07dcfa56aae441fa2b15dba8..cfa0146ae6b70623c2fe63b864ceef7bce0d5fe0 100644
+--- a/libstdc++-v3/config/os/generic/ctype_inline.h
 +++ b/libstdc++-v3/config/os/amigaos/ctype_inline.h
-@@ -0,0 +1,173 @@
-+// Locale support -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Locale support -*- C++ -*-
+ 
+-// Copyright (C) 2000-2018 Free Software Foundation, Inc.
 +// Copyright (C) 2000-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/ctype_inline.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{locale}
-+ */
-+
-+//
-+// ISO C++ 14882: 22.1  Locales
-+//
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -27,16 +27,16 @@
+  *  Do not attempt to use it directly. @headername{locale}
+  */
+ 
+ //
+ // ISO C++ 14882: 22.1  Locales
+ //
+-
 +  
-+// ctype bits to be inlined go here. Non-inlinable (ie virtual do_*)
-+// functions go in ctype.cc
+ // ctype bits to be inlined go here. Non-inlinable (ie virtual do_*)
+ // functions go in ctype.cc
+-
 +  
-+// The following definitions are portable, but insanely slow. If one
-+// cares at all about performance, then specialized ctype
-+// functionality should be added for the native os in question: see
-+// the config/os/bits/ctype_*.h files.
-+
-+// Constructing a synthetic "C" table should be seriously considered...
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  bool
-+  ctype<char>::
-+  is(mask __m, char __c) const
+ // The following definitions are portable, but insanely slow. If one
+ // cares at all about performance, then specialized ctype
+ // functionality should be added for the native os in question: see
+ // the config/os/bits/ctype_*.h files.
+ 
+ // Constructing a synthetic "C" table should be seriously considered...
+@@ -45,19 +45,19 @@ namespace std _GLIBCXX_VISIBILITY(default)
+ {
+ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 
+   bool
+   ctype<char>::
+   is(mask __m, char __c) const
+-  {
 +  { 
-+    if (_M_table)
-+      return _M_table[static_cast<unsigned char>(__c)] & __m;
-+    else
-+      {
-+	bool __ret = false;
+     if (_M_table)
+       return _M_table[static_cast<unsigned char>(__c)] & __m;
+     else
+       {
+ 	bool __ret = false;
+-	const size_t __bitmasksize = 15;
 +	const size_t __bitmasksize = 15; 
-+	size_t __bitcur = 0; // Lowest bitmask in ctype_base == 0
-+	for (; __bitcur <= __bitmasksize; ++__bitcur)
-+	  {
-+	    const mask __bit = static_cast<mask>(1 << __bitcur);
-+	    if (__m & __bit)
-+	      {
-+		bool __testis;
-+		switch (__bit)
-+		  {
-+		  case space:
-+		    __testis = isspace(__c);
-+		    break;
-+		  case print:
-+		    __testis = isprint(__c);
-+		    break;
-+		  case cntrl:
-+		    __testis = iscntrl(__c);
-+		    break;
-+		  case upper:
-+		    __testis = isupper(__c);
-+		    break;
-+		  case lower:
-+		    __testis = islower(__c);
-+		    break;
-+		  case alpha:
-+		    __testis = isalpha(__c);
-+		    break;
-+		  case digit:
-+		    __testis = isdigit(__c);
-+		    break;
-+		  case punct:
-+		    __testis = ispunct(__c);
-+		    break;
-+		  case xdigit:
-+		    __testis = isxdigit(__c);
-+		    break;
-+		  case alnum:
-+		    __testis = isalnum(__c);
-+		    break;
-+		  case graph:
-+		    __testis = isgraph(__c);
-+		    break;
-+#ifdef _GLIBCXX_USE_C99_CTYPE_TR1
-+		  case blank:
-+		    __testis = isblank(__c);
-+		    break;
-+#endif
-+		  default:
-+		    __testis = false;
-+		    break;
-+		  }
-+		__ret |= __testis;
-+	      }
-+	  }
-+	return __ret;
-+      }
-+  }
+ 	size_t __bitcur = 0; // Lowest bitmask in ctype_base == 0
+ 	for (; __bitcur <= __bitmasksize; ++__bitcur)
+ 	  {
+ 	    const mask __bit = static_cast<mask>(1 << __bitcur);
+ 	    if (__m & __bit)
+ 	      {
+@@ -109,29 +109,29 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 		__ret |= __testis;
+ 	      }
+ 	  }
+ 	return __ret;
+       }
+   }
+-
 +   
-+  const char*
-+  ctype<char>::
-+  is(const char* __low, const char* __high, mask* __vec) const
-+  {
-+    if (_M_table)
-+      while (__low < __high)
-+	*__vec++ = _M_table[static_cast<unsigned char>(*__low++)];
-+    else
-+      {
-+	// Highest bitmask in ctype_base == 11.
+   const char*
+   ctype<char>::
+   is(const char* __low, const char* __high, mask* __vec) const
+   {
+     if (_M_table)
+       while (__low < __high)
+ 	*__vec++ = _M_table[static_cast<unsigned char>(*__low++)];
+     else
+       {
+ 	// Highest bitmask in ctype_base == 11.
+-	const size_t __bitmasksize = 15;
 +	const size_t __bitmasksize = 15; 
-+	for (;__low < __high; ++__vec, ++__low)
-+	  {
-+	    mask __m = 0;
-+	    // Lowest bitmask in ctype_base == 0
+ 	for (;__low < __high; ++__vec, ++__low)
+ 	  {
+ 	    mask __m = 0;
+ 	    // Lowest bitmask in ctype_base == 0
+-	    size_t __i = 0;
 +	    size_t __i = 0; 
-+	    for (;__i <= __bitmasksize; ++__i)
-+	      {
-+		const mask __bit = static_cast<mask>(1 << __i);
-+		if (this->is(__bit, *__low))
-+		  __m |= __bit;
-+	      }
-+	    *__vec = __m;
-+	  }
-+      }
-+    return __high;
-+  }
-+
-+  const char*
-+  ctype<char>::
-+  scan_is(mask __m, const char* __low, const char* __high) const
-+  {
-+    if (_M_table)
-+      while (__low < __high
-+	     && !(_M_table[static_cast<unsigned char>(*__low)] & __m))
-+	++__low;
-+    else
-+      while (__low < __high && !this->is(__m, *__low))
-+	++__low;
-+    return __low;
-+  }
-+
-+  const char*
-+  ctype<char>::
-+  scan_not(mask __m, const char* __low, const char* __high) const
-+  {
-+    if (_M_table)
-+      while (__low < __high
-+	     && (_M_table[static_cast<unsigned char>(*__low)] & __m) != 0)
-+	++__low;
-+    else
-+      while (__low < __high && this->is(__m, *__low) != 0)
-+	++__low;
-+    return __low;
-+  }
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-diff --git a/libstdc++-v3/config/os/amigaos/error_constants.h b/libstdc++-v3/config/os/amigaos/error_constants.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..74492cf61c875eac28cb8a86d5bfdb3b8807aa16
---- /dev/null
+ 	    for (;__i <= __bitmasksize; ++__i)
+ 	      {
+ 		const mask __bit = static_cast<mask>(1 << __i);
+ 		if (this->is(__bit, *__low))
+ 		  __m |= __bit;
+ 	      }
+diff --git a/libstdc++-v3/config/os/generic/error_constants.h b/libstdc++-v3/config/os/amigaos/error_constants.h
+similarity index 97%
+copy from libstdc++-v3/config/os/generic/error_constants.h
+copy to libstdc++-v3/config/os/amigaos/error_constants.h
+index af77f46be55ebc597d37b0dfbc2fd28ca803e3ac..74492cf61c875eac28cb8a86d5bfdb3b8807aa16 100644
+--- a/libstdc++-v3/config/os/generic/error_constants.h
 +++ b/libstdc++-v3/config/os/amigaos/error_constants.h
-@@ -0,0 +1,178 @@
-+// Specific definitions for generic platforms  -*- C++ -*-
-+
+@@ -1,9 +1,9 @@
+ // Specific definitions for generic platforms  -*- C++ -*-
+ 
+-// Copyright (C) 2007-2018 Free Software Foundation, Inc.
 +// Copyright (C) 2007-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/error_constants.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{system_error}
-+ */
-+
-+#ifndef _GLIBCXX_ERROR_CONSTANTS
-+#define _GLIBCXX_ERROR_CONSTANTS 1
-+
-+#include <bits/c++config.h>
-+#include <cerrno>
-+
-+namespace std _GLIBCXX_VISIBILITY(default)
-+{
-+_GLIBCXX_BEGIN_NAMESPACE_VERSION
-+
-+  enum class errc
-+    {
-+      address_family_not_supported = 		EAFNOSUPPORT,
-+      address_in_use = 				EADDRINUSE,
-+      address_not_available = 			EADDRNOTAVAIL,
-+      already_connected = 			EISCONN,
-+      argument_list_too_long = 			E2BIG,
-+      argument_out_of_domain = 			EDOM,
-+      bad_address = 				EFAULT,
-+      bad_file_descriptor = 			EBADF,
-+
-+#ifdef _GLIBCXX_HAVE_EBADMSG
-+      bad_message = 				EBADMSG,
-+#endif
-+
-+      broken_pipe = 				EPIPE,
-+      connection_aborted = 			ECONNABORTED,
-+      connection_already_in_progress = 		EALREADY,
-+      connection_refused = 			ECONNREFUSED,
-+      connection_reset = 			ECONNRESET,
-+      cross_device_link = 			EXDEV,
-+      destination_address_required = 		EDESTADDRREQ,
-+      device_or_resource_busy = 		EBUSY,
-+      directory_not_empty = 			ENOTEMPTY,
-+      executable_format_error = 		ENOEXEC,
-+      file_exists = 	       			EEXIST,
-+      file_too_large = 				EFBIG,
-+      filename_too_long = 			ENAMETOOLONG,
-+      function_not_supported = 			ENOSYS,
-+      host_unreachable = 			EHOSTUNREACH,
-+
-+#ifdef _GLIBCXX_HAVE_EIDRM
-+      identifier_removed = 			EIDRM,
-+#endif
-+
-+      illegal_byte_sequence = 			EILSEQ,
-+      inappropriate_io_control_operation = 	ENOTTY,
-+      interrupted = 				EINTR,
-+      invalid_argument = 			EINVAL,
-+      invalid_seek = 				ESPIPE,
-+      io_error = 				EIO,
-+      is_a_directory = 				EISDIR,
-+      message_size = 				EMSGSIZE,
-+      network_down = 				ENETDOWN,
-+      network_reset = 				ENETRESET,
-+      network_unreachable = 			ENETUNREACH,
-+      no_buffer_space = 			ENOBUFS,
-+      no_child_process = 			ECHILD,
-+
-+#ifdef _GLIBCXX_HAVE_ENOLINK
-+      no_link = 				ENOLINK,
-+#endif
-+
-+      no_lock_available = 			ENOLCK,
-+
-+#ifdef _GLIBCXX_HAVE_ENODATA
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -90,16 +90,16 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+       no_link = 				ENOLINK,
+ #endif
+ 
+       no_lock_available = 			ENOLCK,
+ 
+ #ifdef _GLIBCXX_HAVE_ENODATA
+-      no_message_available = 			ENODATA,
 +      no_message_available = 			ENODATA, 
-+#endif
-+
+ #endif
+ 
+-      no_message = 				ENOMSG,
 +      no_message = 				ENOMSG, 
-+      no_protocol_option = 			ENOPROTOOPT,
-+      no_space_on_device = 			ENOSPC,
-+
-+#ifdef _GLIBCXX_HAVE_ENOSR
-+      no_stream_resources = 			ENOSR,
-+#endif
-+
-+      no_such_device_or_address = 		ENXIO,
-+      no_such_device = 				ENODEV,
-+      no_such_file_or_directory = 		ENOENT,
-+      no_such_process = 			ESRCH,
-+      not_a_directory = 			ENOTDIR,
-+      not_a_socket = 				ENOTSOCK,
-+
-+#ifdef _GLIBCXX_HAVE_ENOSTR
-+      not_a_stream = 				ENOSTR,
-+#endif
-+
-+      not_connected = 				ENOTCONN,
-+      not_enough_memory = 			ENOMEM,
-+
-+#ifdef _GLIBCXX_HAVE_ENOTSUP
-+      not_supported = 				ENOTSUP,
-+#endif
-+
-+#ifdef _GLIBCXX_HAVE_ECANCELED
-+      operation_canceled = 			ECANCELED,
-+#endif
-+
-+      operation_in_progress = 			EINPROGRESS,
-+      operation_not_permitted = 		EPERM,
-+      operation_not_supported = 		EOPNOTSUPP,
-+      operation_would_block = 			EWOULDBLOCK,
-+
-+#ifdef _GLIBCXX_HAVE_EOWNERDEAD
-+      owner_dead = 				EOWNERDEAD,
-+#endif
-+
-+      permission_denied = 			EACCES,
-+
-+#ifdef _GLIBCXX_HAVE_EPROTO
-+      protocol_error = 				EPROTO,
-+#endif
-+
-+      protocol_not_supported = 			EPROTONOSUPPORT,
-+      read_only_file_system = 			EROFS,
-+      resource_deadlock_would_occur = 		EDEADLK,
-+      resource_unavailable_try_again = 		EAGAIN,
-+      result_out_of_range = 			ERANGE,
-+
-+#ifdef _GLIBCXX_HAVE_ENOTRECOVERABLE
-+      state_not_recoverable = 			ENOTRECOVERABLE,
-+#endif
-+
-+#ifdef _GLIBCXX_HAVE_ETIME
-+      stream_timeout = 				ETIME,
-+#endif
-+
-+#ifdef _GLIBCXX_HAVE_ETXTBSY
-+      text_file_busy = 				ETXTBSY,
-+#endif
-+
-+      timed_out = 				ETIMEDOUT,
-+      too_many_files_open_in_system = 		ENFILE,
-+      too_many_files_open = 			EMFILE,
-+      too_many_links = 				EMLINK,
-+      too_many_symbolic_link_levels = 		ELOOP,
-+
-+#ifdef _GLIBCXX_HAVE_EOVERFLOW
-+      value_too_large = 			EOVERFLOW,
-+#endif
-+
-+      wrong_protocol_type = 			EPROTOTYPE
-+    };
-+
-+_GLIBCXX_END_NAMESPACE_VERSION
-+} // namespace
-+
-+#endif
-diff --git a/libstdc++-v3/config/os/amigaos/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..346f063958cd7e80ebf97be4acee0bdf391cb811
---- /dev/null
+       no_protocol_option = 			ENOPROTOOPT,
+       no_space_on_device = 			ENOSPC,
+ 
+ #ifdef _GLIBCXX_HAVE_ENOSR
+       no_stream_resources = 			ENOSR,
+ #endif
+diff --git a/libstdc++-v3/config/os/vxworks/os_defines.h b/libstdc++-v3/config/os/amigaos/os_defines.h
+similarity index 86%
+copy from libstdc++-v3/config/os/vxworks/os_defines.h
+copy to libstdc++-v3/config/os/amigaos/os_defines.h
+index 9f43cc4b9d5a2c52215722fec4ac1d895265e869..346f063958cd7e80ebf97be4acee0bdf391cb811 100644
+--- a/libstdc++-v3/config/os/vxworks/os_defines.h
 +++ b/libstdc++-v3/config/os/amigaos/os_defines.h
-@@ -0,0 +1,43 @@
+@@ -1,9 +1,9 @@
+-// Specific definitions for VxWorks  -*- C++ -*-
 +// Specific definitions for AmigaOS -*- C++ -*-
-+
+ 
+-// Copyright (C) 2000-2018 Free Software Foundation, Inc.
 +// Copyright (C) 2000-2015 Free Software Foundation, Inc.
-+//
-+// This file is part of the GNU ISO C++ Library.  This library is free
-+// software; you can redistribute it and/or modify it under the
-+// terms of the GNU General Public License as published by the
-+// Free Software Foundation; either version 3, or (at your option)
-+// any later version.
-+
-+// This library is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+
-+// Under Section 7 of GPL version 3, you are granted additional
-+// permissions described in the GCC Runtime Library Exception, version
-+// 3.1, as published by the Free Software Foundation.
-+
-+// You should have received a copy of the GNU General Public License and
-+// a copy of the GCC Runtime Library Exception along with this program;
-+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+// <http://www.gnu.org/licenses/>.
-+
-+/** @file bits/os_defines.h
-+ *  This is an internal header file, included by other library headers.
-+ *  Do not attempt to use it directly. @headername{iosfwd}
-+ */
-+
-+#ifndef _GLIBCXX_OS_DEFINES
-+#define _GLIBCXX_OS_DEFINES 1
-+
-+// System-specific #define, typedefs, corrections, etc, go here.  This
-+// file will come before all others.
-+
+ //
+ // This file is part of the GNU ISO C++ Library.  This library is free
+ // software; you can redistribute it and/or modify it under the
+ // terms of the GNU General Public License as published by the
+ // Free Software Foundation; either version 3, or (at your option)
+ // any later version.
+@@ -30,13 +30,14 @@
+ #ifndef _GLIBCXX_OS_DEFINES
+ #define _GLIBCXX_OS_DEFINES 1
+ 
+ // System-specific #define, typedefs, corrections, etc, go here.  This
+ // file will come before all others.
+ 
+-//Keep vxWorks from defining min()/max() as macros
+-#ifdef NOMINMAX
+-#undef NOMINMAX
 +// No ioctl() on AmigaOS
 +#define _GLIBCXX_NO_IOCTL 1
 +
 +#ifdef __NEWLIB__
 +#define _GLIBCXX_USE_C99_STDINT_TR1 1
-+#endif
-+
-+#endif
+ #endif
+-#define NOMINMAX 1
+ 
+ #endif
 diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
 index 155a3cdea1bad297b3cd4c21ecd3c7307b5e6ac9..9daab7c3c71169b10f5ff48c70e4d6d13228cf7f 100644
 --- a/libstdc++-v3/configure.host
@@ -620,5 +296,5 @@ index 155a3cdea1bad297b3cd4c21ecd3c7307b5e6ac9..9daab7c3c71169b10f5ff48c70e4d6d1
    cygwin*)
      os_include_dir="os/newlib"
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/8/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,154 +1,100 @@
-From 6d43f9fdb55d9c14dabb384deca605242628ed09 Mon Sep 17 00:00:00 2001
+From 6b2502ad3148594cbc85b03cbf3d85ce82c70af7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 09/27] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 09/28] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---
- libatomic/config/amigaos/host-config.h |  55 +++++++++++++
- libatomic/config/amigaos/lock.c        | 102 +++++++++++++++++++++++++
- libatomic/configure.tgt                |   4 +
- 3 files changed, 161 insertions(+)
- create mode 100644 libatomic/config/amigaos/host-config.h
- create mode 100644 libatomic/config/amigaos/lock.c
+ .../config/{posix => amigaos}/host-config.h   |  2 +-
+ libatomic/config/{posix => amigaos}/lock.c    | 64 ++++++++-----------
+ libatomic/configure.tgt                       |  4 ++
+ 3 files changed, 30 insertions(+), 40 deletions(-)
+ copy libatomic/config/{posix => amigaos}/host-config.h (96%)
+ copy libatomic/config/{posix => amigaos}/lock.c (68%)
 
-diff --git a/libatomic/config/amigaos/host-config.h b/libatomic/config/amigaos/host-config.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..879758e4eb5594a79b8ee2d25564b19a6f51cd31
---- /dev/null
+diff --git a/libatomic/config/posix/host-config.h b/libatomic/config/amigaos/host-config.h
+similarity index 96%
+copy from libatomic/config/posix/host-config.h
+copy to libatomic/config/amigaos/host-config.h
+index f141af17598ecb4e2c0ce2c97d4bc78101af4472..879758e4eb5594a79b8ee2d25564b19a6f51cd31 100644
+--- a/libatomic/config/posix/host-config.h
 +++ b/libatomic/config/amigaos/host-config.h
-@@ -0,0 +1,55 @@
+@@ -1,7 +1,7 @@
+-/* Copyright (C) 2012-2018 Free Software Foundation, Inc.
 +/* Copyright (C) 2012-2015 Free Software Foundation, Inc.
-+   Contributed by Richard Henderson <rth@redhat.com>.
-+
-+   This file is part of the GNU Atomic Library (libatomic).
-+
-+   Libatomic is free software; you can redistribute it and/or modify it
-+   under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   Libatomic is distributed in the hope that it will be useful, but WITHOUT ANY
-+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-+   FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+   more details.
-+
-+   Under Section 7 of GPL version 3, you are granted additional
-+   permissions described in the GCC Runtime Library Exception, version
-+   3.1, as published by the Free Software Foundation.
-+
-+   You should have received a copy of the GNU General Public License and
-+   a copy of the GCC Runtime Library Exception along with this program;
-+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+/* Included after all more target-specific host-config.h.  */
-+
-+
-+#ifndef protect_start_end
-+# ifdef HAVE_ATTRIBUTE_VISIBILITY
-+#  pragma GCC visibility push(hidden)
-+# endif
-+
-+void libat_lock_1 (void *ptr);
-+void libat_unlock_1 (void *ptr);
-+
-+static inline UWORD
-+protect_start (void *ptr)
-+{
-+  libat_lock_1 (ptr);
-+  return 0;
-+}
-+
-+static inline void
-+protect_end (void *ptr, UWORD dummy UNUSED)
-+{
-+  libat_unlock_1 (ptr);
-+}
-+
-+# define protect_start_end 1
-+# ifdef HAVE_ATTRIBUTE_VISIBILITY
-+#  pragma GCC visibility pop
-+# endif
-+#endif /* protect_start_end */
-+
-+#include_next <host-config.h>
-diff --git a/libatomic/config/amigaos/lock.c b/libatomic/config/amigaos/lock.c
-new file mode 100644
-index 0000000000000000000000000000000000000000..ffd09f50095429f844bfe6bf7bec8741f56f1a28
---- /dev/null
+    Contributed by Richard Henderson <rth@redhat.com>.
+ 
+    This file is part of the GNU Atomic Library (libatomic).
+ 
+    Libatomic is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+diff --git a/libatomic/config/posix/lock.c b/libatomic/config/amigaos/lock.c
+similarity index 68%
+copy from libatomic/config/posix/lock.c
+copy to libatomic/config/amigaos/lock.c
+index 13b2bdc930aa2dce47022df97c003eb548c51e21..ffd09f50095429f844bfe6bf7bec8741f56f1a28 100644
+--- a/libatomic/config/posix/lock.c
 +++ b/libatomic/config/amigaos/lock.c
-@@ -0,0 +1,102 @@
+@@ -1,7 +1,7 @@
+-/* Copyright (C) 2012-2018 Free Software Foundation, Inc.
 +/* Copyright (C) 2012-2015 Free Software Foundation, Inc.
-+   Contributed by Richard Henderson <rth@redhat.com>.
-+
-+   This file is part of the GNU Atomic Library (libatomic).
-+
-+   Libatomic is free software; you can redistribute it and/or modify it
-+   under the terms of the GNU General Public License as published by
-+   the Free Software Foundation; either version 3 of the License, or
-+   (at your option) any later version.
-+
-+   Libatomic is distributed in the hope that it will be useful, but WITHOUT ANY
-+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-+   FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-+   more details.
-+
-+   Under Section 7 of GPL version 3, you are granted additional
-+   permissions described in the GCC Runtime Library Exception, version
-+   3.1, as published by the Free Software Foundation.
-+
-+   You should have received a copy of the GNU General Public License and
-+   a copy of the GCC Runtime Library Exception along with this program;
-+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+   <http://www.gnu.org/licenses/>.  */
-+
-+#include "libatomic_i.h"
-+
+    Contributed by Richard Henderson <rth@redhat.com>.
+ 
+    This file is part of the GNU Atomic Library (libatomic).
+ 
+    Libatomic is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+@@ -20,14 +20,15 @@
+    You should have received a copy of the GNU General Public License and
+    a copy of the GCC Runtime Library Exception along with this program;
+    see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+    <http://www.gnu.org/licenses/>.  */
+ 
+ #include "libatomic_i.h"
+-#include <pthread.h>
+ 
 +#define UWORD UWORD_
 +#include <proto/exec.h>
-+
-+/* The target page size.  Must be no larger than the runtime page size,
-+   lest locking fail with virtual address aliasing (i.e. a page mmaped
-+   at two locations).  */
-+#ifndef PAGE_SIZE
-+#define PAGE_SIZE	4096
-+#endif
-+
-+/* The target cacheline size.  This is an optimization; the padding that
-+   should be applied to the locks to keep them from interfering.  */
-+#ifndef CACHLINE_SIZE
-+#define CACHLINE_SIZE	64
-+#endif
-+
-+/* The granularity at which locks are applied.  Almost certainly the
-+   cachline size is the right thing to use here.  */
-+#ifndef WATCH_SIZE
-+#define WATCH_SIZE	CACHLINE_SIZE
-+#endif
-+
-+struct lock
-+{
+ 
+ /* The target page size.  Must be no larger than the runtime page size,
+    lest locking fail with virtual address aliasing (i.e. a page mmaped
+    at two locations).  */
+ #ifndef PAGE_SIZE
+ #define PAGE_SIZE	4096
+@@ -44,73 +45,58 @@
+ #ifndef WATCH_SIZE
+ #define WATCH_SIZE	CACHLINE_SIZE
+ #endif
+ 
+ struct lock
+ {
+-  pthread_mutex_t mutex;
+-  char pad[sizeof(pthread_mutex_t) < CACHLINE_SIZE
+-	   ? CACHLINE_SIZE - sizeof(pthread_mutex_t)
 +  struct SignalSemaphore sem;
 +  char initialized;
 +  char pad[sizeof(struct SignalSemaphore) + 1 < CACHLINE_SIZE
 +	   ? CACHLINE_SIZE - sizeof(struct SignalSemaphore) - 1
-+	   : 0];
-+};
-+
+ 	   : 0];
+ };
+ 
 +/* TODO: Use a constructor to initialize the semaphore */
-+#define NLOCKS		(PAGE_SIZE / WATCH_SIZE)
+ #define NLOCKS		(PAGE_SIZE / WATCH_SIZE)
+-static struct lock locks[NLOCKS] = {
+-  [0 ... NLOCKS-1].mutex = PTHREAD_MUTEX_INITIALIZER
+-};
 +static struct lock locks[NLOCKS];
-+
-+static inline uintptr_t 
-+addr_hash (void *ptr)
-+{
-+  return ((uintptr_t)ptr / WATCH_SIZE) % NLOCKS;
-+}
-+
-+void
-+libat_lock_1 (void *ptr)
-+{
+ 
+ static inline uintptr_t 
+ addr_hash (void *ptr)
+ {
+   return ((uintptr_t)ptr / WATCH_SIZE) % NLOCKS;
+ }
+ 
+ void
+ libat_lock_1 (void *ptr)
+ {
+-  pthread_mutex_lock (&locks[addr_hash (ptr)].mutex);
 +  struct lock *l = &locks[addr_hash (ptr)];
 +  IExec->Forbid();
 +  if (!l->initialized)
@@ -158,27 +104,57 @@ index 0000000000000000000000000000000000000000..ffd09f50095429f844bfe6bf7bec8741
 +  }
 +  IExec->Permit();
 +  IExec->ObtainSemaphore(&l->sem);
-+}
-+
-+void
-+libat_unlock_1 (void *ptr)
-+{
+ }
+ 
+ void
+ libat_unlock_1 (void *ptr)
+ {
+-  pthread_mutex_unlock (&locks[addr_hash (ptr)].mutex);
 +  struct lock *l = &locks[addr_hash (ptr)];
 +  IExec->ReleaseSemaphore(&l->sem);
-+}
-+
+ }
+ 
 +#if 0
 +
 +/* TODO: Implement me when needed */
-+void
-+libat_lock_n (void *ptr, size_t n)
-+{
-+}
-+
-+void
-+libat_unlock_n (void *ptr, size_t n)
-+{
-+}
+ void
+ libat_lock_n (void *ptr, size_t n)
+ {
+-  uintptr_t h = addr_hash (ptr);
+-  size_t i = 0;
+-
+-  /* Don't lock more than all the locks we have.  */
+-  if (n > PAGE_SIZE)
+-    n = PAGE_SIZE;
+-
+-  do
+-    {
+-      pthread_mutex_lock (&locks[h].mutex);
+-      if (++h == NLOCKS)
+-	h = 0;
+-      i += WATCH_SIZE;
+-    }
+-  while (i < n);
+ }
+ 
+ void
+ libat_unlock_n (void *ptr, size_t n)
+ {
+-  uintptr_t h = addr_hash (ptr);
+-  size_t i = 0;
+-
+-  if (n > PAGE_SIZE)
+-    n = PAGE_SIZE;
+-
+-  do
+-    {
+-      pthread_mutex_unlock (&locks[h].mutex);
+-      if (++h == NLOCKS)
+-	h = 0;
+-      i += WATCH_SIZE;
+-    }
+-  while (i < n);
+ }
 +
 +#endif
 diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
@@ -203,5 +179,5 @@ index ea8c34f8c710cc40b5646b665c24cc0933a92c73..03e6e94311c5150894a802637eaa4781
  	# If the target supports disabling interrupts, we can work in
  	# kernel-mode, given the system is not multi-processor.
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/8/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,7 +1,7 @@
-From 44f7770f64b887dae89ecefdd0a49e6e417a6c50 Mon Sep 17 00:00:00 2001
+From f362a8d33be22d7c5900e1f1638f9ab94af27f00 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
-Subject: [PATCH 10/27] Implement libat_lock_n() and libat_unlock_n().
+Subject: [PATCH 10/28] Implement libat_lock_n() and libat_unlock_n().
 
 ---
  libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++-------
@@ -100,5 +100,5 @@ index ffd09f50095429f844bfe6bf7bec8741f56f1a28..82dd696f78cc4afa5592c5fb83f33e91
 -
 -#endif
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/8/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
-From bda9b577df2aea2c36f879cdb057134eefe5f09f Mon Sep 17 00:00:00 2001
+From 1642447c593cb4cedf838c2ec9beb9ccc23ca4b1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/27] Pretend C99 compatibility.
+Subject: [PATCH 11/28] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses
@@ -107,5 +107,5 @@ index 10335017f0c4261c02b0b4d87c15b9a8572e6a61..fb5ae1889b288097f793396f35a9b65c
  } // extern "C++"
  
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/8/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
-From 5e00a73694d610113a79a267b79d8ea59e8137c9 Mon Sep 17 00:00:00 2001
+From 19e51805acfc5d157291e6c06505f941468b71ab Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/27] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/28] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-
@@ -50,5 +50,5 @@ index d29dd8c54530f003c20786c9261159de83276d8e..854009ca098f9dff59be936425a565dd
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/8/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
-From 0cd7892bc1f040ddf16ed3fd37b1826e3fb87ee2 Mon Sep 17 00:00:00 2001
+From 769a4d2d12464d18e5ba73edf60192b93f9109fe Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/27] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/28] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------
@@ -161,5 +161,5 @@ index ae3a66d43cfb5be9e9ae4b2f46136bfc27d5070f..fa4f5f17cb5d9d6d78b3c071c738dec3
  	  $(COMPILE.c) $(PICFLAG) $(NOASANFLAG) $(srcdir)/xmalloc.c -o noasan/$@; \
  	else true; fi
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/8/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
-From c6d68469620b2c54eca081bbe0d197f7dcba5bae Mon Sep 17 00:00:00 2001
+From e0055474bff8049f1174df7fc973ad76595020c1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/27] Add custom implementation of various env-related
+Subject: [PATCH 14/28] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.
@@ -125,7 +125,7 @@ index e0edfb00ac01b1090151a6039b4888b2809ff452..bf659d099e9cdfa030ec2d90e7992d68
      ;;
 diff --git a/libiberty/setenv-amigaos.c b/libiberty/setenv-amigaos.c
 new file mode 100644
-index 0000000000000000000000000000000000000000..dc9a460737538d74558bb43c21c21e61aa5a3305
+index 0000000000000000000000000000000000000000..089d3cbcc6eb7d42d96e8dfb16d1b399cfe856b3
 --- /dev/null
 +++ b/libiberty/setenv-amigaos.c
 @@ -0,0 +1,74 @@
@@ -204,5 +204,5 @@ index 0000000000000000000000000000000000000000..dc9a460737538d74558bb43c21c21e61
 +	return lvar->lv_Value;
 +}
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/8/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
-From df2070856b1a74ed726b2b6f76f7513171a8eb99 Mon Sep 17 00:00:00 2001
+From db892f6d9841605af36b1dddbbe613249c877e84 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/27] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/28] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.
@@ -41,5 +41,5 @@ index e4c73fd23a271b0b452cece0212ff244d2b55d48..46a5a4cc6012b9ab7ea973ce89150f37
     have no conflict with that.  */
  #ifndef _VA_LIST_
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/8/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
-From 452791b78cd99556c8b8b44fb515a19377ddd26a Mon Sep 17 00:00:00 2001
+From e6011ca854253df1900ce2753f2545d5f1618be3 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/27] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/28] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---
@@ -28,5 +28,5 @@ index fcdbc280a32a84a75def8dd490d913ebfe6f57d7..1839d93812ad89204402191e868a788b
        emit_move_insn (reg, mem);
  
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/8/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
-From eeb4e73fe9c2a211c631ecd06a40bbbf3ba3b312 Mon Sep 17 00:00:00 2001
+From 37ef8f1a54b2e94e21b61a3aa0e8a5eb58d7d7e5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/27] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/28] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +
@@ -77,5 +77,5 @@ index 1153ece337930f7bbf5f9978bf6f3faf2138bda6..d339c4280b67d863ec9c60dd38230d7b
  
  #undef INIT_CUMULATIVE_INCOMING_ARGS
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/8/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
-From 44072045f0942e8b5c574932f71357333a7e79e2 Mon Sep 17 00:00:00 2001
+From d5b814e021f21663e8c1cd8426e7e2cb3beb5758 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/27] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/28] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---
@@ -29,5 +29,5 @@ index d339c4280b67d863ec9c60dd38230d7bb2549345..f88bfe5f879cb4ca09f067d907ec36ef
  #define LINK_SPEC "\
  --defsym __amigaos4__=1 \
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0019-Add-_Static_warning.patch
+++ b/gcc/8/patches/0019-Add-_Static_warning.patch
@@ -1,7 +1,7 @@
-From 4c2451360b2e36a724b044c4a18a16e9efff55a6 Mon Sep 17 00:00:00 2001
+From 910c7fb66f34cdecda82a751bfd4dba22bd3a880 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
-Subject: [PATCH 19/27] Add _Static_warning().
+Subject: [PATCH 19/28] Add _Static_warning().
 
 This acts very similar to _Static_assert() but produces a warning
 rather than an compiler error.
@@ -157,5 +157,5 @@ index f2983b6102da7ebe34fb36b304d0620206df779a..70070b06214e314dd7447755350ab5fb
  				  /*maybe_range_for_decl*/NULL);
  }
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0020-Add-tagtype-attribute-that-can-be-passed-to-enum-con.patch
+++ b/gcc/8/patches/0020-Add-tagtype-attribute-that-can-be-passed-to-enum-con.patch
@@ -1,7 +1,7 @@
-From 3bfdbaf33d40f63635c050440989e0c5e495cca8 Mon Sep 17 00:00:00 2001
+From ba0ed10ad3f956059ca727e838bc1644856a8fe1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 06:29:13 +0200
-Subject: [PATCH 20/27] Add tagtype attribute that can be passed to enum
+Subject: [PATCH 20/28] Add tagtype attribute that can be passed to enum
  constants.
 
 The tagtype attribute can be applied to enum constants in order to annotate
@@ -163,5 +163,5 @@ index f88bfe5f879cb4ca09f067d907ec36ef0b4c2da3..0ed2a2b9ca1abe33f6534008f0c9592a
  /* Overrides */
  
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0021-Rename-lineartags-to-checktags.patch
+++ b/gcc/8/patches/0021-Rename-lineartags-to-checktags.patch
@@ -1,7 +1,7 @@
-From 94407d53f0c6835239d8429f03bad07b3c9b8ee1 Mon Sep 17 00:00:00 2001
+From a4c043211aec7a771350a521604b950a9a7deef7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
-Subject: [PATCH 21/27] Rename lineartags to checktags.
+Subject: [PATCH 21/28] Rename lineartags to checktags.
 
 The name lineartags would imply linearvarargs but this is not implemented
 or necessary.
@@ -109,5 +109,5 @@ index 0ed2a2b9ca1abe33f6534008f0c9592a02eacc09..d4812d8f618c2758bf95ec998f6aa53e
  
  /* Overrides */
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0022-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/8/patches/0022-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,7 +1,7 @@
-From de30b79e0989a709b5b28828d7a7e029bff27fda Mon Sep 17 00:00:00 2001
+From 11acd3eca6b03f6f64ab0386ec5d176f656a7bbc Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
-Subject: [PATCH 22/27] Fix order of AmigaOS PPC sections in the documentation.
+Subject: [PATCH 22/28] Fix order of AmigaOS PPC sections in the documentation.
 
 ---
  gcc/doc/invoke.texi | 264 ++++++++++++++++++++++----------------------
@@ -328,5 +328,5 @@ index ee8085fff435aa062c69f666f245ceb4fa68fe22..b21dec174a50bbf7c38b206c93fc34d5
  These options are supported for Xtensa targets:
  
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0023-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/8/patches/0023-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,7 +1,7 @@
-From 89c080a91614aa790eddf909083abf852278bb13 Mon Sep 17 00:00:00 2001
+From 75b58899e792be1e0be50f87ee79726017b9f53a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
-Subject: [PATCH 23/27] Provide a documentation for checktags and tagtype
+Subject: [PATCH 23/28] Provide a documentation for checktags and tagtype
  attributes.
 
 ---
@@ -67,5 +67,5 @@ index 74e4196842260a7904a71279ad08f311660c4527..cb1b4aafd131f08f7ec4641ddfdb7687
  @cindex Statement Attributes
  
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0024-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/8/patches/0024-Adapt-libssp-for-AmigaOS.patch
@@ -1,7 +1,7 @@
-From 80fdfb607de08280c6d34cdaf7318a0a1fcf530f Mon Sep 17 00:00:00 2001
+From 71f5c7753432b362aaa76aacc64dddd9273929cc Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
-Subject: [PATCH 24/27] Adapt libssp for AmigaOS.
+Subject: [PATCH 24/28] Adapt libssp for AmigaOS.
 
 ---
  libssp/ssp.c | 8 +++++---
@@ -64,5 +64,5 @@ index 741377ddd4050a1583952c32bdcffe372a3b4aa8..aa14566dea777c6629f4efd18e0c75d7
       is dead.  */
    {
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0025-Add-amigaos-thread-model.patch
+++ b/gcc/8/patches/0025-Add-amigaos-thread-model.patch
@@ -1,33 +1,33 @@
-From b054dbdd84d9aabc489e4a7a520c67a006a7c4f9 Mon Sep 17 00:00:00 2001
+From 3843dff1665663e20881f12dbab9f402a55591b9 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
-Subject: [PATCH 25/27] Add amigaos thread model.
+Subject: [PATCH 25/28] Add amigaos thread model.
 
 It is work in progress.
 ---
- config/gthr.m4                 |    1 +
- gcc/config.host                |    1 +
- gcc/config/rs6000/amigaos.h    |    8 +-
- gcc/config/rs6000/amigaos.opt  |   18 +
- gcc/config/rs6000/x-amigaos    |   16 +
- gcc/configure                  |    2 +-
- gcc/configure.ac               |    2 +-
- gcc/doc/invoke.texi            |    9 +-
- libgcc/config/rs6000/t-amigaos |    5 +
- libgcc/configure               |    1 +
- libgcc/gthr-amigaos-asserts.h  |    8 +
- libgcc/gthr-amigaos-native.c   | 1017 ++++++++++++++++++++++++++++++++
- libgcc/gthr-amigaos-posix.c    |  233 ++++++++
- libgcc/gthr-amigaos-single.c   |  141 +++++
- libgcc/gthr-amigaos.h          |  347 +++++++++++
- libstdc++-v3/configure         |   15 +-
- 16 files changed, 1812 insertions(+), 12 deletions(-)
+ config/gthr.m4                           |    1 +
+ gcc/config.host                          |    1 +
+ gcc/config/rs6000/amigaos.h              |    8 +-
+ gcc/config/rs6000/amigaos.opt            |   18 +
+ gcc/config/rs6000/x-amigaos              |   16 +
+ gcc/configure                            |    2 +-
+ gcc/configure.ac                         |    2 +-
+ gcc/doc/invoke.texi                      |    9 +-
+ libgcc/config/rs6000/t-amigaos           |    5 +
+ libgcc/configure                         |    1 +
+ libgcc/gthr-amigaos-asserts.h            |    8 +
+ libgcc/gthr-amigaos-native.c             | 1017 ++++++++++++++++++++++
+ libgcc/gthr-amigaos-posix.c              |  233 +++++
+ libgcc/gthr-amigaos-single.c             |  141 +++
+ libgcc/{gthr-single.h => gthr-amigaos.h} |  217 +++--
+ libstdc++-v3/configure                   |   15 +-
+ 16 files changed, 1598 insertions(+), 96 deletions(-)
  create mode 100644 gcc/config/rs6000/x-amigaos
  create mode 100644 libgcc/gthr-amigaos-asserts.h
  create mode 100644 libgcc/gthr-amigaos-native.c
  create mode 100644 libgcc/gthr-amigaos-posix.c
  create mode 100644 libgcc/gthr-amigaos-single.c
- create mode 100644 libgcc/gthr-amigaos.h
+ copy libgcc/{gthr-single.h => gthr-amigaos.h} (59%)
 
 diff --git a/config/gthr.m4 b/config/gthr.m4
 index 7b29f1f3327c9fdde23f15a507757e6a234cd196..6f61465461d6f70a717eb9205062d5aee7375726 100644
@@ -1702,47 +1702,42 @@ index 0000000000000000000000000000000000000000..d68a3e019fbac94a93a420fcf59476d2
 +#ifdef __cplusplus
 +}
 +#endif
-diff --git a/libgcc/gthr-amigaos.h b/libgcc/gthr-amigaos.h
-new file mode 100644
-index 0000000000000000000000000000000000000000..123d3512abed0a43a8c019bbce0d83f0128a89ec
---- /dev/null
+diff --git a/libgcc/gthr-single.h b/libgcc/gthr-amigaos.h
+similarity index 59%
+copy from libgcc/gthr-single.h
+copy to libgcc/gthr-amigaos.h
+index d8bd5138fa35f0c82fe81a2a7cb80a4e2ecd3d60..123d3512abed0a43a8c019bbce0d83f0128a89ec 100644
+--- a/libgcc/gthr-single.h
 +++ b/libgcc/gthr-amigaos.h
-@@ -0,0 +1,347 @@
-+/* Threads compatibility routines for libgcc2 and libobjc.  */
-+/* Compile this one with gcc.  */
-+/* Copyright (C) 1997-2018 Free Software Foundation, Inc.
-+
-+This file is part of GCC.
-+
-+GCC is free software; you can redistribute it and/or modify it under
-+the terms of the GNU General Public License as published by the Free
-+Software Foundation; either version 3, or (at your option) any later
-+version.
-+
-+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
-+WARRANTY; without even the implied warranty of MERCHANTABILITY or
-+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-+for more details.
-+
-+Under Section 7 of GPL version 3, you are granted additional
-+permissions described in the GCC Runtime Library Exception, version
-+3.1, as published by the Free Software Foundation.
-+
-+You should have received a copy of the GNU General Public License and
-+a copy of the GCC Runtime Library Exception along with this program;
-+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-+<http://www.gnu.org/licenses/>.  */
-+
+@@ -20,31 +20,57 @@ permissions described in the GCC Runtime Library Exception, version
+ 
+ You should have received a copy of the GNU General Public License and
+ a copy of the GCC Runtime Library Exception along with this program;
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-#ifndef GCC_GTHR_SINGLE_H
+-#define GCC_GTHR_SINGLE_H
 +#ifndef GCC_GTHR_AMIGAOS_H
 +#define GCC_GTHR_AMIGAOS_H
-+
+ 
+-/* Just provide compatibility for mutex handling.  */
 +#include <stdlib.h>
 +#include <stdint.h>
-+
+ 
+-typedef int __gthread_key_t;
+-typedef int __gthread_once_t;
+-typedef int __gthread_mutex_t;
+-typedef int __gthread_recursive_mutex_t;
 +typedef struct { int data1, data2; } __gthread_once_t;
-+
+ 
+-#define __GTHREAD_ONCE_INIT 0
+-#define __GTHREAD_MUTEX_INIT 0
+-#define __GTHREAD_MUTEX_INIT_FUNCTION(mx) do {} while (0)
+-#define __GTHREAD_RECURSIVE_MUTEX_INIT 0
 +typedef struct { long unsigned int id; } __gthread_key_t;
-+
+ 
+-#define UNUSED __attribute__((__unused__))
 +/* Should cover at least as much data as the maximum of sizeof(struct SignalSemaphore)
 + * and sizeof(pthread_mutex_t)
 + */
@@ -1770,222 +1765,142 @@ index 0000000000000000000000000000000000000000..123d3512abed0a43a8c019bbce0d83f0
 +extern "C"
 +{
 +#endif
-+
-+#ifdef _LIBOBJC
-+
+ 
+ #ifdef _LIBOBJC
+ 
 +#ifndef UNUSED
 +#define UNUSED __attribute__((__unused__))
 +#define UNUSED_DEFINED
 +#endif
 +
-+/* Thread local storage for a single thread */
-+static void *thread_local_storage = NULL;
-+
-+/* Backend initialization functions */
-+
-+/* Initialize the threads subsystem.  */
-+static inline int
-+__gthread_objc_init_thread_system (void)
-+{
-+  /* No thread support available */
-+  return -1;
-+}
-+
-+/* Close the threads subsystem.  */
-+static inline int
-+__gthread_objc_close_thread_system (void)
-+{
-+  /* No thread support available */
-+  return -1;
-+}
-+
-+/* Backend thread functions */
-+
-+/* Create a new thread of execution.  */
-+static inline objc_thread_t
-+__gthread_objc_thread_detach (void (* func)(void *), void * arg UNUSED)
-+{
-+  /* No thread support available */
-+  return NULL;
-+}
-+
-+/* Set the current thread's priority.  */
-+static inline int
-+__gthread_objc_thread_set_priority (int priority UNUSED)
-+{
-+  /* No thread support available */
-+  return -1;
-+}
-+
-+/* Return the current thread's priority.  */
-+static inline int
-+__gthread_objc_thread_get_priority (void)
-+{
-+  return OBJC_THREAD_INTERACTIVE_PRIORITY;
-+}
-+
-+/* Yield our process time to another thread.  */
-+static inline void
-+__gthread_objc_thread_yield (void)
-+{
-+  return;
-+}
-+
-+/* Terminate the current thread.  */
-+static inline int
-+__gthread_objc_thread_exit (void)
-+{
-+  /* No thread support available */
-+  /* Should we really exit the program */
-+  /* exit (&__objc_thread_exit_status); */
-+  return -1;
-+}
-+
-+/* Returns an integer value which uniquely describes a thread.  */
-+static inline objc_thread_t
-+__gthread_objc_thread_id (void)
-+{
-+  /* No thread support, use 1.  */
-+  return (objc_thread_t) 1;
-+}
-+
-+/* Sets the thread's local storage pointer.  */
-+static inline int
-+__gthread_objc_thread_set_data (void *value)
-+{
-+  thread_local_storage = value;
-+  return 0;
-+}
-+
-+/* Returns the thread's local storage pointer.  */
-+static inline void *
-+__gthread_objc_thread_get_data (void)
-+{
-+  return thread_local_storage;
-+}
-+
-+/* Backend mutex functions */
-+
-+/* Allocate a mutex.  */
-+static inline int
-+__gthread_objc_mutex_allocate (objc_mutex_t mutex UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Deallocate a mutex.  */
-+static inline int
-+__gthread_objc_mutex_deallocate (objc_mutex_t mutex UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Grab a lock on a mutex.  */
-+static inline int
-+__gthread_objc_mutex_lock (objc_mutex_t mutex UNUSED)
-+{
-+  /* There can only be one thread, so we always get the lock */
-+  return 0;
-+}
-+
-+/* Try to grab a lock on a mutex.  */
-+static inline int
-+__gthread_objc_mutex_trylock (objc_mutex_t mutex UNUSED)
-+{
-+  /* There can only be one thread, so we always get the lock */
-+  return 0;
-+}
-+
-+/* Unlock the mutex */
-+static inline int
-+__gthread_objc_mutex_unlock (objc_mutex_t mutex UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Backend condition mutex functions */
-+
-+/* Allocate a condition.  */
-+static inline int
-+__gthread_objc_condition_allocate (objc_condition_t condition UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Deallocate a condition.  */
-+static inline int
-+__gthread_objc_condition_deallocate (objc_condition_t condition UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Wait on the condition */
-+static inline int
-+__gthread_objc_condition_wait (objc_condition_t condition UNUSED,
-+			       objc_mutex_t mutex UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Wake up all threads waiting on this condition.  */
-+static inline int
-+__gthread_objc_condition_broadcast (objc_condition_t condition UNUSED)
-+{
-+  return 0;
-+}
-+
-+/* Wake up one thread waiting on this condition.  */
-+static inline int
-+__gthread_objc_condition_signal (objc_condition_t condition UNUSED)
-+{
-+  return 0;
-+}
-+
+ /* Thread local storage for a single thread */
+ static void *thread_local_storage = NULL;
+ 
+ /* Backend initialization functions */
+ 
+ /* Initialize the threads subsystem.  */
+@@ -202,97 +228,120 @@ __gthread_objc_condition_broadcast (objc_condition_t condition UNUSED)
+ static inline int
+ __gthread_objc_condition_signal (objc_condition_t condition UNUSED)
+ {
+   return 0;
+ }
+ 
 +#ifndef UNUSED_DEFINED
 +#undef UNUSED
 +#endif
 +
-+#else /* _LIBOBJC */
-+
+ #else /* _LIBOBJC */
+ 
+-static inline int
+-__gthread_active_p (void)
+-{
+-  return 0;
+-}
 +int
 +__gthread_active_p (void);
-+
+ 
+-static inline int
+-__gthread_once (__gthread_once_t *__once UNUSED, void (*__func) (void) UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_once (__gthread_once_t *__once, void (*__func) (void));
-+
+ 
+-static inline int UNUSED
+-__gthread_key_create (__gthread_key_t *__key UNUSED, void (*__func) (void *) UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_key_create (__gthread_key_t *__key, void (*destroy) (void *));
-+
+ 
+-static int UNUSED
+-__gthread_key_delete (__gthread_key_t __key UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_key_delete (__gthread_key_t __key);
-+
+ 
+-static inline void *
+-__gthread_getspecific (__gthread_key_t __key UNUSED)
+-{
+-  return 0;
+-}
 +void *
 +__gthread_getspecific (__gthread_key_t __key);
-+
+ 
+-static inline int
+-__gthread_setspecific (__gthread_key_t __key UNUSED, const void *__v UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_setspecific (__gthread_key_t __key, const void *__v);
-+
+ 
+-static inline int
+-__gthread_mutex_destroy (__gthread_mutex_t *__mutex UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_mutex_init (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_mutex_lock (__gthread_mutex_t *__mutex UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_mutex_destroy (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_mutex_trylock (__gthread_mutex_t *__mutex UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_mutex_lock (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_mutex_unlock (__gthread_mutex_t *__mutex UNUSED)
+-{
+-  return 0;
+-}
 +int
 +__gthread_mutex_trylock (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex)
+-{
+-  return __gthread_mutex_lock (__mutex);
+-}
 +int
 +__gthread_mutex_unlock (__gthread_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex)
+-{
+-  return __gthread_mutex_trylock (__mutex);
+-}
 +int
 +__gthread_recursive_mutex_init (__gthread_recursive_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_recursive_mutex_unlock (__gthread_recursive_mutex_t *__mutex)
+-{
+-  return __gthread_mutex_unlock (__mutex);
+-}
 +int
 +__gthread_recursive_mutex_lock (__gthread_recursive_mutex_t *__mutex);
-+
+ 
+-static inline int
+-__gthread_recursive_mutex_destroy (__gthread_recursive_mutex_t *__mutex)
+-{
+-  return __gthread_mutex_destroy (__mutex);
+-}
 +int
 +__gthread_recursive_mutex_trylock (__gthread_recursive_mutex_t *__mutex);
 +
@@ -2047,13 +1962,15 @@ index 0000000000000000000000000000000000000000..123d3512abed0a43a8c019bbce0d83f0
 +int
 +__gthread_recursive_mutex_timedlock (__gthread_recursive_mutex_t *m,
 +                                    const __gthread_time_t *abs_time);
-+
-+#endif /* _LIBOBJC */
-+
+ 
+ #endif /* _LIBOBJC */
+ 
+-#undef UNUSED
 +#ifdef __cplusplus
 +}
 +#endif
-+
+ 
+-#endif /* ! GCC_GTHR_SINGLE_H */
 +#endif /* ! GCC_GTHR_AMIGAOS_H */
 diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
 index f16bfea81cb0c480488d72c73b2edf5c7e6e7a87..45dcf6730020ffae5ae76ae84a88d64530f61c27 100755
@@ -2179,5 +2096,5 @@ index f16bfea81cb0c480488d72c73b2edf5c7e6e7a87..45dcf6730020ffae5ae76ae84a88d645
  template<typename T>
    struct same<T, T>;
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0026-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/8/patches/0026-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,7 +1,7 @@
-From 6546786e0f3699b8663fce5cdb4530615f09e36a Mon Sep 17 00:00:00 2001
+From d76787f616ce352bcdda427ad5c2b7a27b7d3da0 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
-Subject: [PATCH 26/27] Add aregparam attribute for functions for the m68k
+Subject: [PATCH 26/28] Add aregparam attribute for functions for the m68k
  backend.
 
 These can be used to pass arguments to directly named registers.
@@ -278,5 +278,5 @@ index 506fa4e50e76f386d683e42351d38ca2c5e3d661..41baf9fc61c3a6784845ee27a3d5c700
  #define EXIT_IGNORE_STACK 1
  
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0027-Default-to-DWARF-v2.patch
+++ b/gcc/8/patches/0027-Default-to-DWARF-v2.patch
@@ -1,7 +1,7 @@
-From 042381d41925b9ae65f87f64bca778a0e16956e7 Mon Sep 17 00:00:00 2001
+From 986ab690792bea0447ddc69c70b5362c67921cf2 Mon Sep 17 00:00:00 2001
 From: Marcus Comstedt <marcus@mc.pp.se>
 Date: Wed, 31 Jul 2019 22:10:48 +0200
-Subject: [PATCH 27/27] Default to DWARF v2
+Subject: [PATCH 27/28] Default to DWARF v2
 
 ---
  gcc/config/rs6000/amigaos.h | 4 ++++
@@ -29,5 +29,5 @@ index ec0146c4b8c05eb300f8928e475641123c3f5632..a8724d3f3efdfe759565828190426c18
    amigaos_expand_builtin (EXP, TARGET, SUBTARGET, MODE, IGNORE, SUCCESS)
  
 -- 
-2.30.0
+2.34.1
 

--- a/gcc/8/patches/0028-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/8/patches/0028-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,0 +1,267 @@
+From db6c0a5d97a77c30a28a30a12e58c3b1bd340fbc Mon Sep 17 00:00:00 2001
+From: rjd <3246251196ryan@gmail.com>
+Date: Thu, 25 Jan 2024 20:40:13 +0000
+Subject: [PATCH 28/28] Provide clib4 as an additional C runtime library.
+
+As well as the existing newlib and clib2 as C runtime library choices,
+clib4 is now introduced.
+---
+ gcc/config/rs6000/amigaos.h           | 43 ++++++++++++++++++++-------
+ gcc/config/rs6000/t-amigaos           |  2 ++
+ libstdc++-v3/configure                | 15 ++++++++++
+ libstdc++-v3/crossconfig.m4           | 12 ++++++++
+ libstdc++-v3/include/c_global/cstdlib |  4 +--
+ 5 files changed, 64 insertions(+), 12 deletions(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index a8724d3f3efdfe759565828190426c180fc3a1ec..85a2ed847e30fc01dac6dd94508cdce44c622e26 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -111,12 +111,17 @@
+       else if (IS_MCRT("clib2") || IS_MCRT("clib2-ts")) \
+         {					\
+           builtin_define_std ("CLIB2");		\
+           if (IS_MCRT("clib2-ts"))		\
+             builtin_define ("__THREAD_SAFE");	\
+         }					\
++      else if (IS_MCRT("clib4"))		\
++        {					\
++          builtin_define_std ("CLIB4");		\
++          builtin_define ("CLIB4");		\
++        }					\
+       else if (IS_MCRT("ixemul"))		\
+         {					\
+           builtin_define_std ("ixemul");	\
+           builtin_define_std ("IXEMUL");	\
+         }					\
+       else if (IS_MCRT("libnix"))		\
+@@ -155,28 +160,18 @@
+ #undef REAL_LIBGCC_SPEC
+ #define REAL_LIBGCC_SPEC "\
+ %{static|static-libgcc: %{!use-dynld: -lgcc -lgcc_eh} %{use-dynld: -lgcc} }%{!static:%{!static-libgcc:%{!shared:%{!shared-libgcc: %{!use-dynld: -lgcc -lgcc_eh} %{use-dynld: -lgcc}}%{shared-libgcc:-lgcc}}%{shared:%{shared-libgcc:-lgcc}%{!shared-libgcc:-lgcc}}}}"
+ 
+ 
+ /* make newlib the default */
+-#if 1
+ #define CPP_AMIGA_DEFAULT_SPEC "%{mcrt=default|!mcrt=*:%<mcrt=default -mcrt=newlib} %(cpp_newlib)"
+ #define LINK_AMIGA_DEFAULT_SPEC "%(link_newlib)"
+ #define STARTFILE_AMIGA_DEFAULT_SPEC "%(startfile_newlib)"
+ #define ENDFILE_AMIGA_DEFAULT_SPEC "%(endfile_newlib)"
+ #undef MULTILIB_DEFAULTS
+ #define MULTILIB_DEFAULTS {"mcrt=newlib"}
+-#else
+-/* make clib2 the default */
+-#define CPP_AMIGA_DEFAULT_SPEC "%{mcrt=default|!mcrt=*:%<mcrt=default -mcrt=clib2} %(cpp_clib2)"
+-#define LINK_AMIGA_DEFAULT_SPEC "%(link_clib2)"
+-#define STARTFILE_AMIGA_DEFAULT_SPEC "%(startfile_clib2)"
+-#define ENDFILE_AMIGA_DEFAULT_SPEC "%(endfile_clib2)"
+-#undef MULTILIB_DEFAULTS
+-#define MULTILIB_DEFAULTS {"mcrt=clib2"}
+-#endif
+ 
+ 
+ /* For specifying the include system paths, we generally use -idirafter so the include
+  * paths are added at the end of the gcc default include paths. This is required for
+  * fixincludes and libstdc++ to work properly
+  */
+@@ -201,12 +196,30 @@
+                  "%{!msoft-float:%(lib_subdir_type)}/crt0.o"
+ 
+ #define ENDFILE_CLIB2_SPEC "\
+ %(base_sdk)clib2/%{mcrt=clib2-ts:lib.threadsafe; :lib}" \
+                  "%{!msoft-float:%(lib_subdir_type)}/crtend.o"
+ 
++/* clib4 */
++
++#define CPP_CLIB4_SPEC "\
++-idirafter %(base_sdk)clib4/include -idirafter %(base_sdk)local/clib4/include"
++
++#define LIB_SUBDIR_CLIB4_SPEC "lib%(lib_subdir_type)"
++
++#define LINK_CLIB4_SPEC "\
++-L%(base_sdk)clib4/%(lib_subdir_clib4) \
++-L%(base_gcc)lib/gcc/ppc-amigaos/%(version)/clib4/lib%(lib_subdir_type) \
++-L%(base_sdk)local/clib4/%(lib_subdir_clib4)"
++
++#define STARTFILE_CLIB4_SPEC "\
++%{shared: %(base_sdk)clib4/%(lib_subdir_clib4)/shcrtbegin.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crtbegin.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crt0.o}"
++
++#define ENDFILE_CLIB4_SPEC "\
++%{shared: %(base_sdk)clib4/%(lib_subdir_clib4)/shcrtend.o} %{!shared: %(base_sdk)clib4/%(lib_subdir_clib4)/crtend.o}"
++
+ /* ixemul */
+ 
+ #define CPP_IXEMUL_SPEC "\
+ -idirafter %(base_sdk)ixemul/include -idirafter %(base_sdk)local/ixemul/include"
+ 
+ #define LIB_SUBDIR_IXEMUL_SPEC "lib%(lib_subdir_type)"
+@@ -256,12 +269,13 @@
+ 
+ /* End clib specific */
+ 
+ #undef CPP_OS_DEFAULT_SPEC
+ #define CPP_OS_DEFAULT_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(cpp_clib2); \
++mcrt=clib4: %(cpp_clib4); \
+ mcrt=ixemul: %(cpp_ixemul); \
+ mcrt=libnix: %(cpp_libnix); \
+ mcrt=newlib: %(cpp_newlib); \
+ mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
+ : %eInvalid C runtime library} \
+ %{!nostdinc: -idirafter %(base_sdk)include/include_h -idirafter %(base_sdk)include/netinclude -idirafter %(base_sdk)local/common/include} \
+@@ -275,12 +289,13 @@ mcrt=default|!mcrt=*: %{mcrt=default|!nostdinc: %(cpp_amiga_default)}; \
+ -q -d %{h*} %{v:-V} %{G*} \
+ %{Wl,*:%*} %{YP,*} %{R*} \
+ %{Qy:} %{!Qn:-Qy} \
+ %(link_thread) %(link_shlib) %(link_text) \
+ %{mbaserel: %{msdata|msdata=default|msdata=sysv: %e-mbaserel and -msdata options are incompatible}} \
+ %{mcrt=clib2|mcrt=clib2-ts: %(link_clib2); \
++mcrt=clib4: %(link_clib4); \
+ mcrt=ixemul: %(link_ixemul); \
+ mcrt=libnix: %(link_libnix); \
+ mcrt=newlib: %(link_newlib); \
+ mcrt=default|!mcrt=*: %(link_amiga_default); \
+ : %eInvalid C runtime library} \
+ -L%(base_sdk)local/common/lib%(lib_subdir_type) \
+@@ -300,21 +315,23 @@ mcrt=default|!mcrt=*: %(link_amiga_default); \
+ #define LINK_THREAD "\
+ %s%{athread=native:gthr-amigaos-native.o;athread=single:gthr-amigaos-single.o;athread=pthread:gthr-amigaos-pthread.o}"
+ 
+ #undef STARTFILE_SPEC
+ #define STARTFILE_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(startfile_clib2); \
++mcrt=clib4: %(startfile_clib4); \
+ mcrt=ixemul: %(startfile_ixemul); \
+ mcrt=libnix: %(startfile_libnix); \
+ mcrt=newlib: %(startfile_newlib); \
+ mcrt=default|!mcrt=*: %(startfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+ #undef ENDFILE_SPEC
+ #define ENDFILE_SPEC "\
+ %{mcrt=clib2|mcrt=clib2-ts: %(endfile_clib2); \
++mcrt=clib4: %(endfile_clib4); \
+ mcrt=ixemul: %(endfile_ixemul); \
+ mcrt=libnix: %(endfile_libnix); \
+ mcrt=newlib: %(endfile_newlib); \
+ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+@@ -339,12 +356,18 @@ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+   /* clib2 */ \
+   {"cpp_clib2", CPP_CLIB2_SPEC}, \
+   {"lib_subdir_clib2", LIB_SUBDIR_CLIB2_SPEC}, \
+   {"link_clib2", LINK_CLIB2_SPEC}, \
+   {"startfile_clib2", STARTFILE_CLIB2_SPEC}, \
+   {"endfile_clib2", ENDFILE_CLIB2_SPEC}, \
++  /* clib4 */ \
++  {"cpp_clib4", CPP_CLIB4_SPEC}, \
++  {"lib_subdir_clib4", LIB_SUBDIR_CLIB4_SPEC}, \
++  {"link_clib4", LINK_CLIB4_SPEC}, \
++  {"startfile_clib4", STARTFILE_CLIB4_SPEC}, \
++  {"endfile_clib4", ENDFILE_CLIB4_SPEC}, \
+   /* ixemul */ \
+   {"cpp_ixemul", CPP_IXEMUL_SPEC}, \
+   {"lib_subdir_ixemul", LIB_SUBDIR_IXEMUL_SPEC}, \
+   {"link_ixemul", LINK_IXEMUL_SPEC}, \
+   {"startfile_ixemul", STARTFILE_IXEMUL_SPEC}, \
+   {"endfile_ixemul", ENDFILE_IXEMUL_SPEC}, \
+diff --git a/gcc/config/rs6000/t-amigaos b/gcc/config/rs6000/t-amigaos
+index 15d9d3fd5a5f0c8109cd158242745fa52b19257e..cc191ee3e23145800183d5ec14dea18cc45f19b2 100644
+--- a/gcc/config/rs6000/t-amigaos
++++ b/gcc/config/rs6000/t-amigaos
+@@ -14,7 +14,9 @@ NATIVE_SYSTEM_HEADER_DIR=/gcc/include
+ 
+ # Build the libraries for both newlib and clib2
+ # We do not build soft float flavours as none of the
+ # libs support soft floats
+ MULTILIB_OPTIONS = mcrt=newlib/mcrt=clib2
+ MULTILIB_DIRNAMES = newlib clib2
++MULTILIB_OPTIONS = mcrt=newlib/mcrt=clib2/mcrt=clib4
++MULTILIB_DIRNAMES = newlib clib2 clib4
+ #MULTILIB_REUSE = =mcrt=newlib
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 45dcf6730020ffae5ae76ae84a88d64530f61c27..78de77933209145dddaa8a918acf75c953dd1571 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -78699,12 +78699,27 @@ $as_echo "$ac_ld_relro" >&6; }
+     OPT_LDFLAGS="-Wl,-O1 $OPT_LDFLAGS"
+   fi
+ 
+ 
+ 
+ 
++
++
++     for ac_func in acosf asinf atan2f atanf ceilf cosf coshf expf fabsf floorf fmodf frexpf sqrtf hypotf ldexpf log10f logf modff powf sinf sinhf tanf tanhf fabsl acosl asinl atanl atan2l ceill cosl coshl expl floorl fmodl frexpl sqrtl hypotl ldexpl logl log10l modfl powl sinl sinhl tanl tanhl
++do :
++  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
++ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
++if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
++  cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
++_ACEOF
++
++fi
++done
++
++
+     ;;
+   *)
+     as_fn_error "No support for this host/target combination." "$LINENO" 5
+    ;;
+ esac
+ 
+diff --git a/libstdc++-v3/crossconfig.m4 b/libstdc++-v3/crossconfig.m4
+index 6a6c0d6b16128ddb7cdb66799e0fbb64fe873d37..23608cae00f33cf6144d433c489e8d8cfa67a78b 100644
+--- a/libstdc++-v3/crossconfig.m4
++++ b/libstdc++-v3/crossconfig.m4
+@@ -295,12 +295,24 @@ case "${host}" in
+     AC_CHECK_HEADERS([nan.h ieeefp.h endian.h sys/isa_defs.h \
+       machine/endian.h machine/param.h sys/machine.h sys/types.h \
+       fp.h locale.h float.h inttypes.h])
+     SECTION_FLAGS='-ffunction-sections -fdata-sections'
+     AC_SUBST(SECTION_FLAGS)
+     GLIBCXX_CHECK_LINKER_FEATURES
++
++dnl # Although we are cross compiling for Amiga, we already built the
++dnl # first stage compiler: the compiler without any libraries such as
++dnl # libstdc++. This means that we DO have access to AC_CHECK_FUNCS
++dnl # as all the CRTs have been built and installed at the point of
++dnl # running the configure file for libstdc++-v3.
++dnl #
++dnl # Adding checks here:
++
++dnl #
++    AC_CHECK_FUNCS(acosf asinf atan2f atanf ceilf cosf coshf expf fabsf floorf fmodf frexpf sqrtf hypotf ldexpf log10f logf modff powf sinf sinhf tanf tanhf fabsl acosl asinl atanl atan2l ceill cosl coshl expl floorl fmodl frexpl sqrtl hypotl ldexpl logl log10l modfl powl sinl sinhl tanl tanhl)
++
+     ;;
+   *)
+     AC_MSG_ERROR([No support for this host/target combination.])
+    ;;
+ esac
+ ])
+diff --git a/libstdc++-v3/include/c_global/cstdlib b/libstdc++-v3/include/c_global/cstdlib
+index fb5ae1889b288097f793396f35a9b65c2acf9fbb..4975c6070fbf120a0061dab496918566ef7b1d70 100644
+--- a/libstdc++-v3/include/c_global/cstdlib
++++ b/libstdc++-v3/include/c_global/cstdlib
+@@ -188,14 +188,14 @@ _GLIBCXX_END_NAMESPACE_VERSION
+ #undef lldiv
+ #undef atoll
+ #undef strtoll
+ #undef strtoull
+ #undef strtof
+ 
+-/* Neigther clib2 nor newlib offers strtoud() */
+-#ifndef __amigaos4__
++/* clib2 and newlib do not provide an implementation of strtold */
++#if !defined (__amigaos4__) || defined(__CLIB4__)
+ #undef strtold
+ #endif
+ 
+ namespace __gnu_cxx _GLIBCXX_VISIBILITY(default)
+ {
+ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+-- 
+2.34.1
+

--- a/native-build/makefile
+++ b/native-build/makefile
@@ -84,7 +84,7 @@ COREUTILS_VERSION=5.2.1
 DIST_VERSION=$(shell date +%Y%m%d)-$(shell git rev-list --count HEAD)
 
 # Set up the necessary variables for the CLIBs
-CLIB4_SUPPORT=$(filter 11 6,$(GCC_BRANCH_NAME))
+CLIB4_SUPPORT=$(filter 11 8 6,$(GCC_BRANCH_NAME))
 CLIB4_URL=https://github.com/AmigaLabs/clib4
 CLIB4_DIR=downloads/clib4/
 CLIB4_RELEASE_ARCHIVE_NAME=adtools-os4-clib4-$(DIST_VERSION).lha


### PR DESCRIPTION
As well as the existing newlib and clib2 as C runtime library choices, clib4 is now introduced. Support for clib4 is currently restricted to GCC version 11, 8 and 6.