### PR TITLE
Brings up to date the GCC11 amigaos.h ASM_CPU_SPEC

### DIFF
--- a/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
+++ b/gcc/11/patches/0001-Changes-for-AmigaOS-version-of-gcc.patch
@@ -1,7 +1,7 @@
 From a065f15c8bb17b6717633ef513e4c2f12f152499 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Feb 2015 20:25:55 +0100
-Subject: [PATCH 01/39] Changes for AmigaOS version of gcc.
+Subject: [PATCH 01/40] Changes for AmigaOS version of gcc.
 
 ---
  fixincludes/configure                 |   1 +

--- a/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
+++ b/gcc/11/patches/0002-Added-new-function-attribute-lineartags-and-pragma-a.patch
@@ -1,7 +1,7 @@
 From 5901f8aec0e2f6a0f826903cd483cc1b10f63aeb Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 14 Nov 2014 20:03:56 +0100
-Subject: [PATCH 02/39] Added new function attribute "lineartags" and pragma
+Subject: [PATCH 02/40] Added new function attribute "lineartags" and pragma
  "amigaos tagtype".
 
 Functions that have the lineartags attribute are assumed to be functions

--- a/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
+++ b/gcc/11/patches/0003-Disable-.machine-directive-generation.patch
@@ -1,7 +1,7 @@
 From 07718db105d776cff50b4cd8102132c88ea7c002 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 9 Jul 2015 06:54:37 +0200
-Subject: [PATCH 03/39] Disable .machine directive generation.
+Subject: [PATCH 03/40] Disable .machine directive generation.
 
 It breaks manual args to the assembler with different flavor,
 e.g., -Wa,-m440. This is probably not the right fix.

--- a/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
+++ b/gcc/11/patches/0004-The-default-link-mode-is-static-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From f7398a949dd5201e983c7d8188d497e548112123 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 20:56:33 +0100
-Subject: [PATCH 04/39] The default link mode is static for AmigaOS.
+Subject: [PATCH 04/40] The default link mode is static for AmigaOS.
 
 Changed the g++ driver to reflect this.
 ---

--- a/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
+++ b/gcc/11/patches/0005-Disable-the-usage-of-dev-urandom-when-compiling-for-.patch
@@ -1,7 +1,7 @@
 From e6ec2d752903863da6dcf190e18c73e346b6b253 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 2 Dec 2015 21:39:42 +0100
-Subject: [PATCH 05/39] Disable the usage of /dev/urandom when compiling for
+Subject: [PATCH 05/40] Disable the usage of /dev/urandom when compiling for
  AmigaOS.
 
 ---

--- a/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
+++ b/gcc/11/patches/0006-Expand-arg-zero-on-AmigaOS-using-the-PROGDIR-assign.patch
@@ -1,7 +1,7 @@
 From a01c2a5ac436a00b931a0146cf802f69127c2884 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 5 Dec 2015 13:17:26 +0100
-Subject: [PATCH 06/39] Expand arg zero on AmigaOS using the PROGDIR: assign.
+Subject: [PATCH 06/40] Expand arg zero on AmigaOS using the PROGDIR: assign.
 
 This should make sure that the proper relative paths are computed during
 process_command().

--- a/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
+++ b/gcc/11/patches/0007-Some-AmigaOS-4.x-compability-changes-for-posix-threa.patch
@@ -1,7 +1,7 @@
 From 6c249f64bd2d0ebf30f51531484ea1742962ee12 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 21 Jan 2016 20:46:59 +0100
-Subject: [PATCH 07/39] Some AmigaOS 4.x compability changes for posix thread
+Subject: [PATCH 07/40] Some AmigaOS 4.x compability changes for posix thread
  support.
 
 ---

--- a/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
+++ b/gcc/11/patches/0008-Added-libstc-support-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From b5b5a3209f4fc3c59198b392b728576612a85f78 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 22 Jan 2016 20:04:50 +0100
-Subject: [PATCH 08/39] Added libstc++ support for AmigaOS.
+Subject: [PATCH 08/40] Added libstc++ support for AmigaOS.
 
 ---
  .../os/{generic => amigaos}/ctype_base.h      |  2 +-

--- a/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
+++ b/gcc/11/patches/0009-Enable-libatomic-for-ppc-amigaos.patch
@@ -1,7 +1,7 @@
 From c9fb3357d886c3e9561e008b9087c9b75caef37d Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 3 Mar 2017 08:52:48 +0100
-Subject: [PATCH 09/39] Enable libatomic for ppc-amigaos.
+Subject: [PATCH 09/40] Enable libatomic for ppc-amigaos.
 
 It is not really finished yet.
 ---

--- a/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
+++ b/gcc/11/patches/0010-Implement-libat_lock_n-and-libat_unlock_n.patch
@@ -1,7 +1,7 @@
 From 33102a20e983d901be1859333d922cb32459d2b2 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 23 May 2018 10:54:19 +0200
-Subject: [PATCH 10/39] Implement libat_lock_n() and libat_unlock_n().
+Subject: [PATCH 10/40] Implement libat_lock_n() and libat_unlock_n().
 
 ---
  libatomic/config/amigaos/lock.c | 58 ++++++++++++++++++++++++++-------

--- a/gcc/11/patches/0011-Pretend-C99-compatibility.patch
+++ b/gcc/11/patches/0011-Pretend-C99-compatibility.patch
@@ -1,7 +1,7 @@
 From 60505eb8b49c04957f3e1122484b5e2297f19c8e Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 4 Mar 2017 07:39:21 +0100
-Subject: [PATCH 11/39] Pretend C99 compatibility.
+Subject: [PATCH 11/40] Pretend C99 compatibility.
 
 At least newlib is not fully C99 compatible because it doesn't expose
 various C99 function if __STRICT_ANSI__ is declared. Also it misses

--- a/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
+++ b/gcc/11/patches/0012-Add-amigaos-stdint.h-for-libatomic.patch
@@ -1,7 +1,7 @@
 From 75d527aeab41195aa6161eb90ab1c75fb39692ac Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 3 Apr 2018 19:52:01 +0200
-Subject: [PATCH 12/39] Add amigaos-stdint.h for libatomic.
+Subject: [PATCH 12/40] Add amigaos-stdint.h for libatomic.
 
 ---
  gcc/config.gcc                                      | 2 +-

--- a/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
+++ b/gcc/11/patches/0013-Rerun-make-maint-deps-in-libiberty.patch
@@ -1,7 +1,7 @@
 From f5d04240570843fd4419cd0d9ce6f9aa50609145 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 22:48:33 +0200
-Subject: [PATCH 13/39] Rerun make maint-deps in libiberty.
+Subject: [PATCH 13/40] Rerun make maint-deps in libiberty.
 
 ---
  libiberty/Makefile.in | 36 ++++++++++++++++++++++--------------

--- a/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
+++ b/gcc/11/patches/0014-Add-custom-implementation-of-various-env-related-fun.patch
@@ -1,7 +1,7 @@
 From 6a98220e936165ce6238e071fcfda1277ef80392 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Wed, 4 Apr 2018 23:50:48 +0200
-Subject: [PATCH 14/39] Add custom implementation of various env-related
+Subject: [PATCH 14/40] Add custom implementation of various env-related
  functions.
 
 No official clib does support unsetenv() but this is required by newer gcc.

--- a/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
+++ b/gcc/11/patches/0015-Define-va_startlinear-and-va_getlinearva.patch
@@ -1,7 +1,7 @@
 From 8982a14a86f101333989f8b8959d031209e2401a Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 5 Apr 2018 19:56:45 +0200
-Subject: [PATCH 15/39] Define va_startlinear and va_getlinearva.
+Subject: [PATCH 15/40] Define va_startlinear and va_getlinearva.
 
 These were usually defined in the clibs' stdarg.h. As we have now
 changed the include path order, clibs' stdarg.h is never included.

--- a/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
+++ b/gcc/11/patches/0016-Fix-r2-restoring-in-the-epilog-of-baserel-restoring-.patch
@@ -1,7 +1,7 @@
 From a5b8eb192677e48f84822bc15c20ba8975b5fad5 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 17 Apr 2018 22:02:09 +0200
-Subject: [PATCH 16/39] Fix r2 restoring in the epilog of baserel-restoring
+Subject: [PATCH 16/40] Fix r2 restoring in the epilog of baserel-restoring
  functions.
 
 ---

--- a/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
+++ b/gcc/11/patches/0017-Avoid-section-anchors-in-the-baserel-mode.patch
@@ -1,7 +1,7 @@
 From dd595e5c58180a1ad9e8572bf17dd5cfbfabf789 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Thu, 19 Apr 2018 21:00:30 +0200
-Subject: [PATCH 17/39] Avoid section anchors in the baserel mode.
+Subject: [PATCH 17/40] Avoid section anchors in the baserel mode.
 
 ---
  gcc/config/rs6000/amigaos-protos.h |  1 +

--- a/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
+++ b/gcc/11/patches/0018-Respect-nostdinc-also-for-SDK-includes.patch
@@ -1,7 +1,7 @@
 From c64cc31006520260c4a23cc23799442e28402415 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 20 Apr 2018 20:04:30 +0200
-Subject: [PATCH 18/39] Respect -nostdinc also for SDK includes.
+Subject: [PATCH 18/40] Respect -nostdinc also for SDK includes.
 
 ---
  gcc/config/rs6000/amigaos.h | 4 +---

--- a/gcc/11/patches/0019-Add-_Static_warning.patch
+++ b/gcc/11/patches/0019-Add-_Static_warning.patch
@@ -1,7 +1,7 @@
 From 7e5ea9debe2babeb92ebd4e6d081599ea8441004 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 24 Apr 2018 22:46:21 +0200
-Subject: [PATCH 19/39] Add _Static_warning().
+Subject: [PATCH 19/40] Add _Static_warning().
 
 This acts very similar to _Static_assert() but produces a warning
 rather than an compiler error.

--- a/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
+++ b/gcc/11/patches/0020-Rename-lineartags-to-checktags.patch
@@ -1,7 +1,7 @@
 From c0a70959ea598b7004bb62e22b42443e090788b4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 27 Apr 2018 22:48:18 +0200
-Subject: [PATCH 20/39] Rename lineartags to checktags.
+Subject: [PATCH 20/40] Rename lineartags to checktags.
 
 The name lineartags would imply linearvarargs but this is not implemented
 or necessary.

--- a/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
+++ b/gcc/11/patches/0021-Fix-order-of-AmigaOS-PPC-sections-in-the-documentati.patch
@@ -1,7 +1,7 @@
 From 4257f6d9961b0a9e583bf71f8cabcceb92ca44d3 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 28 Apr 2018 08:09:58 +0200
-Subject: [PATCH 21/39] Fix order of AmigaOS PPC sections in the documentation.
+Subject: [PATCH 21/40] Fix order of AmigaOS PPC sections in the documentation.
 
 ---
  gcc/doc/extend.texi |  4 ++--

--- a/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
+++ b/gcc/11/patches/0022-Provide-a-documentation-for-checktags-and-tagtype-at.patch
@@ -1,7 +1,7 @@
 From 4cb533514851a1840dea1ce9d8e20884b45f53e1 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sun, 29 Apr 2018 00:08:22 +0200
-Subject: [PATCH 22/39] Provide a documentation for checktags and tagtype
+Subject: [PATCH 22/40] Provide a documentation for checktags and tagtype
  attributes.
 
 ---

--- a/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
+++ b/gcc/11/patches/0023-Adapt-libssp-for-AmigaOS.patch
@@ -1,7 +1,7 @@
 From ab20508a3cdea818bb37195cea6d2e960b32e8d7 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Tue, 22 May 2018 23:14:01 +0200
-Subject: [PATCH 23/39] Adapt libssp for AmigaOS.
+Subject: [PATCH 23/40] Adapt libssp for AmigaOS.
 
 ---
  libssp/ssp.c | 8 +++++---

--- a/gcc/11/patches/0024-Add-amigaos-thread-model.patch
+++ b/gcc/11/patches/0024-Add-amigaos-thread-model.patch
@@ -1,7 +1,7 @@
 From 1a726f2c22094261ab929462bc51bd250f82e3c4 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Fri, 4 May 2018 18:22:24 +0200
-Subject: [PATCH 24/39] Add amigaos thread model.
+Subject: [PATCH 24/40] Add amigaos thread model.
 
 It is work in progress.
 ---

--- a/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
+++ b/gcc/11/patches/0025-Add-aregparam-attribute-for-functions-for-the-m68k-b.patch
@@ -1,7 +1,7 @@
 From 32df36c00d3b7244a206c14d8318d67065a75e26 Mon Sep 17 00:00:00 2001
 From: Sebastian Bauer <mail@sebastianbauer.info>
 Date: Sat, 27 Oct 2018 08:06:21 +0200
-Subject: [PATCH 25/39] Add aregparam attribute for functions for the m68k
+Subject: [PATCH 25/40] Add aregparam attribute for functions for the m68k
  backend.
 
 These can be used to pass arguments to directly named registers.

--- a/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
+++ b/gcc/11/patches/0026-gcc10-Don-t-use-poisoned-define.patch
@@ -1,7 +1,7 @@
 From 28c0ba8817d98c02e3eaeb4e1f9f0186ff221efe Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:22:55 +0100
-Subject: [PATCH 26/39] gcc10: Don't use poisoned define.
+Subject: [PATCH 26/40] gcc10: Don't use poisoned define.
 
 ---
  gcc/config/rs6000/amigaos.h | 3 ---

--- a/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
+++ b/gcc/11/patches/0027-gcc10-Remove-unused-variable.patch
@@ -1,7 +1,7 @@
 From afab86a678caaa9ac9a9c3c3c20f403d751acebf Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 17:25:51 +0100
-Subject: [PATCH 27/39] gcc10: Remove unused variable.
+Subject: [PATCH 27/40] gcc10: Remove unused variable.
 
 ---
  gcc/c/c-parser.c | 3 ---

--- a/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
+++ b/gcc/11/patches/0028-gcc10-Remove-tagtype-attribute.patch
@@ -1,7 +1,7 @@
 From 20b1fd8b7d74b36d7da722bcef98356fea03ec1f Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:05:59 +0100
-Subject: [PATCH 28/39] gcc10: Remove tagtype attribute.
+Subject: [PATCH 28/40] gcc10: Remove tagtype attribute.
 
 The 'Add tagtype attribute that can be passed to enum' patch needs
 to be adapted. Temporarily disable the patch since adaptation requires

--- a/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
+++ b/gcc/11/patches/0029-gcc10-Define-CC1_SPEC.patch
@@ -1,7 +1,7 @@
 From 266f38251b6aa1c7fd3b8429d2d2b95d0c577f5c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sat, 2 Jan 2021 22:07:45 +0100
-Subject: [PATCH 29/39] gcc10: Define CC1_SPEC.
+Subject: [PATCH 29/40] gcc10: Define CC1_SPEC.
 
 ---
  gcc/config/rs6000/amigaos.h | 13 +++++++++++++

--- a/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
+++ b/gcc/11/patches/0030-gcc10-Link-lto-dump-with-athread-native.patch
@@ -1,7 +1,7 @@
 From 0fe8d761ed5446ed3c7ca431659958b2498ee613 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 01:02:33 +0100
-Subject: [PATCH 30/39] gcc10: Link lto-dump with -athread=native.
+Subject: [PATCH 30/40] gcc10: Link lto-dump with -athread=native.
 
 ---
  gcc/config/rs6000/x-amigaos | 3 ++-

--- a/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
+++ b/gcc/11/patches/0031-gcc10-Expose-max_align_t-when-using-clib2.patch
@@ -1,7 +1,7 @@
 From f55c00ae21292b68738143bbf275ef30e94b7efe Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 8 Jan 2021 14:03:50 +0100
-Subject: [PATCH 31/39] gcc10: Expose max_align_t when using clib2.
+Subject: [PATCH 31/40] gcc10: Expose max_align_t when using clib2.
 
 ---
  libstdc++-v3/include/c_global/cstddef | 3 ---

--- a/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
+++ b/gcc/11/patches/0032-gcc10-Don-t-define-__STRICT_ANSI__.patch
@@ -1,7 +1,7 @@
 From 0c74121b54a3b0c55ede757302dd13f6728d560d Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Sun, 7 Feb 2021 19:38:47 +0100
-Subject: [PATCH 32/39] gcc10: Don't define __STRICT_ANSI__.
+Subject: [PATCH 32/40] gcc10: Don't define __STRICT_ANSI__.
 
 Doing so hides C99 features when configuring libstdc++.
 ---

--- a/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
+++ b/gcc/11/patches/0033-gcc10-Fix-libstdc-v3-paths.patch
@@ -1,7 +1,7 @@
 From c3443778d66979c2734bb02baf24c14b979e7326 Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Mon, 15 Mar 2021 15:55:11 +0100
-Subject: [PATCH 33/39] gcc10: Fix libstdc++v3 paths.
+Subject: [PATCH 33/40] gcc10: Fix libstdc++v3 paths.
 
 ---
  libstdc++-v3/src/c++17/fs_ops.cc  |  17 ++++-

--- a/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
+++ b/gcc/11/patches/0034-gcc11-Include-stdint.h-when-sys-mman.h-is-missing.patch
@@ -1,7 +1,7 @@
 From 0b5fd31f94a96acd4b83b34be52e2915982494fc Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:21:55 +0200
-Subject: [PATCH 34/39] gcc11: Include stdint.h when sys/mman.h is missing.
+Subject: [PATCH 34/40] gcc11: Include stdint.h when sys/mman.h is missing.
 
 Since sys/mman.h indirectly includes stdint.h, we need to explicitly
 include stdint.h when sys/mman.h is missing.

--- a/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
+++ b/gcc/11/patches/0035-gcc11-Use-include_next-to-circumvent-fenv.h-include-.patch
@@ -1,7 +1,7 @@
 From 57cdd99bfe45740a2021212005227a089eb5921c Mon Sep 17 00:00:00 2001
 From: "ola.soder@axis.com" <ola.soder@axis.com>
 Date: Fri, 28 May 2021 16:27:59 +0200
-Subject: [PATCH 35/39] gcc11: Use include_next to circumvent fenv.h include
+Subject: [PATCH 35/40] gcc11: Use include_next to circumvent fenv.h include
  guard.
 
 Include guards will prevent the correct fenv.h to be included

--- a/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
+++ b/gcc/11/patches/0036-gcc11-Fix-to-exception-raised-by-Callable-in-call_on.patch
@@ -1,7 +1,7 @@
 From c99b141102f736198f6c013f5e58946ccc6d3b95 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Wed, 5 Oct 2022 11:36:32 +0100
-Subject: [PATCH 36/39] gcc11: Fix to exception raised by Callable in call_once
+Subject: [PATCH 36/40] gcc11: Fix to exception raised by Callable in call_once
  implementation.
 
 In the case the Callable raises an exception, the shared resources between

--- a/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
+++ b/gcc/11/patches/0037-gcc11-Add-builtin-_AMIGA-define.patch
@@ -1,7 +1,7 @@
 From 80cd06ee17ebac85775c82d8b884de7ead35f169 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ola=20S=C3=B6der?= <rolfkopman@gmail.com>
 Date: Sun, 9 Apr 2023 22:34:16 +0200
-Subject: [PATCH 37/39] gcc11: Add builtin _AMIGA define.
+Subject: [PATCH 37/40] gcc11: Add builtin _AMIGA define.
 
 Define _AMIGA like on AROS, MorphOS and OS3 (SAS/C).
 ---

--- a/gcc/11/patches/0038-Provide-clib4-as-an-additional-C-runtime-library.patch
+++ b/gcc/11/patches/0038-Provide-clib4-as-an-additional-C-runtime-library.patch
@@ -1,7 +1,7 @@
 From 874a7d09eb853fe6b5e959a0e60e28636b3f0269 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Thu, 23 Nov 2023 22:12:35 +0000
-Subject: [PATCH 38/39] Provide clib4 as an additional C runtime library.
+Subject: [PATCH 38/40] Provide clib4 as an additional C runtime library.
 
 As well as the existing newlib and clib2 as C runtime library choices,
 clib4 is now introduced. Support for clib4 is currently restricted to

--- a/gcc/11/patches/0039-Allow-option-pthread-to-link-to-libpthread.patch
+++ b/gcc/11/patches/0039-Allow-option-pthread-to-link-to-libpthread.patch
@@ -1,7 +1,7 @@
 From 77656b2f9fe825950b6c399466b0e80d7fa0c723 Mon Sep 17 00:00:00 2001
 From: rjd <3246251196ryan@gmail.com>
 Date: Tue, 14 May 2024 17:54:10 +0100
-Subject: [PATCH 39/39] Allow option -pthread to link to libpthread
+Subject: [PATCH 39/40] Allow option -pthread to link to libpthread
 
 ---
  gcc/config/rs6000/amigaos.h   | 2 +-

--- a/gcc/11/patches/0040-gcc11-Updated-the-amigaos.h-ASM_CPU_SPEC.patch
+++ b/gcc/11/patches/0040-gcc11-Updated-the-amigaos.h-ASM_CPU_SPEC.patch
@@ -1,0 +1,143 @@
+From 0b85334ced2cdf972f806b7f0815ef0e95286dbc Mon Sep 17 00:00:00 2001
+From: rjd <3246251196ryan@gmail.com>
+Date: Sat, 10 Aug 2024 12:10:46 +0100
+Subject: [PATCH 40/40] gcc11: Updated the amigaos.h ASM_CPU_SPEC
+
+---
+ gcc/config/rs6000/amigaos.h | 114 ++++++++++++++++++++----------------
+ 1 file changed, 64 insertions(+), 50 deletions(-)
+
+diff --git a/gcc/config/rs6000/amigaos.h b/gcc/config/rs6000/amigaos.h
+index 497a792ff41c8ecbaa2a5c02d8d5fd4ad3df7887..3b6ed87d82a4f7fa51ac0dd866241b0b5f25abf4 100644
+--- a/gcc/config/rs6000/amigaos.h
++++ b/gcc/config/rs6000/amigaos.h
+@@ -28,62 +28,76 @@
+ 
+ #undef DEFAULT_ABI
+ #define DEFAULT_ABI ABI_V4
+ 
+ #undef ASM_CPU_SPEC
+ #define ASM_CPU_SPEC \
+-"%{!mcpu*: \
+-  %{mpower: %{!mpower2: -mpwr}} \
+-  %{mpower2: -mpwrx} \
+-  %{mpowerpc64*: -mppc64} \
+-  %{!mpowerpc64*: %{mpowerpc*: -mppc}} \
+-  %{mno-power: %{!mpowerpc*: -mcom}} \
+-  %{!mno-power: %{!mpower*: %(asm_default)}}} \
+-%{mcpu=common: -mcom} \
+-%{mcpu=power: -mpwr} \
+-%{mcpu=power2: -mpwrx} \
+-%{mcpu=power3: -mppc64} \
+-%{mcpu=power4: -mpower4} \
+-%{mcpu=power5: -mpower4} \
+-%{mcpu=powerpc: -mppc} \
+-%{mcpu=rios: -mpwr} \
+-%{mcpu=rios1: -mpwr} \
+-%{mcpu=rios2: -mpwrx} \
+-%{mcpu=rsc: -mpwr} \
+-%{mcpu=rsc1: -mpwr} \
+-%{mcpu=rs64a: -mppc64} \
+-%{mcpu=401: -mppc} \
+-%{mcpu=403: -m403} \
+-%{mcpu=405: -m405} \
+-%{mcpu=405fp: -m405} \
+-%{mcpu=440: -m440} \
+-%{mcpu=440fp: -m440} \
+-%{mcpu=505: -mppc} \
+-%{mcpu=601: -m601} \
+-%{mcpu=602: -mppc} \
+-%{mcpu=603: -mppc} \
+-%{mcpu=603e: -mppc} \
+-%{mcpu=ec603e: -mppc} \
+-%{mcpu=604: -mppc} \
+-%{mcpu=604e: -mppc} \
+-%{mcpu=620: -mppc64} \
+-%{mcpu=630: -mppc64} \
+-%{mcpu=740: -mppc} \
+-%{mcpu=750: -mppc} \
+-%{mcpu=G3: -mppc} \
+-%{mcpu=7400: -mppc -maltivec} \
+-%{mcpu=7450: -mppc -maltivec} \
+-%{mcpu=G4: -mppc -maltivec} \
+-%{mcpu=801: -mppc} \
+-%{mcpu=821: -mppc} \
+-%{mcpu=823: -mppc} \
+-%{mcpu=860: -mppc} \
+-%{mcpu=970: -mpower4 -maltivec} \
+-%{mcpu=G5: -mpower4 -maltivec} \
+-%{mcpu=8540: -me500} \
+-%{maltivec: -maltivec}"
++"%{mcpu=native: %(asm_cpu_native); \
++  mcpu=power10: -mpower10; \
++  mcpu=power9: -mpower9; \
++  mcpu=power8|mcpu=powerpc64le: %{mpower9-vector: -mpower9;: -mpower8}; \
++  mcpu=power7: -mpower7; \
++  mcpu=power6x: -mpower6 %{!mvsx:%{!maltivec:-maltivec}}; \
++  mcpu=power6: -mpower6 %{!mvsx:%{!maltivec:-maltivec}}; \
++  mcpu=power5+: -mpower5; \
++  mcpu=power5: -mpower5; \
++  mcpu=power4: -mpower4; \
++  mcpu=power3: -mppc64; \
++  mcpu=powerpc: -mppc; \
++  mcpu=powerpc64: -mppc64; \
++  mcpu=a2: -ma2; \
++  mcpu=cell: -mcell; \
++  mcpu=rs64: -mppc64; \
++  mcpu=401: -mppc; \
++  mcpu=403: -m403; \
++  mcpu=405: -m405; \
++  mcpu=405fp: -m405; \
++  mcpu=440: -m440; \
++  mcpu=440fp: -m440; \
++  mcpu=464: -m440; \
++  mcpu=464fp: -m440; \
++  mcpu=476: -m476; \
++  mcpu=476fp: -m476; \
++  mcpu=505: -mppc; \
++  mcpu=601: -m601; \
++  mcpu=602: -mppc; \
++  mcpu=603: -mppc; \
++  mcpu=603e: -mppc; \
++  mcpu=ec603e: -mppc; \
++  mcpu=604: -mppc; \
++  mcpu=604e: -mppc; \
++  mcpu=620: -mppc64; \
++  mcpu=630: -mppc64; \
++  mcpu=740: -mppc; \
++  mcpu=750: -mppc; \
++  mcpu=G3: -mppc; \
++  mcpu=7400: -mppc %{!mvsx:%{!maltivec:-maltivec}}; \
++  mcpu=7450: -mppc %{!mvsx:%{!maltivec:-maltivec}}; \
++  mcpu=G4: -mppc %{!mvsx:%{!maltivec:-maltivec}}; \
++  mcpu=801: -mppc; \
++  mcpu=821: -mppc; \
++  mcpu=823: -mppc; \
++  mcpu=860: -mppc; \
++  mcpu=970: -mpower4 %{!mvsx:%{!maltivec:-maltivec}}; \
++  mcpu=G5: -mpower4 %{!mvsx:%{!maltivec:-maltivec}}; \
++  mcpu=8540: -me500; \
++  mcpu=8548: -me500; \
++  mcpu=e300c2: -me300; \
++  mcpu=e300c3: -me300; \
++  mcpu=e500mc: -me500mc; \
++  mcpu=e500mc64: -me500mc64; \
++  mcpu=e5500: -me5500; \
++  mcpu=e6500: -me6500; \
++  mcpu=titan: -mtitan; \
++  !mcpu*: %{mpower9-vector: -mpower9; \
++	    mpower8-vector|mcrypto|mdirect-move|mhtm: -mpower8; \
++	    mvsx: -mpower7; \
++	    mpowerpc64: -mppc64;: %(asm_default)}; \
++  :%eMissing -mcpu option in ASM_CPU_SPEC?\n} \
++%{mvsx: -mvsx -maltivec; maltivec: -maltivec}" \
++ASM_OPT_ANY
+ 
+ #undef CC1_SPEC
+ #define        CC1_SPEC "%{G*} %(cc1_cpu)" \
+ "%{g: %{!fno-eliminate-unused-debug-symbols: -feliminate-unused-debug-symbols}} \
+ %{g1: %{!fno-eliminate-unused-debug-symbols: -feliminate-unused-debug-symbols}} \
+ %{msdata: -msdata=default} \
+-- 
+2.34.1
+


### PR DESCRIPTION
amigaos.h was presumably using an older version of rs6000.h many years ago. It is now out of date. GCC 11 has been updated to use the later version of rs6000's ASM_CPU_SPEC.