### PR TITLE
Allow option -pthread to link to libpthread

### DIFF
--- a/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
 From a065f15c8bb17b6717633ef513e4c2f12f152499 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/38] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/39] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |   1 +

--- a/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
 From 5901f8aec0e2f6a0f826903cd483cc1b10f63aeb Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/38] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/39] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions

--- a/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
 From 07718db105d776cff50b4cd8102132c88ea7c002 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/38] Disable .machine directive generation.
+Subject: [PATCH 03/39] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.

--- a/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From f7398a949dd5201e983c7d8188d497e548112123 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/38] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/39] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---

--- a/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
 From e6ec2d752903863da6dcf190e18c73e346b6b253 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/38] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/39] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---

--- a/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
 From a01c2a5ac436a00b931a0146cf802f69127c2884 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/38] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/39] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().

--- a/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
 From 6c249f64bd2d0ebf30f51531484ea1742962ee12 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/38] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/39] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---

--- a/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From b5b5a3209f4fc3c59198b392b728576612a85f78 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/38] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/39] Added libstc++ support for AmigaOS.
 
 ---
  .../os/{generic => amigaos}/ctype_base.h      |  2 +-

--- a/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,7 +1,7 @@
 From c9fb3357d886c3e9561e008b9087c9b75caef37d Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 09/38] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 09/39] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---

--- a/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,7 +1,7 @@
 From 33102a20e983d901be1859333d922cb32459d2b2 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
-Subject: [PATCH 10/38] Implement libat_lock_n() and libat_unlock_n().
+Subject: [PATCH 10/39] Implement libat_lock_n() and libat_unlock_n().
 
 ---
  libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++-------

--- a/gcc/11/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/11/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
 From 60505eb8b49c04957f3e1122484b5e2297f19c8e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/38] Pretend C99 compatibility.
+Subject: [PATCH 11/39] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses

--- a/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
 From 75d527aeab41195aa6161eb90ab1c75fb39692ac Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/38] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/39] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-

--- a/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
 From f5d04240570843fd4419cd0d9ce6f9aa50609145 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/38] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/39] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------

--- a/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
 From 6a98220e936165ce6238e071fcfda1277ef80392 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/38] Add custom implementation of various env-related
+Subject: [PATCH 14/39] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.

--- a/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
 From 8982a14a86f101333989f8b8959d031209e2401a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/38] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/39] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.

--- a/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
 From a5b8eb192677e48f84822bc15c20ba8975b5fad5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/38] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/39] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---

--- a/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
 From dd595e5c58180a1ad9e8572bf17dd5cfbfabf789 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/38] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/39] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +

--- a/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
 From c64cc31006520260c4a23cc23799442e28402415 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/38] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/39] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---

--- a/gcc/11/patches/0019-Add-_Static_warning.patch
+++ b/gcc/11/patches/0019-Add-_Static_warning.patch
@@ -1,7 +1,7 @@
 From 7e5ea9debe2babeb92ebd4e6d081599ea8441004 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
-Subject: [PATCH 19/38] Add _Static_warning().
+Subject: [PATCH 19/39] Add _Static_warning().
 
 This acts very similar to _Static_assert() but produces a warning
 rather than an compiler error.

--- a/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
+++ b/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
@@ -1,7 +1,7 @@
 From c0a70959ea598b7004bb62e22b42443e090788b4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
-Subject: [PATCH 20/38] Rename lineartags to checktags.
+Subject: [PATCH 20/39] Rename lineartags to checktags.
 
 The name lineartags would imply linearvarargs but this is not implemented
 or necessary.

--- a/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,7 +1,7 @@
 From 4257f6d9961b0a9e583bf71f8cabcceb92ca44d3 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
-Subject: [PATCH 21/38] Fix order of AmigaOS PPC sections in the documentation.
+Subject: [PATCH 21/39] Fix order of AmigaOS PPC sections in the documentation.
 
 ---
  gcc/doc/extend.texi |  4 ++--

--- a/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,7 +1,7 @@
 From 4cb533514851a1840dea1ce9d8e20884b45f53e1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
-Subject: [PATCH 22/38] Provide a documentation for checktags and tagtype
+Subject: [PATCH 22/39] Provide a documentation for checktags and tagtype
  attributes.
 
 ---

--- a/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From ab20508a3cdea818bb37195cea6d2e960b32e8d7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
-Subject: [PATCH 23/38] Adapt libssp for AmigaOS.
+Subject: [PATCH 23/39] Adapt libssp for AmigaOS.
 
 ---
  libssp/ssp.c | 8 +++++---

--- a/gcc/11/patches/0024-Add-amigaos-thread-model.patch
+++ b/gcc/11/patches/0024-Add-amigaos-thread-model.patch
@@ -1,7 +1,7 @@
 From 1a726f2c22094261ab929462bc51bd250f82e3c4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
-Subject: [PATCH 24/38] Add amigaos thread model.
+Subject: [PATCH 24/39] Add amigaos thread model.
 
 It is work in progress.
 ---

--- a/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,7 +1,7 @@
 From 32df36c00d3b7244a206c14d8318d67065a75e26 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
-Subject: [PATCH 25/38] Add aregparam attribute for functions for the m68k
+Subject: [PATCH 25/39] Add aregparam attribute for functions for the m68k
  backend.
 
 These can be used to pass arguments to directly named registers.

--- a/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
+++ b/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
@@ -1,7 +1,7 @@
 From 28c0ba8817d98c02e3eaeb4e1f9f0186ff221efe Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:22:55 +0100
-Subject: [PATCH 26/38] gcc10: Don't use poisoned define.
+Subject: [PATCH 26/39] gcc10: Don't use poisoned define.
 
 ---
  gcc/config/rs6000/amigaos.h | 3 ---

--- a/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
+++ b/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
@@ -1,7 +1,7 @@
 From afab86a678caaa9ac9a9c3c3c20f403d751acebf Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:25:51 +0100
-Subject: [PATCH 27/38] gcc10: Remove unused variable.
+Subject: [PATCH 27/39] gcc10: Remove unused variable.
 
 ---
  gcc/c/c-parser.c | 3 ---

--- a/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
+++ b/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
@@ -1,7 +1,7 @@
 From 20b1fd8b7d74b36d7da722bcef98356fea03ec1f Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:05:59 +0100
-Subject: [PATCH 28/38] gcc10: Remove tagtype attribute.
+Subject: [PATCH 28/39] gcc10: Remove tagtype attribute.
 
 The 'Add tagtype attribute that can be passed to enum' patch needs
 to be adapted. Temporarily disable the patch since adaptation requires

--- a/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
+++ b/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
@@ -1,7 +1,7 @@
 From 266f38251b6aa1c7fd3b8429d2d2b95d0c577f5c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:07:45 +0100
-Subject: [PATCH 29/38] gcc10: Define CC1_SPEC.
+Subject: [PATCH 29/39] gcc10: Define CC1_SPEC.
 
 ---
  gcc/config/rs6000/amigaos.h | 13 +++++++++++++

--- a/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
+++ b/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
@@ -1,7 +1,7 @@
 From 0fe8d761ed5446ed3c7ca431659958b2498ee613 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 01:02:33 +0100
-Subject: [PATCH 30/38] gcc10: Link lto-dump with -athread=native.
+Subject: [PATCH 30/39] gcc10: Link lto-dump with -athread=native.
 
 ---
  gcc/config/rs6000/x-amigaos | 3 ++-

--- a/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
+++ b/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
@@ -1,7 +1,7 @@
 From f55c00ae21292b68738143bbf275ef30e94b7efe Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 14:03:50 +0100
-Subject: [PATCH 31/38] gcc10: Expose max_align_t when using clib2.
+Subject: [PATCH 31/39] gcc10: Expose max_align_t when using clib2.
 
 ---
  libstdc++-v3/include/c_global/cstddef | 3 ---

--- a/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
+++ b/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
@@ -1,7 +1,7 @@
 From 0c74121b54a3b0c55ede757302dd13f6728d560d Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sun, 7 Feb 2021 19:38:47 +0100
-Subject: [PATCH 32/38] gcc10: Don't define __STRICT_ANSI__.
+Subject: [PATCH 32/39] gcc10: Don't define __STRICT_ANSI__.
 
 Doing so hides C99 features when configuring libstdc++.
 ---

--- a/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
+++ b/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
@@ -1,7 +1,7 @@
 From c3443778d66979c2734bb02baf24c14b979e7326 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Mon, 15 Mar 2021 15:55:11 +0100
-Subject: [PATCH 33/38] gcc10: Fix libstdc++v3 paths.
+Subject: [PATCH 33/39] gcc10: Fix libstdc++v3 paths.
 
 ---
  libstdc++-v3/src/c++17/fs_ops.cc  |  17 ++++-

--- a/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
+++ b/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
@@ -1,7 +1,7 @@
 From 0b5fd31f94a96acd4b83b34be52e2915982494fc Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:21:55 +0200
-Subject: [PATCH 34/38] gcc11: Include stdint.h when sys/mman.h is missing.
+Subject: [PATCH 34/39] gcc11: Include stdint.h when sys/mman.h is missing.
 
 Since sys/mman.h indirectly includes stdint.h, we need to explicitly
 include stdint.h when sys/mman.h is missing.

--- a/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
+++ b/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
@@ -1,7 +1,7 @@
 From 57cdd99bfe45740a2021212005227a089eb5921c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:27:59 +0200
-Subject: [PATCH 35/38] gcc11: Use include_next to circumvent fenv.h include
+Subject: [PATCH 35/39] gcc11: Use include_next to circumvent fenv.h include
  guard.
 
 Include guards will prevent the correct fenv.h to be included

--- a/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
+++ b/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
@@ -1,7 +1,7 @@
 From c99b141102f736198f6c013f5e58946ccc6d3b95 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 5 Oct 2022 11:36:32 +0100
-Subject: [PATCH 36/38] gcc11: Fix to exception raised by Callable in call_once
+Subject: [PATCH 36/39] gcc11: Fix to exception raised by Callable in call_once
  implementation.
 
 In the case the Callable raises an exception, the shared resources between

--- a/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
+++ b/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
@@ -1,7 +1,7 @@
 From 80cd06ee17ebac85775c82d8b884de7ead35f169 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ola=20S=C3=B6der?= <rolfkopman@gmail.com>
 Date: Sun, 9 Apr 2023 22:34:16 +0200
-Subject: [PATCH 37/38] gcc11: Add builtin _AMIGA define.
+Subject: [PATCH 37/39] gcc11: Add builtin _AMIGA define.
 
 Define _AMIGA like on AROS, MorphOS and OS3 (SAS/C).
 ---

--- a/gcc/11/patches/0038-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/11/patches/0038-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,7 +1,7 @@
 From 874a7d09eb853fe6b5e959a0e60e28636b3f0269 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Thu, 23 Nov 2023 22:12:35 +0000
-Subject: [PATCH 38/38] Provide clib4 as an additional C runtime library.
+Subject: [PATCH 38/39] Provide clib4 as an additional C runtime library.
 
 As well as the existing newlib and clib2 as C runtime library choices,
 clib4 is now introduced. Support for clib4 is currently restricted to

--- a/gcc/11/patches/0039-Allow-option-pthread-to-link-to-libpthread.patch
+++ b/gcc/11/patches/0039-Allow-option-pthread-to-link-to-libpthread.patch
@@ -1,0 +1,52 @@
+From 77656b2f9fe825950b6c399466b0e80d7fa0c723 Mon Sep 17 00:00:00 2001
+From: rjd <3246251196ryan@gmail.com>
+Date: Tue, 14 May 2024 17:54:10 +0100
+Subject: [PATCH 39/39] Allow option -pthread to link to libpthread
+
+---
+ gcc/config/rs6000/amigaos.h   | 2 +-
+ gcc/config/rs6000/amigaos.opt | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index f92526783393a0ac40d0ea9c08ab932c7f472744..497a792ff41c8ecbaa2a5c02d8d5fd4ad3df7887 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -345,13 +345,13 @@ mcrt=libnix: %(endfile_libnix); \
+ mcrt=newlib: %(endfile_newlib); \
+ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+ #undef LIB_SPEC
+ #define LIB_SPEC "\
+---start-group -lc --end-group"
++--start-group %{pthread:-lpthread} -lc --end-group"
+ 
+ #undef TARGET_DEFAULT
+ #define TARGET_DEFAULT 0
+ 
+ #undef SUBTARGET_EXTRA_SPECS
+ #define SUBTARGET_EXTRA_SPECS \
+diff --git a/gcc/config/rs6000/amigaos.opt b/gcc/config/rs6000/amigaos.opt
+index 73107b5ad79109bdb095f7ca0eaee5e725d2f8fc..771caa087fed837124cf2436b800df15d16735c3 100644
+--- a/gcc/config/rs6000/amigaos.opt
++++ b/gcc/config/rs6000/amigaos.opt
+@@ -29,12 +29,15 @@ Target Mask(BASEREL)
+ Generate base relative data access
+ 
+ mcheck68kfuncptr
+ Target Var(CHECK68KFUNCPTR)
+ Generate target checking for function pointers
+ 
++pthread
++Driver. Will link with -lpthread and nothing more
++
+ use-dynld
+ Target Driver
+ Generated binary employs the dynamic linker for shared objects.
+ 
+ Enum
+ Name(athread) Type(int) UnknownError(argument %qs to %<-athread%> not recognized)
+-- 
+2.34.1
+

--- a/gcc/6/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/6/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
 From fb1fbc56ecf4c107fb138577d8aa135ed2ed80f6 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/19] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/20] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |    1 +

--- a/gcc/6/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/6/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
 From 091ebe485044d027b393b067505e9dfc35c12267 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/19] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/20] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions

--- a/gcc/6/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/6/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
 From 3bfa44553e3aa11ca27cc5a6fa2f1f5270c01a89 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/19] Disable .machine directive generation.
+Subject: [PATCH 03/20] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.

--- a/gcc/6/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/6/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 8032a07ba466421f9376f7e0bca8c692464063ae Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/19] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/20] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---

--- a/gcc/6/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/6/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
 From 170b394977e6ae18a504573e299ac290a0c58441 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/19] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/20] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---

--- a/gcc/6/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/6/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
 From a008069e551d9658ebd5d166a1569f102dadea4a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/19] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/20] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().

--- a/gcc/6/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/6/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
 From 35669b2c7f84f356af24dfbab6040214e22497c0 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/19] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/20] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---

--- a/gcc/6/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/6/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 8e344c7495f38559c4ab23692f86fc7a78ee551a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/19] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/20] Added libstc++ support for AmigaOS.
 
 ---
  .../config/os/{generic => amigaos}/ctype_base.h     |  2 +-

--- a/gcc/6/patches/0009-Added-e500-support-for-AmigaOS.patch
+++ b/gcc/6/patches/0009-Added-e500-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 3fbaae9e66b5a962272be8f453b2e128e67a1a28 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Mon, 30 Jan 2017 20:49:17 +0100
-Subject: [PATCH 09/19] Added e500 support for AmigaOS.
+Subject: [PATCH 09/20] Added e500 support for AmigaOS.
 
 ---
  gcc/config.gcc | 2 +-

--- a/gcc/6/patches/0010-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/6/patches/0010-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,7 +1,7 @@
 From 9b444e7541cbc72562cee7a8e1795a250d10d613 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 10/19] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 10/20] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---

--- a/gcc/6/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/6/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
 From 03161dccf14e031ceb5c62241bb62ce232c6e94c Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/19] Pretend C99 compatibility.
+Subject: [PATCH 11/20] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses

--- a/gcc/6/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/6/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
 From 0cce69f2c07f7cb47daeeaddc02ca2de2afddc25 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/19] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/20] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-

--- a/gcc/6/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/6/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
 From a9933b944a4d65e33075614bb35a00ad5328a435 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/19] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/20] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------

--- a/gcc/6/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/6/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
 From 50341f21238fed7b02599edbcecc0b2b62a20a1a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/19] Add custom implementation of various env-related
+Subject: [PATCH 14/20] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.

--- a/gcc/6/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/6/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
 From 60f42e29046983ae4ffbc9a759e2a871d013dc92 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/19] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/20] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.

--- a/gcc/6/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/6/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
 From db84bd50e70189be71612ff6baf32371703ce129 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/19] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/20] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---

--- a/gcc/6/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/6/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
 From 3208b1057c63dfebd82fdbe25784742c92888491 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/19] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/20] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +

--- a/gcc/6/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/6/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
 From a8c9e108ae1743f3451691f0506db40a1e5a1360 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/19] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/20] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---

--- a/gcc/6/patches/0019-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/6/patches/0019-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,7 +1,7 @@
 From 74d90b4683ab3248fe2f3ee1154fe552a6d4f4a8 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Fri, 12 Jan 2024 00:15:23 +0000
-Subject: [PATCH 19/19] Provide clib4 as an additional C runtime library.
+Subject: [PATCH 19/20] Provide clib4 as an additional C runtime library.
 
 As well as the existing newlib and clib2 as C runtime library choices,
 clib4 is now introduced.

--- a/gcc/6/patches/0020-Allow-option-pthread-to-link-to-libpthread.patch
+++ b/gcc/6/patches/0020-Allow-option-pthread-to-link-to-libpthread.patch
@@ -1,0 +1,49 @@
+From f69786f7865fa309edb8a6f8d82c967e4e305c09 Mon Sep 17 00:00:00 2001
+From: rjd <3246251196ryan@gmail.com>
+Date: Wed, 15 May 2024 23:56:46 +0100
+Subject: [PATCH 20/20] Allow option -pthread to link to libpthread
+
+---
+ gcc/config/rs6000/amigaos.h   | 2 +-
+ gcc/config/rs6000/amigaos.opt | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index 51ac3583c76b8c0edcd8a2ab606fa0066adcc080..a212fbcd749337840cb529fb7d8d4f1e16f9ab2e 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -331,13 +331,13 @@ mcrt=libnix: %(endfile_libnix); \
+ mcrt=newlib: %(endfile_newlib); \
+ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+ #undef LIB_SPEC
+ #define LIB_SPEC "\
+---start-group -lc --end-group"
++--start-group %{pthread:-lpthread} -lc --end-group"
+ 
+ #undef TARGET_DEFAULT
+ #define TARGET_DEFAULT 0
+ 
+ #undef SUBTARGET_EXTRA_SPECS
+ #define SUBTARGET_EXTRA_SPECS \
+diff --git a/gcc/config/rs6000/amigaos.opt b/gcc/config/rs6000/amigaos.opt
+index 93d74f10bea8c1b23c82a9650bb0c3c153464ba7..2c4dcf7c76e8195a6712a92a3b2a501cc63bfe40 100644
+--- a/gcc/config/rs6000/amigaos.opt
++++ b/gcc/config/rs6000/amigaos.opt
+@@ -29,9 +29,12 @@ Target Report Mask(BASEREL)
+ Generate base relative data access
+ 
+ mcheck68kfuncptr
+ Target Report Var(CHECK68KFUNCPTR)
+ Generate target checking for function pointers
+ 
++pthread
++Driver. Will link with -lpthread and nothing more
++
+ use-dynld
+ Target Driver
+ Generated binary employs the dynamic linker for shared objects.
+-- 
+2.34.1
+

--- a/gcc/8/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/8/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
 From 6f3b0c228b2122d1f601ed71a53185476b0cc3bb Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/28] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/29] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |    1 +

--- a/gcc/8/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/8/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
 From c5f2a43b7ae028a95f5744d76583035fd0171cf1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/28] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/29] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions

--- a/gcc/8/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/8/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
 From d801914b78606622e63d6ed0aedff816f9d67622 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/28] Disable .machine directive generation.
+Subject: [PATCH 03/29] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.

--- a/gcc/8/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/8/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 19c459b4d1347b83a56893212fbb6886102df2a5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/28] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/29] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---

--- a/gcc/8/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/8/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
 From c28e3674877c0aede0c36e9288a0287d157df936 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/28] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/29] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---

--- a/gcc/8/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/8/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
 From 38789b3a6ff9d8a04aa7a27e88bbe6e244c81d2f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/28] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/29] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().

--- a/gcc/8/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/8/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
 From 6c50d0f39edd65987c4bfb486e54e0f9498e3a3f Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/28] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/29] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---

--- a/gcc/8/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/8/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 04b87b3ca37f1a9de987637f5b223c27c5aaa579 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/28] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/29] Added libstc++ support for AmigaOS.
 
 ---
  .../os/{generic => amigaos}/ctype_base.h      |  2 +-

--- a/gcc/8/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/8/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,7 +1,7 @@
 From 6b2502ad3148594cbc85b03cbf3d85ce82c70af7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 09/28] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 09/29] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---

--- a/gcc/8/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/8/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,7 +1,7 @@
 From f362a8d33be22d7c5900e1f1638f9ab94af27f00 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
-Subject: [PATCH 10/28] Implement libat_lock_n() and libat_unlock_n().
+Subject: [PATCH 10/29] Implement libat_lock_n() and libat_unlock_n().
 
 ---
  libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++-------

--- a/gcc/8/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/8/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
 From 1642447c593cb4cedf838c2ec9beb9ccc23ca4b1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/28] Pretend C99 compatibility.
+Subject: [PATCH 11/29] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses

--- a/gcc/8/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/8/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
 From 19e51805acfc5d157291e6c06505f941468b71ab Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/28] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/29] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-

--- a/gcc/8/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/8/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
 From 769a4d2d12464d18e5ba73edf60192b93f9109fe Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/28] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/29] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------

--- a/gcc/8/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/8/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
 From e0055474bff8049f1174df7fc973ad76595020c1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/28] Add custom implementation of various env-related
+Subject: [PATCH 14/29] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.

--- a/gcc/8/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/8/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
 From db892f6d9841605af36b1dddbbe613249c877e84 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/28] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/29] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.

--- a/gcc/8/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/8/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
 From e6011ca854253df1900ce2753f2545d5f1618be3 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/28] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/29] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---

--- a/gcc/8/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/8/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
 From 37ef8f1a54b2e94e21b61a3aa0e8a5eb58d7d7e5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/28] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/29] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +

--- a/gcc/8/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/8/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
 From d5b814e021f21663e8c1cd8426e7e2cb3beb5758 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/28] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/29] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---

--- a/gcc/8/patches/0019-Add-_Static_warning.patch
+++ b/gcc/8/patches/0019-Add-_Static_warning.patch
@@ -1,7 +1,7 @@
 From 910c7fb66f34cdecda82a751bfd4dba22bd3a880 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
-Subject: [PATCH 19/28] Add _Static_warning().
+Subject: [PATCH 19/29] Add _Static_warning().
 
 This acts very similar to _Static_assert() but produces a warning
 rather than an compiler error.

--- a/gcc/8/patches/0020-Add-tagtype-attribute-that-can-be-passed-to-enum-con.patch
+++ b/gcc/8/patches/0020-Add-tagtype-attribute-that-can-be-passed-to-enum-con.patch
@@ -1,7 +1,7 @@
 From ba0ed10ad3f956059ca727e838bc1644856a8fe1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 06:29:13 +0200
-Subject: [PATCH 20/28] Add tagtype attribute that can be passed to enum
+Subject: [PATCH 20/29] Add tagtype attribute that can be passed to enum
  constants.
 
 The tagtype attribute can be applied to enum constants in order to annotate

--- a/gcc/8/patches/0021-Rename-lineartags-to-checktags.patch
+++ b/gcc/8/patches/0021-Rename-lineartags-to-checktags.patch
@@ -1,7 +1,7 @@
 From a4c043211aec7a771350a521604b950a9a7deef7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
-Subject: [PATCH 21/28] Rename lineartags to checktags.
+Subject: [PATCH 21/29] Rename lineartags to checktags.
 
 The name lineartags would imply linearvarargs but this is not implemented
 or necessary.

--- a/gcc/8/patches/0022-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/8/patches/0022-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,7 +1,7 @@
 From 11acd3eca6b03f6f64ab0386ec5d176f656a7bbc Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
-Subject: [PATCH 22/28] Fix order of AmigaOS PPC sections in the documentation.
+Subject: [PATCH 22/29] Fix order of AmigaOS PPC sections in the documentation.
 
 ---
  gcc/doc/invoke.texi | 264 ++++++++++++++++++++++----------------------

--- a/gcc/8/patches/0023-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/8/patches/0023-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,7 +1,7 @@
 From 75b58899e792be1e0be50f87ee79726017b9f53a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
-Subject: [PATCH 23/28] Provide a documentation for checktags and tagtype
+Subject: [PATCH 23/29] Provide a documentation for checktags and tagtype
  attributes.
 
 ---

--- a/gcc/8/patches/0024-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/8/patches/0024-Adapt-libssp-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From 71f5c7753432b362aaa76aacc64dddd9273929cc Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
-Subject: [PATCH 24/28] Adapt libssp for AmigaOS.
+Subject: [PATCH 24/29] Adapt libssp for AmigaOS.
 
 ---
  libssp/ssp.c | 8 +++++---

--- a/gcc/8/patches/0025-Add-amigaos-thread-model.patch
+++ b/gcc/8/patches/0025-Add-amigaos-thread-model.patch
@@ -1,7 +1,7 @@
 From 3843dff1665663e20881f12dbab9f402a55591b9 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
-Subject: [PATCH 25/28] Add amigaos thread model.
+Subject: [PATCH 25/29] Add amigaos thread model.
 
 It is work in progress.
 ---

--- a/gcc/8/patches/0026-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/8/patches/0026-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,7 +1,7 @@
 From d76787f616ce352bcdda427ad5c2b7a27b7d3da0 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
-Subject: [PATCH 26/28] Add aregparam attribute for functions for the m68k
+Subject: [PATCH 26/29] Add aregparam attribute for functions for the m68k
  backend.
 
 These can be used to pass arguments to directly named registers.

--- a/gcc/8/patches/0027-Default-to-DWARF-v2.patch
+++ b/gcc/8/patches/0027-Default-to-DWARF-v2.patch
@@ -1,7 +1,7 @@
 From 986ab690792bea0447ddc69c70b5362c67921cf2 Mon Sep 17 00:00:00 2001
 From: Marcus Comstedt <marcus@mc.pp.se>
 Date: Wed, 31 Jul 2019 22:10:48 +0200
-Subject: [PATCH 27/28] Default to DWARF v2
+Subject: [PATCH 27/29] Default to DWARF v2
 
 ---
  gcc/config/rs6000/amigaos.h | 4 ++++

--- a/gcc/8/patches/0028-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/8/patches/0028-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,7 +1,7 @@
 From db6c0a5d97a77c30a28a30a12e58c3b1bd340fbc Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Thu, 25 Jan 2024 20:40:13 +0000
-Subject: [PATCH 28/28] Provide clib4 as an additional C runtime library.
+Subject: [PATCH 28/29] Provide clib4 as an additional C runtime library.
 
 As well as the existing newlib and clib2 as C runtime library choices,
 clib4 is now introduced.

--- a/gcc/8/patches/0029-Allow-option-pthread-to-link-to-libpthread.patch
+++ b/gcc/8/patches/0029-Allow-option-pthread-to-link-to-libpthread.patch
@@ -1,0 +1,52 @@
+From 1aa95d994f4de69667e276c8557365eaeb957d04 Mon Sep 17 00:00:00 2001
+From: rjd <3246251196ryan@gmail.com>
+Date: Wed, 15 May 2024 19:20:02 +0100
+Subject: [PATCH 29/29] Allow option -pthread to link to libpthread
+
+---
+ gcc/config/rs6000/amigaos.h   | 2 +-
+ gcc/config/rs6000/amigaos.opt | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index 85a2ed847e30fc01dac6dd94508cdce44c622e26..2c9eb4fbc48c6d1fe0c267a43305f3301814ebf4 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -334,13 +334,13 @@ mcrt=libnix: %(endfile_libnix); \
+ mcrt=newlib: %(endfile_newlib); \
+ mcrt=default|!mcrt=*: %(endfile_amiga_default); \
+ : %eInvalid C runtime library}"
+ 
+ #undef LIB_SPEC
+ #define LIB_SPEC "\
+---start-group -lc --end-group"
++--start-group %{pthread:-lpthread} -lc --end-group"
+ 
+ #undef TARGET_DEFAULT
+ #define TARGET_DEFAULT 0
+ 
+ #undef SUBTARGET_EXTRA_SPECS
+ #define SUBTARGET_EXTRA_SPECS \
+diff --git a/gcc/config/rs6000/amigaos.opt b/gcc/config/rs6000/amigaos.opt
+index 1980ef231d7f849309ce24062d41992e01d77288..19c2b703c4ef69ddf7aec6f04502d1dda9e29ae7 100644
+--- a/gcc/config/rs6000/amigaos.opt
++++ b/gcc/config/rs6000/amigaos.opt
+@@ -29,12 +29,15 @@ Target Report Mask(BASEREL)
+ Generate base relative data access
+ 
+ mcheck68kfuncptr
+ Target Report Var(CHECK68KFUNCPTR)
+ Generate target checking for function pointers
+ 
++pthread
++Driver. Will link with -lpthread and nothing more
++
+ use-dynld
+ Target Driver
+ Generated binary employs the dynamic linker for shared objects.
+ 
+ Enum
+ Name(athread) Type(int) UnknownError(argument %qs to %<-athread%> not recognized)
+-- 
+2.34.1
+

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -13,5 +13,7 @@
 /test-thread-direct
 /test-thread.d
 /test-thread.o
+/test-pthread-option
 /test-tls
 /test-wchar
+/test-call-once

--- a/tests/makefile
+++ b/tests/makefile
@@ -12,7 +12,8 @@ TESTS = \
 	test-lineartags.o \
 	test-std-string \
 	test-thread \
-	test-wchar
+	test-wchar \
+	test-pthread-option
 
 all: $(TESTS)
 
@@ -38,6 +39,9 @@ test-thread-direct: test-thread.cpp ../gcc/repo/libgcc/gthr-amigaos-native.c
 
 test-wchar: test-wchar.cpp
 	$(CPP) test-wchar.cpp -std=c++11 -mcrt=clib2 -o $@ -H
+
+test-pthread-option: test-pthread-option.c
+	$(CC) -o $@ $< -pthread -mcrt=clib4
 
 test-tls: test-tls.cpp
 	$(CPP) -g $< -o $@ ../gcc/repo/libgcc/gthr-amigaos-native.c -Wl,--cref -Wl,-M=$@.map

--- a/tests/test-pthread-option.c
+++ b/tests/test-pthread-option.c
@@ -1,0 +1,57 @@
+#include <pthread.h> // for pthread_create, pthread_join, pthread_exit
+#include <stdio.h>   // for printf
+#include <stdlib.h>  // for exit
+
+#define NITER 100000
+
+void *Count(void *a);
+
+int cnt = 0;
+
+void *Count(void *a)
+{
+    int i, tmp;
+    for (i = 0; i < NITER; i++)
+    {
+        tmp = cnt;     /* copy the global cnt locally */
+        tmp = tmp + 1; /* increment the local copy */
+        cnt = tmp;     /* store the local value into the global cnt */
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    pthread_t tid1, tid2;
+
+    if (pthread_create(&tid1, NULL, Count, NULL))
+    {
+        printf("\n ERROR creating thread 1");
+        exit(1);
+    }
+
+    if (pthread_create(&tid2, NULL, Count, NULL))
+    {
+        printf("\n ERROR creating thread 2");
+        exit(1);
+    }
+
+    if (pthread_join(tid1, NULL)) /* wait for the thread 1 to finish */
+    {
+        printf("\n ERROR joining thread");
+        exit(1);
+    }
+
+    if (pthread_join(tid2, NULL)) /* wait for the thread 2 to finish */
+    {
+        printf("\n ERROR joining thread");
+        exit(1);
+    }
+
+    if (cnt < 2 * NITER)
+        printf("\n BOOM! cnt is [%d], should be %d\n", cnt, 2 * NITER);
+    else
+        printf("\n OK! cnt is [%d]\n", cnt);
+
+    pthread_exit(NULL);
+    return 0;
+}


### PR DESCRIPTION
Request to allow the -pthread option to be recognised by the Amiga cross compiler. It will perform _as if_ -lpthread was used.